### PR TITLE
Extract kubeflow logic from ComponentSpec to KubeflowComponent

### DIFF
--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -40,7 +40,8 @@ kubeflow2python_type = {
 @dataclass
 class Argument:
     """
-    Kubeflow component input argument
+    Kubeflow component argument
+
     Args:
         name: name of the argument
         description: argument description
@@ -55,14 +56,12 @@ class Argument:
 class ComponentSubset:
     """
     Class representing a Fondant Component subset.
+
+    Args:
+        specification: the part of the component json representing the subset
     """
 
     def __init__(self, specification: dict) -> None:
-        """
-        Initialize subsets
-        Args:
-            specification: the part of the component json representing the subset
-        """
         self._specification = specification
 
     def __repr__(self) -> str:
@@ -78,7 +77,7 @@ class ComponentSubset:
         )
 
 
-class ComponentSpec:
+class FondantComponentSpec:
     """
     Class representing a Fondant component specification.
 
@@ -92,7 +91,8 @@ class ComponentSpec:
 
     def _validate_spec(self) -> None:
         """Validate a component specification against the component schema
-        Raises: InvalidManifest when the manifest is not valid.
+
+        Raises: InvalidComponent when the component specification is not valid.
         """
         spec_schema = json.loads(
             pkgutil.get_data("fondant", "schemas/component_spec.json")
@@ -108,14 +108,14 @@ class ComponentSpec:
             raise InvalidComponentSpec.create_from(e)
 
     @classmethod
-    def from_file(cls, path: str) -> "ComponentSpec":
-        """Load the manifest from the file specified by the provided path"""
+    def from_file(cls, path: str) -> "FondantComponentSpec":
+        """Load the component spec from the file specified by the provided path"""
         with open(path, encoding="utf-8") as file_:
             specification = yaml.safe_load(file_)
             return cls(specification)
 
     def to_file(self, path) -> None:
-        """Dump the manifest to the file specified by the provided path"""
+        """Dump the component spec to the file specified by the provided path"""
         with open(path, "w", encoding="utf-8") as file_:
             yaml.dump(self._specification, file_)
 
@@ -171,14 +171,14 @@ class ComponentSpec:
         ]
 
     @property
-    def kubeflow_specification(self) -> "KubeflowComponent":
-        return KubeflowComponent.from_fondant_component(self)
+    def kubeflow_specification(self) -> "KubeflowComponentSpec":
+        return KubeflowComponentSpec.from_fondant_component_spec(self)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._specification!r}"
 
 
-class KubeflowComponent:
+class KubeflowComponentSpec:
     """
     Class representing a Kubeflow component specification.
 
@@ -190,9 +190,9 @@ class KubeflowComponent:
         self._specification = specification
 
     @classmethod
-    def from_fondant_component(
-        cls, fondant_component: ComponentSpec
-    ) -> "KubeflowComponent":
+    def from_fondant_component_spec(
+        cls, fondant_component: FondantComponentSpec
+    ) -> "KubeflowComponentSpec":
         """Create a Kubeflow component spec from a Fondant component spec."""
         specification = {
             "name": fondant_component.name,
@@ -238,7 +238,7 @@ class KubeflowComponent:
 
     @staticmethod
     def _dump_args(args: t.List[Argument]) -> t.List[t.Union[str, t.Dict[str, str]]]:
-        """Dump Fondant specification arguments to KfP command arguments."""
+        """Dump Fondant specification arguments to kfp command arguments."""
         dumped_args = []
         for arg in args:
             arg_name = arg.name.replace("-", "_").strip()

--- a/fondant/dataset.py
+++ b/fondant/dataset.py
@@ -11,7 +11,7 @@ from typing import List, Mapping
 
 import dask.dataframe as dd
 
-from fondant.component_spec import ComponentSpec, kubeflow2python_type
+from fondant.component_spec import FondantComponentSpec, kubeflow2python_type
 from fondant.manifest import Manifest
 from fondant.schema import Type, Field
 
@@ -44,7 +44,7 @@ class FondantDataset:
 
         return df
 
-    def load_data(self, spec: ComponentSpec) -> dd.DataFrame:
+    def load_data(self, spec: FondantComponentSpec) -> dd.DataFrame:
         subsets = []
         for name, subset in spec.input_subsets.items():
             fields = list(subset.fields.keys())
@@ -93,7 +93,7 @@ class FondantDataset:
 
         self._upload_index(index_df)
 
-    def add_subsets(self, df: dd.DataFrame, spec: ComponentSpec):
+    def add_subsets(self, df: dd.DataFrame, spec: FondantComponentSpec):
         for name, subset in spec.output_subsets.items():
             fields = list(subset.fields.keys())
             # verify fields are present in the output dataframe
@@ -129,7 +129,7 @@ class FondantComponent:
     def __init__(self, type="transform"):
         # note: Fondant spec always needs to be called like this
         # and placed in the src directory
-        self.spec = ComponentSpec.from_file("fondant_component.yaml")
+        self.spec = FondantComponentSpec.from_file("fondant_component.yaml")
         self.type = type
 
     def run(self) -> dd.DataFrame:

--- a/fondant/dataset.py
+++ b/fondant/dataset.py
@@ -129,7 +129,7 @@ class FondantComponent:
     def __init__(self, type="transform"):
         # note: Fondant spec always needs to be called like this
         # and placed in the src directory
-        self.spec = ComponentSpec("fondant_component.yaml")
+        self.spec = ComponentSpec.from_file("fondant_component.yaml")
         self.type = type
 
     def run(self) -> dd.DataFrame:
@@ -179,8 +179,11 @@ class FondantComponent:
         Add and parse component arguments based on the component specification.
         """
         parser = argparse.ArgumentParser()
+
+        kubeflow_component = self.spec.kubeflow_specification
+
         # add input args
-        for arg in self.spec.input_arguments.values():
+        for arg in kubeflow_component.input_arguments.values():
             parser.add_argument(
                 f"--{arg.name}",
                 type=kubeflow2python_type[arg.type],
@@ -190,7 +193,7 @@ class FondantComponent:
                 help=arg.description,
             )
         # add output args
-        for arg in self.spec.output_arguments.values():
+        for arg in kubeflow_component.output_arguments.values():
             parser.add_argument(
                 f"--{arg.name}",
                 required=True,

--- a/tests/component_example/valid_component/kubeflow_component.yaml
+++ b/tests/component_example/valid_component/kubeflow_component.yaml
@@ -2,14 +2,15 @@ name: Example component
 description: This is an example component
 inputs:
 -   name: input_manifest_path
-    description: Path to the the input manifest
+    description: Path to the input manifest
     type: String
 -   name: storage_args
     description: Storage arguments
     type: String
 outputs:
 -   name: output_manifest_path
-    description: The path to the output manifest
+    description: Path to the output manifest
+    type: String
 implementation:
     container:
         image: example_component:latest

--- a/tests/test_components_specs.py
+++ b/tests/test_components_specs.py
@@ -4,7 +4,7 @@ import yaml
 from pathlib import Path
 
 from fondant.exceptions import InvalidComponentSpec
-from fondant.component_spec import ComponentSpec
+from fondant.component_spec import FondantComponentSpec
 
 valid_path = Path("tests/component_example/valid_component")
 invalid_path = Path("tests/component_example/invalid_component")
@@ -30,9 +30,9 @@ def invalid_fondant_schema() -> dict:
 
 def test_component_spec_validation(valid_fondant_schema, invalid_fondant_schema):
     """Test that the manifest is validated correctly on instantiation"""
-    ComponentSpec(valid_fondant_schema)
+    FondantComponentSpec(valid_fondant_schema)
     with pytest.raises(InvalidComponentSpec):
-        ComponentSpec(invalid_fondant_schema)
+        FondantComponentSpec(invalid_fondant_schema)
 
 
 def test_attribute_access(valid_fondant_schema):
@@ -41,7 +41,7 @@ def test_attribute_access(valid_fondant_schema):
     - Fixed properties should be accessible as an attribute
     - Dynamic properties should be accessible by lookup
     """
-    fondant_component = ComponentSpec(valid_fondant_schema)
+    fondant_component = FondantComponentSpec(valid_fondant_schema)
 
     assert fondant_component.name == "Example component"
     assert fondant_component.description == "This is an example component"
@@ -52,6 +52,6 @@ def test_kfp_component_creation(valid_fondant_schema, valid_kubeflow_schema):
     """
     Test that the created kubeflow component matches the expected kubeflow component
     """
-    fondant_component = ComponentSpec(valid_fondant_schema)
+    fondant_component = FondantComponentSpec(valid_fondant_schema)
     kubeflow_component = fondant_component.kubeflow_specification
     assert kubeflow_component._specification == valid_kubeflow_schema

--- a/tests/test_components_specs.py
+++ b/tests/test_components_specs.py
@@ -1,27 +1,31 @@
 """Fondant component specs test"""
-import os
 import pytest
 import yaml
+from pathlib import Path
+
 from fondant.exceptions import InvalidComponentSpec
 from fondant.component_spec import ComponentSpec
 
-valid_path = os.path.join("tests/component_example", "valid_component")
-invalid_path = os.path.join("tests/component_example", "invalid_component")
+valid_path = Path("tests/component_example/valid_component")
+invalid_path = Path("tests/component_example/invalid_component")
 
 
 @pytest.fixture
-def valid_fondant_schema() -> str:
-    return os.path.join(valid_path, "fondant_component.yaml")
+def valid_fondant_schema() -> dict:
+    with open(valid_path / "fondant_component.yaml") as f:
+        return yaml.safe_load(f)
 
 
 @pytest.fixture
-def valid_kubeflow_schema() -> str:
-    return os.path.join(valid_path, "kubeflow_component.yaml")
+def valid_kubeflow_schema() -> dict:
+    with open(valid_path / "kubeflow_component.yaml") as f:
+        return yaml.safe_load(f)
 
 
 @pytest.fixture
-def invalid_fondant_schema() -> str:
-    return os.path.join(invalid_path, "fondant_component.yaml")
+def invalid_fondant_schema() -> dict:
+    with open(invalid_path / "fondant_component.yaml") as f:
+        return yaml.safe_load(f)
 
 
 def test_component_spec_validation(valid_fondant_schema, invalid_fondant_schema):
@@ -49,5 +53,5 @@ def test_kfp_component_creation(valid_fondant_schema, valid_kubeflow_schema):
     Test that the created kubeflow component matches the expected kubeflow component
     """
     fondant_component = ComponentSpec(valid_fondant_schema)
-    kubeflow_schema = yaml.safe_load(open(valid_kubeflow_schema, 'r'))
-    assert fondant_component.kubeflow_component_specification == kubeflow_schema
+    kubeflow_component = fondant_component.kubeflow_specification
+    assert kubeflow_component._specification == valid_kubeflow_schema


### PR DESCRIPTION
This PR extracts all the kubeflow logic from the `ComponentSpec` to the `KubeflowComponent` so the `ComponentSpec` is a minimal representation of the fondant component specification. I also brought the classes a bit more in line with the `Manifest` class.

This is preparation for the work to deduct the output manifest from the input manifest and component spec only.