### PR TITLE
Align manifest and component spec schemas

### DIFF
--- a/fondant/schemas/common.json
+++ b/fondant/schemas/common.json
@@ -2,10 +2,50 @@
   "definitions": {
     "subset_data_type": {
       "type": "string",
-      "enum": ["bool", "int8", "int16", "int32", "uint8", "uint16", "uint32", "uint64",
-               "float16", "float32", "float64", "decimal",
-               "time32", "time64", "timestamp", "date32", "date64", "duration",
-               "utf8", "binary", "categorical", "list", "struct"]
+      "enum": [
+        "bool",
+        "int8",
+        "int16",
+        "int32",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float16",
+        "float32",
+        "float64",
+        "decimal",
+        "time32",
+        "time64",
+        "timestamp",
+        "date32",
+        "date64",
+        "duration",
+        "utf8",
+        "binary",
+        "categorical",
+        "list",
+        "struct"
+      ]
+    },
+    "field": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "$ref": "#/definitions/subset_data_type"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "fields": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/definitions/field"
+      }
     }
   }
 }

--- a/fondant/schemas/component_spec.json
+++ b/fondant/schemas/component_spec.json
@@ -2,7 +2,14 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Example Component Schema",
   "type": "object",
-  "required": ["name", "description", "image", "input_subsets", "output_subsets", "args"],
+  "required": [
+    "name",
+    "description",
+    "image",
+    "input_subsets",
+    "output_subsets",
+    "args"
+  ],
   "properties": {
     "name": {
       "type": "string",
@@ -16,82 +23,60 @@
       "type": "string",
       "description": "Docker image for the component"
     },
-     "input_subsets": {
-      "type": "object",
-      "description": "Input subsets for the component",
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "$ref": "#/definitions/data_type"
-                },
-                "description": {
-                  "type": "string"
-                }
-              },
-              "required": ["type"]
-            }
-          }
-        },
-        "required": ["fields"],
-        "additionalProperties": false
-      }
+    "input_subsets": {
+      "$ref": "#/definitions/subsets"
     },
-     "output_subsets": {
+    "output_subsets": {
+      "$ref": "#/definitions/subsets"
+    },
+    "args": {
+      "$ref": "#/definitions/args"
+    }
+  },
+  "definitions": {
+    "subset": {
       "type": "object",
-      "description": "Output subsets for the component",
+      "properties": {
+        "fields": {
+          "$ref": "common.json#/definitions/fields"
+        }
+      },
+      "required": [
+        "fields"
+      ]
+    },
+    "subsets": {
+      "type": "object",
       "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "$ref": "#/definitions/data_type"
-                },
-                "description": {
-                  "type": "string"
-                }
-              },
-              "required": ["type"]
-            }
-          }
-        },
-        "required": ["fields"],
-        "additionalProperties": false
+        "$ref": "#/definitions/subset"
       }
     },
     "args": {
       "type": "object",
-     "additionalProperties": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": ["list", "str", "int", "float", "bool", "dict", "tuple", "set"]
-            },
-            "description": {
-              "type": "string"
-            }
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "list",
+              "str",
+              "int",
+              "float",
+              "bool",
+              "dict",
+              "tuple",
+              "set"
+            ]
           },
-               "required": ["type"]
-        }
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ]
       }
-    },
-  "definitions": {
-    "data_type": {
-      "type": "string",
-          "$ref": "common.json#/definitions/subset_data_type",
-      "description": "Valid data types"
     }
   }
 }

--- a/fondant/schemas/manifest.json
+++ b/fondant/schemas/manifest.json
@@ -43,23 +43,6 @@
     "subsets"
   ],
   "definitions": {
-    "field": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "$ref": "common.json#/definitions/subset_data_type"
-        }
-      },
-      "required": ["type"]
-    },
-    "fields": {
-      "type": "object",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "#/definitions/field"
-      }
-    },
     "subset": {
       "type": "object",
       "properties": {
@@ -68,10 +51,13 @@
           "pattern": "/.*"
         },
         "fields": {
-          "$ref": "#/definitions/fields"
+          "$ref": "common.json#/definitions/fields"
         }
       },
-      "required": ["location", "fields"]
+      "required": [
+        "location",
+        "fields"
+      ]
     },
     "subsets": {
       "type": "object",


### PR DESCRIPTION
This PR:
- shares the `field` and `fields` definitions between the manifest and component spec
- Moves object definitions into the `definitions` block for the component spec
- Formats the schema files