### PR TITLE
Evolve manifest based on component spec

### DIFF
--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -13,7 +13,7 @@ from jsonschema import Draft4Validator
 from jsonschema.validators import RefResolver
 
 from fondant.exceptions import InvalidComponentSpec
-from fondant.schema import Field
+from fondant.schema import Field, Type
 
 # TODO: Change after upgrading to kfp v2
 # :https://www.kubeflow.org/docs/components/pipelines/v2/data-types/parameters/
@@ -71,10 +71,14 @@ class ComponentSubset:
     def fields(self) -> t.Mapping[str, Field]:
         return types.MappingProxyType(
             {
-                name: Field(name=name, type=field["type"])
+                name: Field(name=name, type=Type[field["type"]])
                 for name, field in self._specification["fields"].items()
             }
         )
+
+    @property
+    def additional_fields(self) -> bool:
+        return self._specification.get("additionalFields", True)
 
 
 class FondantComponentSpec:
@@ -138,6 +142,7 @@ class FondantComponentSpec:
             {
                 name: ComponentSubset(subset)
                 for name, subset in self._specification["input_subsets"].items()
+                if name != "additionalSubsets"
             }
         )
 
@@ -148,6 +153,7 @@ class FondantComponentSpec:
             {
                 name: ComponentSubset(subset)
                 for name, subset in self._specification["output_subsets"].items()
+                if name != "additionalSubsets"
             }
         )
 

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -168,7 +168,7 @@ class Manifest:
         self, name: str, fields: t.Iterable[t.Union[Field, t.Tuple[str, Type]]]
     ) -> None:
         if name in self._specification["subsets"]:
-            raise ValueError("A subset with name {name} already exists")
+            raise ValueError(f"A subset with name {name} already exists")
 
         self._specification["subsets"][name] = {
             "location": f"/{self.run_id}/{self.component_id}/{name}",
@@ -216,7 +216,7 @@ class Manifest:
         for subset_name, subset in component_spec.output_subsets.items():
             # Subset is already in manifest, update it
             if subset_name in evolved_manifest.subsets:
-                # If additional fields are not allowed, remove the fields not define in the
+                # If additional fields are not allowed, remove the fields not defined in the
                 # component spec output subsets
                 if not subset.additional_fields:
                     for field_name in evolved_manifest.subsets[subset_name].fields:

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -45,7 +45,7 @@ class Subset:
 
     def add_field(self, name: str, type_: Type, *, overwrite: bool = False) -> None:
         if not overwrite and name in self._specification["fields"]:
-            raise ValueError("A field with name {name} already exists")
+            raise ValueError(f"A field with name {name} already exists")
 
         self._specification["fields"][name] = {"type": type_.value}
 

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -10,6 +10,7 @@ import jsonschema.exceptions
 from jsonschema import Draft4Validator
 from jsonschema.validators import RefResolver
 
+from fondant.component_spec import FondantComponentSpec
 from fondant.exceptions import InvalidManifest
 from fondant.schema import Type, Field
 
@@ -42,8 +43,8 @@ class Subset:
             }
         )
 
-    def add_field(self, name: str, type_: Type) -> None:
-        if name in self._specification["fields"]:
+    def add_field(self, name: str, type_: Type, *, overwrite: bool = False) -> None:
+        if not overwrite and name in self._specification["fields"]:
             raise ValueError("A field with name {name} already exists")
 
         self._specification["fields"][name] = {"type": type_.value}
@@ -126,7 +127,7 @@ class Manifest:
         with open(path, "w", encoding="utf-8") as file_:
             json.dump(self._specification, file_)
 
-    def copy(self):
+    def copy(self) -> "Manifest":
         """Return a deep copy of itself"""
         return self.__class__(copy.deepcopy(self._specification))
 
@@ -163,7 +164,9 @@ class Manifest:
             }
         )
 
-    def add_subset(self, name: str, fields: t.List[t.Tuple[str, Type]]) -> None:
+    def add_subset(
+        self, name: str, fields: t.Iterable[t.Union[Field, t.Tuple[str, Type]]]
+    ) -> None:
         if name in self._specification["subsets"]:
             raise ValueError("A subset with name {name} already exists")
 
@@ -177,6 +180,62 @@ class Manifest:
             raise ValueError(f"Subset {name} not found in specification")
 
         del self._specification["subsets"][name]
+
+    def evolve(self, component_spec: FondantComponentSpec) -> "Manifest":
+        """Evolve the manifest based on the provided component spec. The resulting manifest is
+        the expected result if the current manifest is provided to the component defined by the
+        component spec."""
+        evolved_manifest = self.copy()
+
+        # If additionalSubsets is False in component input subsets,
+        # Remove all subsets from the manifest that are not listed
+        if not component_spec.accepts_additional_subsets:
+            for subset_name in evolved_manifest.subsets:
+                if subset_name not in component_spec.input_subsets:
+                    evolved_manifest.remove_subset(subset_name)
+
+        # If additionalSubsets is False in component output subsets,
+        # Remove all subsets from the manifest that are not listed
+        if not component_spec.produces_additional_subsets:
+            for subset_name in evolved_manifest.subsets:
+                if subset_name not in component_spec.output_subsets:
+                    evolved_manifest.remove_subset(subset_name)
+
+        # If additionalFields is False for input subsets,
+        # Remove all fields from that subset that are not listed
+        for subset_name, subset in component_spec.input_subsets.items():
+            if subset_name in evolved_manifest.subsets:
+                if not subset.additional_fields:
+                    for field_name in evolved_manifest.subsets[subset_name].fields:
+                        if field_name not in subset.fields:
+                            evolved_manifest.subsets[subset_name].remove_field(
+                                field_name
+                            )
+
+        # For each output subset defined in the component, add or update it
+        for subset_name, subset in component_spec.output_subsets.items():
+            # Subset is already in manifest, update it
+            if subset_name in evolved_manifest.subsets:
+                # If additional fields are not allowed, remove the fields not define in the
+                # component spec output subsets
+                if not subset.additional_fields:
+                    for field_name in evolved_manifest.subsets[subset_name].fields:
+                        if field_name not in subset.fields:
+                            evolved_manifest.subsets[subset_name].remove_field(
+                                field_name
+                            )
+
+                # Add fields defined in the component spec output subsets
+                # Overwrite to persist changes to the field (eg. type of column)
+                for field in subset.fields.values():
+                    evolved_manifest.subsets[subset_name].add_field(
+                        field.name, field.type, overwrite=True
+                    )
+            # Subset is not yet in manifest, add it
+            else:
+                evolved_manifest.add_subset(subset_name, subset.fields.values())
+
+        return evolved_manifest
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._specification!r}"

--- a/fondant/schemas/component_spec.json
+++ b/fondant/schemas/component_spec.json
@@ -39,6 +39,9 @@
       "properties": {
         "fields": {
           "$ref": "common.json#/definitions/fields"
+        },
+        "additionalFields": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/fondant/schemas/component_spec.json
+++ b/fondant/schemas/component_spec.json
@@ -47,6 +47,11 @@
     },
     "subsets": {
       "type": "object",
+      "properties": {
+        "additionalSubsets": {
+          "type": "boolean"
+        }
+      },
       "additionalProperties": {
         "$ref": "#/definitions/subset"
       }

--- a/tests/example_specs/evolution_examples/1/component.yaml
+++ b/tests/example_specs/evolution_examples/1/component.yaml
@@ -1,0 +1,20 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+input_subsets:
+  images:
+    fields:
+      data:
+        type: binary
+  
+output_subsets:
+  embeddings:
+    fields:
+      data:
+        type: binary
+
+args:
+  storage_args:
+    description: Storage arguments
+    type: str

--- a/tests/example_specs/evolution_examples/1/output_manifest.json
+++ b/tests/example_specs/evolution_examples/1/output_manifest.json
@@ -1,0 +1,42 @@
+{
+  "metadata": {
+    "base_path": "gs://bucket",
+    "run_id": "12345",
+    "component_id": "67890"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "width": {
+          "type": "int32"
+        },
+        "height": {
+          "type": "int32"
+        },
+        "data": {
+          "type": "binary"
+        }
+      }
+    },
+    "captions": {
+      "location": "/captions",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    },
+    "embeddings": {
+      "location": "/12345/67890/embeddings",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/evolution_examples/2/component.yaml
+++ b/tests/example_specs/evolution_examples/2/component.yaml
@@ -1,0 +1,21 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+input_subsets:
+  images:
+    fields:
+      data:
+        type: binary
+  additionalSubsets: false
+  
+output_subsets:
+  embeddings:
+    fields:
+      data:
+        type: binary
+
+args:
+  storage_args:
+    description: Storage arguments
+    type: str

--- a/tests/example_specs/evolution_examples/2/output_manifest.json
+++ b/tests/example_specs/evolution_examples/2/output_manifest.json
@@ -1,0 +1,34 @@
+{
+  "metadata": {
+    "base_path": "gs://bucket",
+    "run_id": "12345",
+    "component_id": "67890"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "width": {
+          "type": "int32"
+        },
+        "height": {
+          "type": "int32"
+        },
+        "data": {
+          "type": "binary"
+        }
+      }
+    },
+    "embeddings": {
+      "location": "/12345/67890/embeddings",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/evolution_examples/3/component.yaml
+++ b/tests/example_specs/evolution_examples/3/component.yaml
@@ -1,0 +1,22 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+input_subsets:
+  images:
+    fields:
+      data:
+        type: binary
+    additionalFields: false
+  additionalSubsets: false
+  
+output_subsets:
+  embeddings:
+    fields:
+      data:
+        type: binary
+
+args:
+  storage_args:
+    description: Storage arguments
+    type: str

--- a/tests/example_specs/evolution_examples/3/output_manifest.json
+++ b/tests/example_specs/evolution_examples/3/output_manifest.json
@@ -1,0 +1,28 @@
+{
+  "metadata": {
+    "base_path": "gs://bucket",
+    "run_id": "12345",
+    "component_id": "67890"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    },
+    "embeddings": {
+      "location": "/12345/67890/embeddings",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/evolution_examples/4/component.yaml
+++ b/tests/example_specs/evolution_examples/4/component.yaml
@@ -1,0 +1,20 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+input_subsets:
+  images:
+    fields:
+      data:
+        type: binary
+  
+output_subsets:
+  images:
+    fields:
+      encoding:
+        type: utf8
+
+args:
+  storage_args:
+    description: Storage arguments
+    type: str

--- a/tests/example_specs/evolution_examples/4/output_manifest.json
+++ b/tests/example_specs/evolution_examples/4/output_manifest.json
@@ -1,0 +1,37 @@
+{
+  "metadata": {
+    "base_path": "gs://bucket",
+    "run_id": "12345",
+    "component_id": "67890"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "width": {
+          "type": "int32"
+        },
+        "height": {
+          "type": "int32"
+        },
+        "data": {
+          "type": "binary"
+        },
+        "encoding": {
+          "type": "utf8"
+        }
+      }
+    },
+    "captions": {
+      "location": "/captions",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/evolution_examples/5/component.yaml
+++ b/tests/example_specs/evolution_examples/5/component.yaml
@@ -1,0 +1,21 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+input_subsets:
+  images:
+    fields:
+      data:
+        type: binary
+  
+output_subsets:
+  images:
+    fields:
+      encoding:
+        type: utf8
+    additionalFields: false
+
+args:
+  storage_args:
+    description: Storage arguments
+    type: str

--- a/tests/example_specs/evolution_examples/5/output_manifest.json
+++ b/tests/example_specs/evolution_examples/5/output_manifest.json
@@ -1,0 +1,28 @@
+{
+  "metadata": {
+    "base_path": "gs://bucket",
+    "run_id": "12345",
+    "component_id": "67890"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "encoding": {
+          "type": "utf8"
+        }
+      }
+    },
+    "captions": {
+      "location": "/captions",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/evolution_examples/6/component.yaml
+++ b/tests/example_specs/evolution_examples/6/component.yaml
@@ -1,0 +1,22 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+input_subsets:
+  images:
+    fields:
+      data:
+        type: binary
+  
+output_subsets:
+  images:
+    fields:
+      encoding:
+        type: utf8
+    additionalFields: false
+  additionalSubsets: false
+
+args:
+  storage_args:
+    description: Storage arguments
+    type: str

--- a/tests/example_specs/evolution_examples/6/output_manifest.json
+++ b/tests/example_specs/evolution_examples/6/output_manifest.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "base_path": "gs://bucket",
+    "run_id": "12345",
+    "component_id": "67890"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "encoding": {
+          "type": "utf8"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/evolution_examples/7/component.yaml
+++ b/tests/example_specs/evolution_examples/7/component.yaml
@@ -1,0 +1,22 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+input_subsets:
+  images:
+    fields:
+      data:
+        type: binary
+  
+output_subsets:
+  images:
+    fields:
+      data:
+        type: utf8
+    additionalFields: false
+  additionalSubsets: false
+
+args:
+  storage_args:
+    description: Storage arguments
+    type: str

--- a/tests/example_specs/evolution_examples/7/output_manifest.json
+++ b/tests/example_specs/evolution_examples/7/output_manifest.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "base_path": "gs://bucket",
+    "run_id": "12345",
+    "component_id": "67890"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "data": {
+          "type": "utf8"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/evolution_examples/input_manifest.json
+++ b/tests/example_specs/evolution_examples/input_manifest.json
@@ -1,0 +1,34 @@
+{
+  "metadata": {
+    "base_path": "gs://bucket",
+    "run_id": "12345",
+    "component_id": "67890"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "width": {
+          "type": "int32"
+        },
+        "height": {
+          "type": "int32"
+        },
+        "data": {
+          "type": "binary"
+        }
+      }
+    },
+    "captions": {
+      "location": "/captions",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_components_specs.py
+++ b/tests/test_components_specs.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fondant.exceptions import InvalidComponentSpec
 from fondant.component_spec import FondantComponentSpec
+from fondant.schema import Type
 
 valid_path = Path(__file__).parent / "example_specs/valid_component"
 invalid_path = Path(__file__).parent / "example_specs/invalid_component"
@@ -45,7 +46,7 @@ def test_attribute_access(valid_fondant_schema):
 
     assert fondant_component.name == "Example component"
     assert fondant_component.description == "This is an example component"
-    assert fondant_component.input_subsets['images'].fields["data"].type == "binary"
+    assert fondant_component.input_subsets['images'].fields["data"].type == Type.binary
 
 
 def test_kfp_component_creation(valid_fondant_schema, valid_kubeflow_schema):

--- a/tests/test_manifest_evolution.py
+++ b/tests/test_manifest_evolution.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from fondant.component_spec import FondantComponentSpec
+from fondant.manifest import Manifest
+
+
+examples_path = Path(__file__).parent / "example_specs/evolution_examples"
+
+
+@pytest.fixture
+def input_manifest():
+    with open(examples_path / "input_manifest.json") as f:
+        return json.load(f)
+
+
+def examples():
+    """Returns examples as tuples of component and expected output_manifest"""
+    for directory in (f for f in examples_path.iterdir() if f.is_dir()):
+        with open(directory / "component.yaml") as c, open(directory / "output_manifest.json") as o:
+            yield yaml.safe_load(c), json.load(o)
+
+
+@pytest.mark.parametrize("component_spec,output_manifest", list(examples()))
+def test_evolution(input_manifest, component_spec, output_manifest):
+    manifest = Manifest(input_manifest)
+    component = FondantComponentSpec(component_spec)
+    evolved_manifest = manifest.evolve(component)
+
+    print(json.dumps(evolved_manifest._specification, indent=4))
+
+    assert evolved_manifest._specification == output_manifest

--- a/tests/test_manifest_evolution.py
+++ b/tests/test_manifest_evolution.py
@@ -30,6 +30,4 @@ def test_evolution(input_manifest, component_spec, output_manifest):
     component = FondantComponentSpec(component_spec)
     evolved_manifest = manifest.evolve(component)
 
-    print(json.dumps(evolved_manifest._specification, indent=4))
-
     assert evolved_manifest._specification == output_manifest


### PR DESCRIPTION
Don't be alarmed by the size of this PR, it contains a lot of test cases :sweat_smile: 

This PR adds functionality to generate the output manifest based on the input manifest and component specification alone. By deducting the output manifest this way, it can be used for validation of the output data in the component, and for static validation of the pipeline before execution.

I implemented this as an `.evolve()` method on the manifest, since the input manifest is always the starting point. This will also allow for nice chaining in the future. The method is quite long, but I don't think splitting it up will improve readability.

This PR only provides the functionality and tests. As a next step, we'll have to integrate this into the `Dataset` class to actually leverage the functionality for output validation.