### PR TITLE
Add coverage check

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -39,7 +39,9 @@ jobs:
         run: |
           poetry run pytest tests --cov connexion --cov-report term-missing
       - name: Coveralls
-        run: coveralls --service github
+        run: |
+          pip install "coveralls<4"
+          coveralls --service github
         env:
           COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -37,7 +37,7 @@ jobs:
           pylint fondant --exit-zero
       - name: Test with pytest
         run: |
-          poetry run pytest tests --cov connexion --cov-report term-missing
+          poetry run pytest tests --cov fondant --cov-report term-missing
       - name: Coveralls
         run: |
           pip install "coveralls<4"

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -37,4 +37,21 @@ jobs:
           pylint fondant --exit-zero
       - name: Test with pytest
         run: |
-          poetry run pytest tests
+          poetry run pytest tests --cov connexion --cov-report term-missing
+      - name: Coveralls
+        run: coveralls --service github
+        env:
+          COVERALLS_PARALLEL: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: test-${{ matrix.python-version }}
+
+  finish-coveralls:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install "coveralls<4"
+        run: pip install coveralls
+      - name: Coveralls Finished
+        run: coveralls --service github --finish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ pipelines = ["kfp", "kubernetes"]
 liccheck = "^0.7.3"
 pre-commit = "^3.1.1"
 pytest = "^7.2.2"
+pytest-cov = "~2.12.1"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.1.8"


### PR DESCRIPTION
Fixes #47 

Coverage allows you to set a threshold for accepted coverage decline. Above it, the pipeline will fail. I currently set it at 0% since we should increase our coverage.