### PR TITLE
Move from caret to inequality requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,14 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-jsonschema = "^4.17.3"
-dask = {extras = ["dataframe"], version = "^2023.4.1"}
+python = ">= 3.8"
+jsonschema = ">= 4.17.3"
+dask = {extras = ["dataframe"], version = ">= 2023.4.1"}
 
-pyarrow = "^11.0.0"
-kfp = { version = "^1.8.19", optional = true }
-kubernetes = { version = "^18.20.0", optional = true }
-pandas = { version = "^1.3.5", optional = true }
+pyarrow = ">= 11.0.0"
+kfp = { version = ">= 1.8.19", optional = true }
+kubernetes = { version = ">= 18.20.0", optional = true }
+pandas = { version = ">= 1.3.5", optional = true }
 
 [tool.poetry.extras]
 pipelines = ["kfp", "kubernetes"]


### PR DESCRIPTION
I would have expected poetry to convert the caret requirements into something generic that other tools such as `pip` could handle as well, but apparently this is not the case.

Best practice for frameworks / libraries is also to not pin any upper limits unless there are clear incompatibilities, so I switched all the caret versioning to `>=`.

[Relevant discussion on the Poetry repo](https://github.com/orgs/python-poetry/discussions/3757#discussioncomment-435337).