### PR TITLE
Extend Ruff to tests and with extra rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,7 @@ repos:
         files:  |
             (?x)^(
                 fondant/.*|
-                examples/pipelines/hf_dataset_pipeline|
-                examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component|
-                examples/pipelines/finetune_stable_diffusion/components/image_filter_component|
-                examples/pipelines/finetune_stable_diffusion/components/embedding_component|
-                examples/pipelines/finetune_stable_diffusion/dataset_creation_pipeline.py|
+                tests/.*|
             )$
         args: [--fix, --exit-non-zero-on-fix]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.254'
+    rev: 'v0.0.264'
     hooks:
       - id: ruff
         files:  |

--- a/examples/pipelines/simple_pipeline/components/image_filtering/src/main.py
+++ b/examples/pipelines/simple_pipeline/components/image_filtering/src/main.py
@@ -2,7 +2,6 @@
 This component filters images of the dataset based on image size (minimum height and width).
 """
 import logging
-from typing import Dict
 
 import dask.dataframe as dd
 

--- a/examples/pipelines/simple_pipeline/config/general_config.py
+++ b/examples/pipelines/simple_pipeline/config/general_config.py
@@ -29,7 +29,7 @@ class KubeflowConfig(GeneralConfig):
         HOST (str): kfp host url
     """
 
-    BASE_PATH = f"gcs://soy-audio-379412_kfp-artifacts/custom_artifact"
+    BASE_PATH = "gcs://soy-audio-379412_kfp-artifacts/custom_artifact"
     CLUSTER_NAME = "kfp-fondant"
     CLUSTER_ZONE = "europe-west4-a"
     HOST = "https://52074149b1563463-dot-europe-west1.pipelines.googleusercontent.com"

--- a/examples/pipelines/simple_pipeline/simple_pipeline.py
+++ b/examples/pipelines/simple_pipeline/simple_pipeline.py
@@ -47,7 +47,7 @@ def simple_pipeline(
     ).set_display_name("Load initial images")
 
     # Component 2
-    image_filter_task = image_filtering_op(
+    image_filtering_op(
         input_manifest_path=load_from_hub_task.outputs["output_manifest_path"],
         min_width=image_filter_min_width,
         min_height=image_filter_min_height,

--- a/fondant/component.py
+++ b/fondant/component.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class FondantComponent(ABC):
-    """Abstract base class for a Fondant component"""
+    """Abstract base class for a Fondant component."""
 
     def __init__(self, spec: FondantComponentSpec) -> None:
         self.spec = spec
@@ -32,7 +32,7 @@ class FondantComponent(ABC):
     def from_file(
         cls, path: t.Union[str, Path] = "../fondant_component.yaml"
     ) -> "FondantComponent":
-        """Create a component from a component spec file
+        """Create a component from a component spec file.
 
         Args:
             path: Path to the component spec file
@@ -55,7 +55,7 @@ class FondantComponent(ABC):
 
     @abstractmethod
     def _add_and_parse_args(self) -> argparse.Namespace:
-        """Abstract method to add and parse the component arguments"""
+        """Abstract method to add and parse the component arguments."""
 
     @property
     def user_arguments(self) -> t.Dict[str, t.Any]:
@@ -68,17 +68,16 @@ class FondantComponent(ABC):
 
     @abstractmethod
     def _load_or_create_manifest(self) -> Manifest:
-        """Abstract method that returns the dataset manifest"""
+        """Abstract method that returns the dataset manifest."""
 
     @abstractmethod
     def _process_dataset(self, dataset: FondantDataset) -> dd.DataFrame:
         """Abstract method that processes the input dataframe of the `FondantDataset` and
-        returns another dataframe"""
+        returns another dataframe.
+        """
 
     def run(self):
-        """
-        Runs the component.
-        """
+        """Runs the component."""
         input_manifest = self._load_or_create_manifest()
         input_dataset = FondantDataset(input_manifest)
 
@@ -100,7 +99,7 @@ class FondantComponent(ABC):
 
 
 class FondantLoadComponent(FondantComponent):
-    """Base class for a Fondant load component"""
+    """Base class for a Fondant load component."""
 
     def _add_and_parse_args(self):
         parser = argparse.ArgumentParser()
@@ -145,7 +144,7 @@ class FondantLoadComponent(FondantComponent):
 
     @abstractmethod
     def load(self, **kwargs) -> dd.DataFrame:
-        """Abstract method that loads the initial dataframe"""
+        """Abstract method that loads the initial dataframe."""
 
     def _process_dataset(self, dataset: FondantDataset) -> dd.DataFrame:
         """This function loads the initial dataframe sing the user-provided `load` method.
@@ -160,7 +159,7 @@ class FondantLoadComponent(FondantComponent):
 
 
 class FondantTransformComponent(FondantComponent):
-    """Base class for a Fondant transform component"""
+    """Base class for a Fondant transform component."""
 
     def _add_and_parse_args(self):
         parser = argparse.ArgumentParser()
@@ -181,7 +180,7 @@ class FondantTransformComponent(FondantComponent):
 
     @abstractmethod
     def transform(self, dataframe: dd.DataFrame, **kwargs) -> dd.DataFrame:
-        """Abstract method for applying data transformations to the input dataframe"""
+        """Abstract method for applying data transformations to the input dataframe."""
 
     def _process_dataset(self, dataset: FondantDataset) -> dd.DataFrame:
         """

--- a/fondant/component.py
+++ b/fondant/component.py
@@ -8,13 +8,13 @@ components take care of processing, filtering and extending the data.
 import argparse
 import json
 import logging
-from pathlib import Path
 import typing as t
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 import dask.dataframe as dd
 
-from fondant.component_spec import FondantComponentSpec, kubeflow2python_type, Argument
+from fondant.component_spec import Argument, FondantComponentSpec, kubeflow2python_type
 from fondant.dataset import FondantDataset
 from fondant.manifest import Manifest
 

--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -40,7 +40,7 @@ kubeflow2python_type = {
 @dataclass
 class Argument:
     """
-    Kubeflow component argument
+    Kubeflow component argument.
 
     Args:
         name: name of the argument
@@ -94,11 +94,10 @@ class FondantComponentSpec:
         self._validate_spec()
 
     def _validate_spec(self) -> None:
-        """Validate a component specification against the component schema
+        """Validate a component specification against the component schema.
 
         Raises: InvalidComponent when the component specification is not valid.
         """
-
         spec_data = pkgutil.get_data("fondant", "schemas/component_spec.json")
 
         if spec_data is None:
@@ -118,13 +117,13 @@ class FondantComponentSpec:
 
     @classmethod
     def from_file(cls, path: t.Union[str, Path]) -> "FondantComponentSpec":
-        """Load the component spec from the file specified by the provided path"""
+        """Load the component spec from the file specified by the provided path."""
         with open(path, encoding="utf-8") as file_:
             specification = yaml.safe_load(file_)
             return cls(specification)
 
     def to_file(self, path) -> None:
-        """Dump the component spec to the file specified by the provided path"""
+        """Dump the component spec to the file specified by the provided path."""
         with open(path, "w", encoding="utf-8") as file_:
             yaml.dump(self._specification, file_)
 
@@ -142,7 +141,7 @@ class FondantComponentSpec:
 
     @property
     def input_subsets(self) -> t.Mapping[str, ComponentSubset]:
-        """The input subsets of the component as an immutable mapping"""
+        """The input subsets of the component as an immutable mapping."""
         return types.MappingProxyType(
             {
                 name: ComponentSubset(subset)
@@ -153,7 +152,7 @@ class FondantComponentSpec:
 
     @property
     def output_subsets(self) -> t.Mapping[str, ComponentSubset]:
-        """The output subsets of the component as an immutable mapping"""
+        """The output subsets of the component as an immutable mapping."""
         return types.MappingProxyType(
             {
                 name: ComponentSubset(subset)
@@ -267,7 +266,7 @@ class KubeflowComponentSpec:
         return dumped_args
 
     def to_file(self, path: t.Union[str, Path]) -> None:
-        """Dump the component specification to the file specified by the provided path"""
+        """Dump the component specification to the file specified by the provided path."""
         with open(path, "w", encoding="utf-8") as file_:
             yaml.dump(
                 self._specification,
@@ -279,7 +278,7 @@ class KubeflowComponentSpec:
 
     @property
     def input_arguments(self) -> t.Mapping[str, Argument]:
-        """The input arguments of the component as an immutable mapping"""
+        """The input arguments of the component as an immutable mapping."""
         return types.MappingProxyType(
             {
                 info["name"]: Argument(
@@ -293,7 +292,7 @@ class KubeflowComponentSpec:
 
     @property
     def output_arguments(self) -> t.Mapping[str, Argument]:
-        """The output arguments of the component as an immutable mapping"""
+        """The output arguments of the component as an immutable mapping."""
         return types.MappingProxyType(
             {
                 info["name"]: Argument(

--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -1,19 +1,19 @@
 """This module defines classes to represent an Fondant component specification."""
 import copy
 import json
-import yaml
 import pkgutil
 import types
 import typing as t
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
 
 import jsonschema.exceptions
+import yaml
 from jsonschema import Draft4Validator
 from jsonschema.validators import RefResolver
 
 from fondant.exceptions import InvalidComponentSpec
-from fondant.schema import Field, Type, KubeflowCommandArguments
+from fondant.schema import Field, KubeflowCommandArguments, Type
 
 # TODO: Change after upgrading to kfp v2
 # :https://www.kubeflow.org/docs/components/pipelines/v2/data-types/parameters/

--- a/fondant/dataset.py
+++ b/fondant/dataset.py
@@ -95,7 +95,7 @@ class FondantDataset:
             # left joins -> filter on index
             df = dd.merge(df, subset_df, on=["id", "source"], how="left")
 
-        logging.info("Columns of dataframe:", list(df.columns))
+        logging.info(f"Columns of dataframe: {list(df.columns)}")
 
         return df
 

--- a/fondant/dataset.py
+++ b/fondant/dataset.py
@@ -37,7 +37,6 @@ class FondantDataset:
         Returns:
             The subset as a dask dataframe
         """
-
         subset = self.manifest.subsets[subset_name]
         remote_path = subset.location
         index_fields = list(self.manifest.index.fields.keys())
@@ -78,7 +77,7 @@ class FondantDataset:
     def load_dataframe(self, spec: FondantComponentSpec) -> dd.DataFrame:
         """
         Function that loads the subsets defined in the component spec as a single Dask dataframe for
-          the user
+          the user.
 
         Args:
             spec: the fondant component spec
@@ -116,7 +115,6 @@ class FondantDataset:
              A delayed Dask task that uploads the DataFrame to the remote storage location when
               executed.
         """
-
         # Define task to upload index to remote storage
         write_task = dd.to_parquet(
             df, remote_path, schema=schema, overwrite=False, compute=False
@@ -126,6 +124,7 @@ class FondantDataset:
     def write_index(self, df: dd.DataFrame):
         """
         Write the index dataframe to a remote location.
+
         Args:
             df: The output Dask dataframe returned by the user.
         """
@@ -163,7 +162,7 @@ class FondantDataset:
         ) -> t.List[str]:
             """
             Verify that all the fields defined in the output subset are present in
-            the output dataframe
+            the output dataframe.
             """
             # TODO: add logic for `additional fields`
             subset_columns = [f"{subset_name}_{field}" for field in subset_fields]
@@ -181,9 +180,7 @@ class FondantDataset:
         def create_subset_dataframe(
             subset_name: str, subset_columns: t.List[str], df: dd.DataFrame
         ):
-            """
-            Create subset dataframe to save with the original field name as the column name
-            """
+            """Create subset dataframe to save with the original field name as the column name."""
             # Create a new dataframe with only the columns needed for the output subset
             subset_df = df[subset_columns]
 

--- a/fondant/dataset.py
+++ b/fondant/dataset.py
@@ -6,7 +6,7 @@ import typing as t
 import dask.dataframe as dd
 
 from fondant.component_spec import FondantComponentSpec
-from fondant.manifest import Manifest, Field
+from fondant.manifest import Field, Manifest
 
 logger = logging.getLogger(__name__)
 

--- a/fondant/import_utils.py
+++ b/fondant/import_utils.py
@@ -1,11 +1,11 @@
 """
 Import utils
 """
-import logging
-import importlib.util
 import importlib.metadata
-from pathlib import Path
+import importlib.util
+import logging
 import sys
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/fondant/import_utils.py
+++ b/fondant/import_utils.py
@@ -1,6 +1,4 @@
-"""
-Import utils
-"""
+"""Import utils."""
 import importlib.metadata
 import importlib.util
 import logging
@@ -36,9 +34,8 @@ def is_package_available(package_name: str, import_error_msg: str) -> bool:
         package_name (str): the name of the package
         import_error_msg (str): the error message to return if the package is not found
     Returns:
-        bool: check if package is available
+        bool: check if package is available.
     """
-
     package_available = importlib.util.find_spec(package_name) is not None
 
     try:
@@ -54,15 +51,15 @@ def is_package_available(package_name: str, import_error_msg: str) -> bool:
 
 
 def is_datasets_available():
-    """Check if 'datasets' is available"""
+    """Check if 'datasets' is available."""
     return is_package_available("datasets", DATASETS_IMPORT_ERROR)
 
 
 def is_pandas_available():
-    """Check if 'pandas' is available"""
+    """Check if 'pandas' is available."""
     return is_package_available("pandas", PANDAS_IMPORT_ERROR)
 
 
 def is_kfp_available():
-    """Check if 'pandas' is available"""
+    """Check if 'pandas' is available."""
     return is_package_available("kfp", KFP_IMPORT_ERROR)

--- a/fondant/logger.py
+++ b/fondant/logger.py
@@ -1,8 +1,8 @@
 """Utils file with useful methods."""
 
 import logging
-import sys
 import os
+import sys
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", default="INFO")
 

--- a/fondant/logger.py
+++ b/fondant/logger.py
@@ -8,7 +8,7 @@ LOG_LEVEL = os.environ.get("LOG_LEVEL", default="INFO")
 
 
 def configure_logging(log_level=LOG_LEVEL) -> None:
-    """Configure the root logger based on config settings"""
+    """Configure the root logger based on config settings."""
     logger = logging.getLogger()
 
     # set loglevel

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -188,7 +188,9 @@ class Manifest:
 
         del self._specification["subsets"][name]
 
-    def evolve(self, component_spec: FondantComponentSpec) -> "Manifest":
+    def evolve(  # noqa : PLR0912 (too many branches)
+        self, component_spec: FondantComponentSpec
+    ) -> "Manifest":
         """Evolve the manifest based on the component spec. The resulting
         manifest is the expected result if the current manifest is provided
         to the component defined by the component spec."""

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -30,7 +30,7 @@ class Subset:
 
     @property
     def location(self) -> str:
-        """The absolute location of the subset"""
+        """The absolute location of the subset."""
         return self._base_path + self._specification["location"]
 
     @property
@@ -57,7 +57,7 @@ class Subset:
 
 
 class Index(Subset):
-    """Special case of a subset for the index, which has fixed fields"""
+    """Special case of a subset for the index, which has fixed fields."""
 
     @property
     def fields(self) -> t.Dict[str, Field]:
@@ -69,7 +69,7 @@ class Index(Subset):
 
 class Manifest:
     """
-    Class representing an Fondant manifest
+    Class representing an Fondant manifest.
 
     Args:
         specification: The manifest specification as a Python dict
@@ -80,11 +80,10 @@ class Manifest:
         self._validate_spec()
 
     def _validate_spec(self) -> None:
-        """Validate a manifest specification against the manifest schema
+        """Validate a manifest specification against the manifest schema.
 
         Raises: InvalidManifest when the manifest is not valid.
         """
-
         spec_data = pkgutil.get_data("fondant", "schemas/manifest.json")
 
         if spec_data is None:
@@ -104,7 +103,7 @@ class Manifest:
 
     @classmethod
     def create(cls, *, base_path: str, run_id: str, component_id: str) -> "Manifest":
-        """Create an empty manifest
+        """Create an empty manifest.
 
         Args:
             base_path: The base path of the manifest
@@ -124,18 +123,18 @@ class Manifest:
 
     @classmethod
     def from_file(cls, path: str) -> "Manifest":
-        """Load the manifest from the file specified by the provided path"""
+        """Load the manifest from the file specified by the provided path."""
         with open(path, encoding="utf-8") as file_:
             specification = json.load(file_)
             return cls(specification)
 
     def to_file(self, path) -> None:
-        """Dump the manifest to the file specified by the provided path"""
+        """Dump the manifest to the file specified by the provided path."""
         with open(path, "w", encoding="utf-8") as file_:
             json.dump(self._specification, file_)
 
     def copy(self) -> "Manifest":
-        """Return a deep copy of itself"""
+        """Return a deep copy of itself."""
         return self.__class__(copy.deepcopy(self._specification))
 
     @property
@@ -163,7 +162,7 @@ class Manifest:
 
     @property
     def subsets(self) -> t.Mapping[str, Subset]:
-        """The subsets of the manifest as an immutable mapping"""
+        """The subsets of the manifest as an immutable mapping."""
         return types.MappingProxyType(
             {
                 name: Subset(subset, base_path=self.base_path)
@@ -193,8 +192,8 @@ class Manifest:
     ) -> "Manifest":
         """Evolve the manifest based on the component spec. The resulting
         manifest is the expected result if the current manifest is provided
-        to the component defined by the component spec."""
-
+        to the component defined by the component spec.
+        """
         evolved_manifest = self.copy()
 
         # Update `component_id` of the metadata

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -12,7 +12,7 @@ from jsonschema.validators import RefResolver
 
 from fondant.component_spec import FondantComponentSpec
 from fondant.exceptions import InvalidManifest
-from fondant.schema import Type, Field
+from fondant.schema import Field, Type
 
 
 class Subset:

--- a/fondant/pipeline_utils.py
+++ b/fondant/pipeline_utils.py
@@ -1,4 +1,4 @@
-"""General pipeline utils"""
+"""General pipeline utils."""
 
 import logging
 import os
@@ -17,12 +17,13 @@ def compile_and_upload_pipeline(
     pipeline: Callable[[], None], host: str, env: str, pipeline_id: Optional[str] = None
 ) -> None:
     """Upload pipeline to kubeflow.
+
     Args:
         pipeline: function that contains the pipeline definition
         host: the url host for kfp
         env: the project run environment (sbx, dev, prd)
         pipeline_id: pipeline id of existing component under the same name. Pass it on when you
-        want to delete current existing pipelines
+        want to delete current existing pipelines.
     """
     client = kfp.Client(host=host)
 

--- a/fondant/pipeline_utils.py
+++ b/fondant/pipeline_utils.py
@@ -1,7 +1,7 @@
 """General pipeline utils"""
 
-import os
 import logging
+import os
 from typing import Callable, Optional
 
 from fondant.import_utils import is_kfp_available

--- a/fondant/schema.py
+++ b/fondant/schema.py
@@ -1,5 +1,6 @@
 """This module defines common schemas and datatypes used to define Fondant manifests, components
-and pipelines."""
+and pipelines.
+"""
 
 import enum
 import typing as t

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,4 +65,6 @@ requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
+select = ["E", "F", "PL", "RUF"]
+
 line-length = 100  # Only for comments, as code is handled by black at length 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,19 @@ requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-select = ["E", "F", "I", "PL", "RUF"]
-
+select = ["D", "E", "F", "I", "PL", "RUF"]
+ignore = [
+    "D100",  # Missing docstring in public module
+    "D101",  # Missing docstring in public class
+    "D102",  # Missing docstring in public method
+    "D103",  # Missing docstring in public function
+    "D104",  # Missing docstring in public package
+    "D105",  # Missing docstring in magic method
+    "D107",  # Missing docstring in __init__
+    "D205",  # 1 blank line required between summary line and description (autofix not working)
+    "D212",  # Multi-line docstring summary should start at first line (we choose 2nd)
+]
 line-length = 100  # Only for comments, as code is handled by black at length 88
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,6 @@ requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-select = ["E", "F", "PL", "RUF"]
+select = ["E", "F", "I", "PL", "RUF"]
 
 line-length = 100  # Only for comments, as code is handled by black at length 88

--- a/tests/example_data/raw/split.py
+++ b/tests/example_data/raw/split.py
@@ -9,6 +9,7 @@ The data is the 151 first pokemon and the following fields are available:
 
 """
 from pathlib import Path
+
 import dask.dataframe as dd
 
 data_path = Path(__file__).parent

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,4 +1,4 @@
-"""Fondant component tests"""
+"""Fondant component tests."""
 
 import argparse
 import json
@@ -75,7 +75,7 @@ def test_transform_kwargs(monkeypatch):
     """Test that arguments are passed correctly to `Component.transform` method."""
 
     class EarlyStopException(Exception):
-        """Used to stop execution early instead of mocking all later functionality"""
+        """Used to stop execution early instead of mocking all later functionality."""
 
     # Mock `Dataset.load_dataframe` so no actual data is loaded
     def mocked_load_dataframe(self, spec):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -12,7 +12,6 @@ import pytest
 from fondant.component import FondantLoadComponent, FondantTransformComponent
 from fondant.dataset import FondantDataset
 
-
 components_path = Path(__file__).parent / "example_specs/components"
 component_specs_path = Path(__file__).parent / "example_specs/component_specs"
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -2,7 +2,6 @@
 
 import argparse
 import json
-import tempfile
 import sys
 from pathlib import Path
 from unittest import mock
@@ -11,7 +10,6 @@ import dask.dataframe as dd
 import pytest
 
 from fondant.component import FondantLoadComponent, FondantTransformComponent
-from fondant.component_spec import FondantComponentSpec
 from fondant.dataset import FondantDataset
 
 

--- a/tests/test_component_specs.py
+++ b/tests/test_component_specs.py
@@ -1,10 +1,11 @@
 """Fondant component specs test"""
-import pytest
-import yaml
 from pathlib import Path
 
-from fondant.exceptions import InvalidComponentSpec
+import pytest
+import yaml
+
 from fondant.component_spec import FondantComponentSpec
+from fondant.exceptions import InvalidComponentSpec
 from fondant.schema import Type
 
 component_specs_path = Path(__file__).parent / "example_specs/component_specs"

--- a/tests/test_component_specs.py
+++ b/tests/test_component_specs.py
@@ -1,4 +1,4 @@
-"""Fondant component specs test"""
+"""Fondant component specs test."""
 from pathlib import Path
 
 import pytest
@@ -30,7 +30,7 @@ def invalid_fondant_schema() -> dict:
 
 
 def test_component_spec_validation(valid_fondant_schema, invalid_fondant_schema):
-    """Test that the manifest is validated correctly on instantiation"""
+    """Test that the manifest is validated correctly on instantiation."""
     FondantComponentSpec(valid_fondant_schema)
     with pytest.raises(InvalidComponentSpec):
         FondantComponentSpec(invalid_fondant_schema)
@@ -40,7 +40,7 @@ def test_attribute_access(valid_fondant_schema):
     """
     Test that attributes can be accessed as expected:
     - Fixed properties should be accessible as an attribute
-    - Dynamic properties should be accessible by lookup
+    - Dynamic properties should be accessible by lookup.
     """
     fondant_component = FondantComponentSpec(valid_fondant_schema)
 
@@ -50,9 +50,7 @@ def test_attribute_access(valid_fondant_schema):
 
 
 def test_kfp_component_creation(valid_fondant_schema, valid_kubeflow_schema):
-    """
-    Test that the created kubeflow component matches the expected kubeflow component
-    """
+    """Test that the created kubeflow component matches the expected kubeflow component."""
     fondant_component = FondantComponentSpec(valid_fondant_schema)
     kubeflow_component = fondant_component.kubeflow_specification
     assert kubeflow_component._specification == valid_kubeflow_schema

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -11,6 +11,8 @@ input_manifest_path = Path(__file__).parent / "example_data/input_manifest.json"
 output_manifest_path = Path(__file__).parent / "example_data/output_manifest.json"
 component_spec_path = Path(__file__).parent / "example_data/components/1.yaml"
 
+DATASET_SIZE = 151
+
 
 @pytest.fixture
 def input_manifest():
@@ -29,13 +31,13 @@ def component_spec():
 
 def test_load_index(input_manifest):
     fds = FondantDataset(input_manifest)
-    assert len(fds._load_index()) == 151
+    assert len(fds._load_index()) == DATASET_SIZE
 
 
 def test_merge_subsets(input_manifest, component_spec):
     fds = FondantDataset(manifest=input_manifest)
     df = fds.load_dataframe(spec=component_spec)
-    assert len(df) == 151
+    assert len(df) == DATASET_SIZE
     assert list(df.columns) == [
         "id",
         "source",
@@ -70,5 +72,5 @@ def test_write_subsets(input_manifest, output_manifest, component_spec):
         for subset, subset_columns in subset_columns_dict.items():
             subset_path = Path(tmp_dir_path / subset)
             df = dd.read_parquet(subset_path)
-            assert len(df) == 151
+            assert len(df) == DATASET_SIZE
             assert list(df.columns) == subset_columns

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,11 +1,12 @@
 import tempfile
-import pytest
-import dask.dataframe as dd
 from pathlib import Path
 
-from fondant.manifest import Manifest
-from fondant.dataset import FondantDataset
+import dask.dataframe as dd
+import pytest
+
 from fondant.component_spec import FondantComponentSpec
+from fondant.dataset import FondantDataset
+from fondant.manifest import Manifest
 
 input_manifest_path = Path(__file__).parent / "example_data/input_manifest.json"
 output_manifest_path = Path(__file__).parent / "example_data/output_manifest.json"

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -1,6 +1,4 @@
-"""
-Test scripts for import module functionality
-"""
+"""Test scripts for import module functionality."""
 import pytest
 
 from fondant.import_utils import is_package_available
@@ -18,9 +16,7 @@ from fondant.import_utils import is_package_available
     ],
 )
 def test_is_package_available(package_name, import_error_msg, expected_result):
-    """
-    Test function for is_package_available().
-    """
+    """Test function for is_package_available()."""
     if isinstance(expected_result, bool):
         assert is_package_available(package_name, import_error_msg) == expected_result
     else:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,4 @@
-"""
-Test scripts for logger functionalities
-"""
+"""Test scripts for logger functionalities."""
 import logging
 
 import pytest
@@ -19,7 +17,7 @@ from fondant.logger import configure_logging
     ],
 )
 def test_configure_logging(log_level, expected_level):
-    """Function to test"""
+    """Function to test."""
     configure_logging(log_level)
 
     logger = logging.getLogger(__name__)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -2,6 +2,7 @@
 Test scripts for logger functionalities
 """
 import logging
+
 import pytest
 
 from fondant.logger import configure_logging

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2,9 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+
 from fondant.exceptions import InvalidManifest
 from fondant.manifest import Manifest, Type
-
 
 manifest_path = Path(__file__).parent / "example_specs/manifests"
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -22,14 +22,14 @@ def invalid_manifest():
 
 
 def test_manifest_validation(valid_manifest, invalid_manifest):
-    """Test that the manifest is validated correctly on instantiation"""
+    """Test that the manifest is validated correctly on instantiation."""
     Manifest(valid_manifest)
     with pytest.raises(InvalidManifest):
         Manifest(invalid_manifest)
 
 
 def test_from_to_file(valid_manifest):
-    """Test reading from and writing to file"""
+    """Test reading from and writing to file."""
     tmp_path = "/tmp/manifest.json"
     with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(valid_manifest, f)
@@ -46,7 +46,7 @@ def test_attribute_access(valid_manifest):
     """
     Test that attributes can be accessed as expected:
     - Fixed properties should be accessible as an attribute
-    - Dynamic properties should be accessible by lookup
+    - Dynamic properties should be accessible by lookup.
     """
     manifest = Manifest(valid_manifest)
 
@@ -57,7 +57,7 @@ def test_attribute_access(valid_manifest):
 
 
 def test_manifest_creation():
-    """Test the stepwise creation of a manifest via the Manifest class"""
+    """Test the stepwise creation of a manifest via the Manifest class."""
     base_path = "gs://bucket"
     run_id = "run_id"
     component_id = "component_id"

--- a/tests/test_manifest_evolution.py
+++ b/tests/test_manifest_evolution.py
@@ -17,7 +17,7 @@ def input_manifest():
 
 
 def examples():
-    """Returns examples as tuples of component and expected output_manifest"""
+    """Returns examples as tuples of component and expected output_manifest."""
     for directory in (f for f in examples_path.iterdir() if f.is_dir()):
         with open(directory / "component.yaml") as c, open(
             directory / "output_manifest.json"

--- a/tests/test_manifest_evolution.py
+++ b/tests/test_manifest_evolution.py
@@ -7,7 +7,6 @@ import yaml
 from fondant.component_spec import FondantComponentSpec
 from fondant.manifest import Manifest
 
-
 examples_path = Path(__file__).parent / "example_specs/evolution_examples"
 
 


### PR DESCRIPTION
This PR makes Ruff run on tests as well and adds extra rules:
- More Pylint rules not yet covered by default checks
- Isort for import order
- Pydocstyle rules
  - I ignored quite a few rules here, which we might want to activate (D100 - D107), but we can do that in separate PRs as they require manual effort.

I only had to fix one issue and add one local ignore. All other issues were auto-fixed, so these rules shouldn't lead to additional overhead.