### PR TITLE
Add test for component spec without args

### DIFF
--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -177,17 +177,14 @@ class FondantComponentSpec:
 
     @property
     def args(self) -> t.Dict[str, Argument]:
-        if "args" in self._specification:
-            return {
-                name: Argument(
-                    name=name,
-                    description=arg_info["description"],
-                    type=arg_info["type"],
-                )
-                for name, arg_info in self._specification["args"].items()
-            }
-        else:
-            return {}
+        return {
+            name: Argument(
+                name=name,
+                description=arg_info["description"],
+                type=arg_info["type"],
+            )
+            for name, arg_info in self._specification.get("args", {}).items()
+        }
 
     @property
     def kubeflow_specification(self) -> "KubeflowComponentSpec":

--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -177,14 +177,17 @@ class FondantComponentSpec:
 
     @property
     def args(self) -> t.Dict[str, Argument]:
-        return {
-            name: Argument(
-                name=name,
-                description=arg_info["description"],
-                type=arg_info["type"],
-            )
-            for name, arg_info in self._specification["args"].items()
-        }
+        if "args" in self._specification:
+            return {
+                name: Argument(
+                    name=name,
+                    description=arg_info["description"],
+                    type=arg_info["type"],
+                )
+                for name, arg_info in self._specification["args"].items()
+            }
+        else:
+            return {}
 
     @property
     def kubeflow_specification(self) -> "KubeflowComponentSpec":

--- a/tests/example_specs/component_specs/valid_component_no_args.yaml
+++ b/tests/example_specs/component_specs/valid_component_no_args.yaml
@@ -1,0 +1,15 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+input_subsets:
+  images:
+    fields:
+      data:
+        type: binary
+
+output_subsets:
+  captions:
+    fields:
+      data:
+        type: utf8

--- a/tests/test_component_specs.py
+++ b/tests/test_component_specs.py
@@ -18,6 +18,12 @@ def valid_fondant_schema() -> dict:
 
 
 @pytest.fixture
+def valid_fondant_schema_no_args() -> dict:
+    with open(component_specs_path / "valid_component_no_args.yaml") as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture
 def valid_kubeflow_schema() -> dict:
     with open(component_specs_path / "kubeflow_component.yaml") as f:
         return yaml.safe_load(f)
@@ -54,3 +60,12 @@ def test_kfp_component_creation(valid_fondant_schema, valid_kubeflow_schema):
     fondant_component = FondantComponentSpec(valid_fondant_schema)
     kubeflow_component = fondant_component.kubeflow_specification
     assert kubeflow_component._specification == valid_kubeflow_schema
+
+
+def test_component_spec_no_args(valid_fondant_schema_no_args):
+    """Test that a component spec without args is supported."""
+    fondant_component = FondantComponentSpec(valid_fondant_schema_no_args)
+
+    assert fondant_component.name == "Example component"
+    assert fondant_component.description == "This is an example component"
+    assert fondant_component.args == {}


### PR DESCRIPTION
Follow-up of #87 which tests whether a component spec without any args is supported.