### PR TITLE
Switch to OpenRAIL-S license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,179 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+RESPONSIBLE AI SOURCE CODE LICENSE
+Version 1.1, Nov 20, 2022
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+http://licenses.ai/
 
-   1. Definitions.
+TERMS AND CONDITIONS. 
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The Responsible Artificial Intelligence Source Code License (“License”) governs the use of the
+accompanying software. If you access or use the software, you accept the License. If you do not
+accept the License, do not access or use the software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+1. Definitions.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+    As used in this License, the following capitalized terms have the following meanings:
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+    (i)   "License" means the terms and conditions for use, reproduction, and distribution as
+          defined by Sections one (1) through eight (8) of this document.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+    (ii)  "Licensor" means the copyright owner or legal entity authorized by the copyright owner
+          that is granting the License.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+    (iii) "You" (or "Your") means an individual or legal entity exercising permissions granted by
+          this License.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+    (iv)  The terms “reproduce”, “reproduction”, “derivative works”, and “distribution” have the
+          same meaning here as under U.S. Copyright Law.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+    (v)   “Contribution” means the original software, additions to the original software,
+          modifications to the original software, or derivative works of the original software.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+    (vi)  "Contributor" means any person or Licensor who provides a Contribution.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+2. Grant of Rights.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+    Subject to this License, each Contributor grants You a non-exclusive, worldwide, royalty-free
+    copyright license to reproduce its Contribution, prepare derivative works of its Contribution,
+    and distribute its Contribution or any derivative works of its Contribution that You create.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+3. Restrictions.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+    1. If You distribute any portion of the Contribution, You must include a complete copy of this
+       License with the distribution; and
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+    2. You agree that the Contribution, or any derivative work of the Contribution, will not be
+       used by You or any third party subject to Your control, to:
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+        a. Surveillance
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+            i.    Detect or infer any legally protected class or aspect of any person, as defined
+                  by U.S. Federal Law; and
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+            ii.   Detect or infer aspects and/or features of an identity any person, such as name,
+                  family name, address, gender, sexual orientation, race, religion, age, location
+                  (at any geographical level), skin color, society or political affiliations,
+                  employment status and/or employment history, and health and medical conditions.
+                  Age and medical conditions may be inferred solely for the purpose of improving
+                  software/hardware accessibility and such data should not be cached or stored
+                  without the explicit and time limited permission of Licensor
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+        b. Computer Generated Media
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+            i.    Synthesize and/or modify audio-realistic and/or video-realistic representations
+                  (indistinguishable from photo/video recordings) of people and events, without
+                  including a caption, watermark, and/or metadata file indicating that the
+                  audio-realistic and/or video-realistic representations were generated using the
+                  Contribution.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+        c. Health Care
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+            i.    Predict the likelihood that any person will request to file an insurance claim;
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+            ii.   Determine an insurance premium or deny insurance applications or claims;
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+            iii.  Predict the likelihood that any person request to file an insurance claim based
+                  on determining a lifestyle of a person, medical-test reports, demographic details
+                  of a person and/or online activity of a person;
 
-   END OF TERMS AND CONDITIONS
+            iv.   Determine an insurance premium or deny insurance applications or claims based on
+                  data determining a lifestyle of a person, medical-test reports, demographic
+                  details of a person, and/or online activity of a person;
 
-   APPENDIX: How to apply the Apache License to your work.
+            v.    Deny an insurance claim based on any predicted likelihood of the possibility of
+                  insurance fraud; and
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+            vi.   Diagnose a medical condition without human oversight.
 
-   Copyright [yyyy] [name of copyright owner]
+        d. Criminal
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+            i.    Predict the likelihood that a crime will be committed by any person;
 
-       http://www.apache.org/licenses/LICENSE-2.0
+            ii.   Predict the likelihood, of any person, being a criminal or having committed a
+                  crime;
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+            iii.  Predict the likelihood, of any person, being a criminal, based on the person’s
+                  facial attributes or another person’s facial attributes;
+
+            iv.   Predict the likelihood, of any person, having committed a crime, based on the
+                  person’s facial attributes or another person’s facial attributes;
+
+            v.    Predict the likelihood that a crime will be committed by any person, based on the
+                  person’s facial attributes or another person’s facial attributes;
+
+            vi.   Predict a likelihood of a crime being committed by any person, based on evidence
+                  collected, facial and emotion analysis, or other such features
+
+            vii.  Use personal data and/or personal characteristics or features such as: name,
+                  family name, address, gender, sexual orientation, race, religion, age, location
+                  (at any geographical level), skin color, society or political affiliations,
+                  employment status and/or history, health and medical conditions (including
+                  physical, mental), family history, social media and publicly available data,
+                  image or video analysis of an individual or a group(s) of individuals,
+                  heart-rate, perspiration, breathing, and brain imaging and other metabolic data
+                  to predict the likelihood a person will engage in criminal behavior; and
+
+            viii. Predict the likelihood of a person being a criminal based on the person or other
+                  User’s facial attributes.
+
+    3. Restrictions referenced in Section 3.2 MUST be included as an enforceable provision by You
+       in any type of legal agreement governing the use and/or distribution of the Work or any
+       Derivative Works, and You shall give notice to subsequent users You Distribute to, that the
+       Work or any Derivative Works are subject to Section 3.2. You shall require all of Your users
+       who use the Work or any Derivative Works to comply with the terms of Section 3.2.
+
+4. Termination
+
+    Upon the occurrence of any of the restricted uses listed above in “3. Restrictions”, Licensor
+    shall have the right to:
+
+    (i)   terminate this License Agreement and disable any Contribution either by pre-installed or
+          then installed disabling instructions, and to take immediate possession of the
+          Contribution and all copies wherever located, without demand or notice;
+
+    (ii)  require You to immediately return to Licensor all copies of the Contribution, or upon
+          request by Licensor destroy the Contribution and all copies and certify in writing that
+          they have been destroyed;
+
+    (iii) for a period of 1 year, provide a prominent notice on the Licensor’s website indicating
+          that this License was violated by the Licensor;
+
+    (iv)  release/delete any and all data collected through use of the Contribution; and
+
+    (v)   notify all parties affected by use of the Contribution.
+
+    Termination of this License Agreement shall be in addition to and not in lieu of any other
+    remedies available to Licensor. Licensor expressly reserves the right to pursue all legal and
+    equitable remedies available under the law.
+
+5. Disclaimer of Warranty.
+
+    Unless required by applicable law or agreed to in writing, Licensor provides any Contribution
+    (and each Contributor provides its Contributions) on an "As-Is" basis, without WARRANTIES OR
+    CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any
+    warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or
+    redistributing a Contribution and assume any risks associated with Your exercise of permissions
+    under this License.
+
+6. Limitation of Liability.
+
+    In no event and under no legal theory, whether in tort (including negligence), contract, or
+    otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or
+    agreed to in writing, shall any Contributor be liable to You for damages, including any direct,
+    indirect, special, incidental, or consequential damages of any character arising as a result of
+    this License or out of the use or inability to use any Contribution (including but not limited
+    to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor has been advised of the
+    possibility of such damages.
+
+7. Accepting Warranty or Additional Liability.
+
+    While redistributing the Contribution, You may choose to offer, and charge a fee for,
+    acceptance of support, warranty, indemnity, or other liability obligations and/or rights
+    consistent with this License. However, in accepting such obligations, You may act only on Your
+    own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if
+    You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred
+    by, or claims asserted against, such Contributor by reason of your accepting any such warranty
+    or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ Example use cases of Fondant include:
 
 Check out the [examples folder](examples) for some illustrations.
 
+## License
+
+Fondant is distributed under the OpenRAIL-S license, which stands for "Open Responsible AI 
+License for Source code". 
+
+This is a permissive license that allows for commercial and non-commercial usage. This license is 
+focused on ethical and legal use of the software as your responsibility and must accompany any 
+distribution of the software. The license is similar to Apache 2.0, but includes specific use case 
+restrictions.
+
+Versions of the OpenRAIL licenses have already been adopted by 
+[Hugging Face](https://huggingface.co/blog/open_rail), 
+[BigScience](https://bigscience.huggingface.co/blog/the-bigscience-rail-license), and 
+[stability.ai](https://stability.ai/blog/stable-diffusion-public-release#:~:text=The%20model,service%20on%20it.) 
+for the release of their open source models.
+
+For more information on the license, check:
+- Our [LICENSE](LICENSE) file
+- Our [license documentation](https://fondant.readthedocs.io/en/latest/license/)
+
 ## Contributing
 
 We use [poetry](https://python-poetry.org/docs/) and pre-commit to enable a smooth developer flow. Run the following commands to 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,49 @@
+# License
+
+Fondant is distributed under the [OpenRAIL-S license](https://www.licenses.ai/source-code-license), 
+a permissive license that allows for commercial and non-commercial usage.
+
+RAIL stands for `Responsible AI Licenses`, which empower developers to restrict the use of their AI 
+technology in order to prevent irresponsible and harmful applications. These licenses include 
+behavioral-use clauses which restrict certain use-cases.
+
+The `Open-` prefix indicates that it permits free use and distribution, albeit subject to use 
+restrictions. It aims to clarify, on its face, that the licensor offers royalty free access and 
+flexible downstream use and re-distribution of the licensed material or any derivatives of it.
+
+The `-S` suffix indicates that the license applies to source code. Alternative license versions 
+are available to license data, applications, or models.
+
+## Adoption
+
+Early adopters of the OpenRAIL licenses were:
+- [Hugging Face](https://huggingface.co/blog/open_rail)
+- [BigScience](https://bigscience.huggingface.co/blog/the-bigscience-rail-license)
+- [stability.ai](https://stability.ai/blog/stable-diffusion-public-release#:~:text=The%20model,service%20on%20it.) 
+
+Adoption of the OpenRAIL licenses had already 
+[increased to 9.81% of all model repositories](https://openfuture.pubpub.org/pub/growth-of-responsible-ai-licensing/release/2) 
+on the Hugging Face Hub by 24 January 2023.
+
+## FAQ
+
+#### What are we licensing?
+The license covers the Fondant framework and provided reusable components.
+
+#### Is this an open source license?
+This is not an open source license according to the Open Source Initiative definition, because it 
+has some restrictions on the use of the model. That said, it does not impose any restrictions on 
+reuse, distribution, commercialization, adaptation as long as the software is not being applied 
+towards use-cases that have been restricted.
+
+#### Does the license allow commercial use?
+Yes, as long as the software is not applied towards use-cases that have been restricted.
+
+#### How does the license compare with other open source licenses?
+The license is closest to the Apache 2.0 open source license but it includes specific conditions 
+under which restrictions to the USE, REPRODUCTION, AND DISTRIBUTION of source code can apply.   
+
+#### Do the use case restrictions apply to datasets generated using Fondant?
+Yes. As the license prohibits Fondant to be used towards any of the restricted use cases, it cannot 
+be used to generate datasets for those use cases. Generated datasets should integrate the same 
+use-based restrictions as part of their license.

--- a/license_strategy.ini
+++ b/license_strategy.ini
@@ -34,6 +34,7 @@ authorized_licenses:
   Mozilla Public License 1.0 (MPL)
   Mozilla Public License 1.1 (MPL 1.1)
   Mozilla Public License 2.0 (MPL 2.0)
+  OpenRAIL-S
   The Unlicense (Unlicense)
 
 [Authorized Packages]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ theme:
 nav:
     - Home: index.md
     - Manifest: manifest.md
+    - License: license.md
 
 markdown_extensions:
 - pymdownx.snippets:


### PR DESCRIPTION
Fixes #90 

This PR updates our license to OpenRAIL-S and adds documentation to explain the license. Let me know if you have any feedback or if there's additional questions to include in the FAQ.

You can find the generated documentation [here](https://fondant--126.org.readthedocs.build/en/126/license/).