### PR TITLE
Bugfix for release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         python-version: 3.9
 
     - name: Build components
-      run: ./scripts/build_components.sh -t $GITHUB_REF
+      run: ./scripts/build_components.sh -t $GITHUB_REF_NAME
 
     - name: Update version in pyproject.toml with tag version
       run: sed -i "s/^version = .*/version = '${{github.ref_name}}'/" pyproject.toml

--- a/scripts/build_components.sh
+++ b/scripts/build_components.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function usage {
   echo "Usage: $0 [options]"

--- a/scripts/pre-build.sh
+++ b/scripts/pre-build.sh
@@ -2,6 +2,7 @@
 # This script copies the components/ directory to fondant/components, replacing the symlink
 # It should be run before building the fondant package'
 # This script makes changes to the local files, which should not be committed to git
+set -e
 
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 

--- a/scripts/pre-build.sh
+++ b/scripts/pre-build.sh
@@ -4,9 +4,10 @@
 # This script makes changes to the local files, which should not be committed to git
 set -e
 
-parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+scripts_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+root_path=$(dirname "$scripts_path")
 
-pushd "$parent_path"
+pushd "$root_path"
 rm fondant/components
 cp -r components/ fondant/
 popd


### PR DESCRIPTION
Fixes for the release pipeline:
- `GITHUB_REF` contains the full ref in the format `refs/tags/<tag>`, while `GITHUB_REF_NAME` only contains `<tag>`
- `set -e` in bash scripts to make the pipeline fail if the scripts fail.
- Fix paths in `pre-build.sh` script