### PR TITLE
Rename input_subsets/output_subsets to consumes/produces

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ name: Image filtering
 description: Component that filters images based on desired minimum width and height
 image: image_filtering:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       width:

--- a/components/prompt_based_laion_retrieval/fondant_component.yaml
+++ b/components/prompt_based_laion_retrieval/fondant_component.yaml
@@ -2,13 +2,13 @@ name: LAION retrieval
 description: A component that retrieves image URLs from LAION-5B based on a set of seed prompts
 image: ghcr.io/ml6team/prompt_based_laion_retrieval:latest
 
-input_subsets:
+consumes:
   prompts:
     fields:
       text:
         type: string
 
-output_subsets:
+produces:
   images:
     fields:
       url:

--- a/examples/pipelines/controlnet-interior-design/components/caption_images/fondant_component.yaml
+++ b/examples/pipelines/controlnet-interior-design/components/caption_images/fondant_component.yaml
@@ -2,13 +2,13 @@ name: Caption images
 description: Component that captions images using a model from the Hugging Face hub
 image: ghcr.io/ml6team/caption_images:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
 
-output_subsets:
+produces:
   captions:
     fields:
       text:

--- a/examples/pipelines/controlnet-interior-design/components/download_images/fondant_component.yaml
+++ b/examples/pipelines/controlnet-interior-design/components/download_images/fondant_component.yaml
@@ -2,13 +2,13 @@ name: Download images
 description: Component that downloads images based on URLs
 image: ghcr.io/ml6team/download_images:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       url:
         type: string
 
-output_subsets:
+produces:
   images:
     fields:
       data:

--- a/examples/pipelines/controlnet-interior-design/components/download_images/src/main.py
+++ b/examples/pipelines/controlnet-interior-design/components/download_images/src/main.py
@@ -123,6 +123,8 @@ class DownloadImagesComponent(TransformComponent):
             max_aspect_ratio=max_aspect_ratio,
         )
 
+        print(dataframe.head())
+
         # retrieve and resize images
         # source: https://stackoverflow.com/questions/41728527/how-to-apply-a-function-to-a-dask-dataframe-and-return-multiple-values
         logger.info("Downloading and resizing images...")
@@ -148,6 +150,8 @@ class DownloadImagesComponent(TransformComponent):
         )
 
         dataframe = dataframe.reset_index(drop=True)
+
+        print(dataframe.head())
 
         return dataframe
 

--- a/examples/pipelines/controlnet-interior-design/components/generate_prompts/fondant_component.yaml
+++ b/examples/pipelines/controlnet-interior-design/components/generate_prompts/fondant_component.yaml
@@ -2,7 +2,7 @@ name: Generate prompts
 description: Component that generates a set of seed prompts
 image: ghcr.io/ml6team/generate_prompts:latest
 
-output_subsets:
+produces:
   prompts:
     fields:
       text:

--- a/examples/pipelines/controlnet-interior-design/components/generate_prompts/src/main.py
+++ b/examples/pipelines/controlnet-interior-design/components/generate_prompts/src/main.py
@@ -122,6 +122,8 @@ class GeneratePromptsComponent(LoadComponent):
         df = df[["id", "source", "prompts_text"]]
         df = df.astype({"id": "string"})
 
+        df = dd.from_pandas(df.head(), npartitions=1)
+
         return df
 
 

--- a/examples/pipelines/controlnet-interior-design/components/segment_images/fondant_component.yaml
+++ b/examples/pipelines/controlnet-interior-design/components/segment_images/fondant_component.yaml
@@ -2,13 +2,13 @@ name: Segment images
 description: Component that creates segmentation masks for images using a model from the Hugging Face hub
 image: ghcr.io/ml6team/segment_images:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
 
-output_subsets:
+produces:
   segmentations:
     fields:
       data:

--- a/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/fondant_component.yaml
+++ b/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/fondant_component.yaml
@@ -2,7 +2,7 @@ name: Write to hub
 description: Component that writes a dataset to the hub
 image: ghcr.io/ml6team/write_to_hub_controlnet:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:

--- a/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/src/main.py
+++ b/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/src/main.py
@@ -44,7 +44,7 @@ class WriteToHubComponent(TransformComponent):
         # Get columns to write and schema
         write_columns = []
         schema = {}
-        for subset_name, subset in self.spec.input_subsets.items():
+        for subset_name, subset in self.spec.consumes.items():
             write_columns.extend([f"{subset_name}_{field}" for field in subset.fields])
             # Get schema
             subset_schema = {

--- a/examples/pipelines/finetune_stable_diffusion/components/embedding_based_laion_retrieval/fondant_component.yaml
+++ b/examples/pipelines/finetune_stable_diffusion/components/embedding_based_laion_retrieval/fondant_component.yaml
@@ -2,13 +2,13 @@ name: LAION retrieval
 description: A component that retrieves image URLs from LAION-5B based on a set of CLIP embeddings
 image: ghcr.io/ml6team/embedding_based_laion_retrieval:latest
 
-input_subsets:
+consumes:
   embeddings:
     fields:
       data:
         type: float32_list
 
-output_subsets:
+produces:
   images:
     fields:
       url:

--- a/examples/pipelines/finetune_stable_diffusion/components/image_embedding/fondant_component.yaml
+++ b/examples/pipelines/finetune_stable_diffusion/components/image_embedding/fondant_component.yaml
@@ -2,13 +2,13 @@ name: Image embedding
 description: Component that embeds images using CLIP
 image: ghcr.io/ml6team/image_embedding:latest
 
-input_subsets:
+consumes:
   images:
       fields:
         data:
           type: binary
 
-output_subsets:
+produces:
   embeddings:
     fields:
       data:

--- a/examples/pipelines/finetune_stable_diffusion/components/image_filtering/fondant_component.yaml
+++ b/examples/pipelines/finetune_stable_diffusion/components/image_filtering/fondant_component.yaml
@@ -2,7 +2,7 @@ name: Image filtering
 description: Component that filters images based on desired minimum width and height
 image: ghcr.io/ml6team/image_filtering:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       width:

--- a/examples/pipelines/finetune_stable_diffusion/components/load_from_hub/fondant_component.yaml
+++ b/examples/pipelines/finetune_stable_diffusion/components/load_from_hub/fondant_component.yaml
@@ -2,7 +2,7 @@ name: Load from hub
 description: Component that loads a dataset from the hub
 image: ghcr.io/ml6team/load_from_hub:latest
 
-output_subsets:
+produces:
   images:
     fields:
       data:

--- a/examples/pipelines/simple_pipeline/components/image_cropping/fondant_component.yaml
+++ b/examples/pipelines/simple_pipeline/components/image_cropping/fondant_component.yaml
@@ -2,13 +2,13 @@ name: Image cropping
 description: Component that removes single-colored borders around images and crops them appropriately
 image: ghcr.io/ml6team/image_cropping:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
 
-output_subsets:
+produces:
   images:
     fields:
       data:

--- a/examples/pipelines/simple_pipeline/components/write_to_hub/fondant_component.yaml
+++ b/examples/pipelines/simple_pipeline/components/write_to_hub/fondant_component.yaml
@@ -2,7 +2,7 @@ name: Write to hub
 description: Component that writes a dataset to the hub
 image: ghcr.io/ml6team/write_to_hub:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:

--- a/examples/pipelines/simple_pipeline/components/write_to_hub/src/main.py
+++ b/examples/pipelines/simple_pipeline/components/write_to_hub/src/main.py
@@ -44,7 +44,7 @@ class WriteToHubComponent(FondantTransformComponent):
         # Get columns to write and schema
         write_columns = []
         schema = {}
-        for subset_name, subset in self.spec.input_subsets.items():
+        for subset_name, subset in self.spec.consumes.items():
             write_columns.extend([f"{subset_name}_{field}" for field in subset.fields])
             # Get schema
             subset_schema = {

--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -140,40 +140,34 @@ class ComponentSpec:
         return self._specification["image"]
 
     @property
-    def input_subsets(self) -> t.Mapping[str, ComponentSubset]:
-        """The input subsets of the component as an immutable mapping."""
+    def consumes(self) -> t.Mapping[str, ComponentSubset]:
+        """The subsets consumed by the component as an immutable mapping."""
         return types.MappingProxyType(
             {
                 name: ComponentSubset(subset)
-                for name, subset in self._specification.get("input_subsets", {}).items()
+                for name, subset in self._specification.get("consumes", {}).items()
                 if name != "additionalSubsets"
             }
         )
 
     @property
-    def output_subsets(self) -> t.Mapping[str, ComponentSubset]:
-        """The output subsets of the component as an immutable mapping."""
+    def produces(self) -> t.Mapping[str, ComponentSubset]:
+        """The subsets produced by the component as an immutable mapping."""
         return types.MappingProxyType(
             {
                 name: ComponentSubset(subset)
-                for name, subset in self._specification.get(
-                    "output_subsets", {}
-                ).items()
+                for name, subset in self._specification.get("produces", {}).items()
                 if name != "additionalSubsets"
             }
         )
 
     @property
     def accepts_additional_subsets(self) -> bool:
-        return self._specification.get("input_subsets", {}).get(
-            "additionalSubsets", True
-        )
+        return self._specification.get("consumes", {}).get("additionalSubsets", True)
 
     @property
-    def produces_additional_subsets(self) -> bool:
-        return self._specification.get("output_subsets", {}).get(
-            "additionalSubsets", True
-        )
+    def outputs_additional_subsets(self) -> bool:
+        return self._specification.get("produces", {}).get("additionalSubsets", True)
 
     @property
     def args(self) -> t.Dict[str, Argument]:

--- a/fondant/data_io.py
+++ b/fondant/data_io.py
@@ -74,7 +74,7 @@ class DaskDataLoader(DataIO):
         """
         # load index into dataframe
         df = self._load_index()
-        for name, subset in spec.input_subsets.items():
+        for name, subset in spec.consumes.items():
             fields = list(subset.fields.keys())
             subset_df = self._load_subset(name, fields)
             # left joins -> filter on index
@@ -202,7 +202,7 @@ class DaskDataWriter(DataIO):
         divisions = list(df.divisions) if df.known_divisions else None
 
         # Loop through each output subset defined in the spec
-        for subset_name, subset in spec.output_subsets.items():
+        for subset_name, subset in spec.produces.items():
             # Verify that all the fields defined in the output subset are present in the
             # output dataframe
             subset_columns = verify_subset_columns(subset_name, subset.fields, df)

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -205,23 +205,23 @@ class Manifest:
             "location"
         ] = f"/index/{self.run_id}/{component_id}"
 
-        # If additionalSubsets is False in component input subsets,
+        # If additionalSubsets is False in consumes,
         # Remove all subsets from the manifest that are not listed
         if not component_spec.accepts_additional_subsets:
             for subset_name in evolved_manifest.subsets:
-                if subset_name not in component_spec.input_subsets:
+                if subset_name not in component_spec.consumes:
                     evolved_manifest.remove_subset(subset_name)
 
-        # If additionalSubsets is False in component output subsets,
+        # If additionalSubsets is False in produces,
         # Remove all subsets from the manifest that are not listed
-        if not component_spec.produces_additional_subsets:
+        if not component_spec.outputs_additional_subsets:
             for subset_name in evolved_manifest.subsets:
-                if subset_name not in component_spec.output_subsets:
+                if subset_name not in component_spec.produces:
                     evolved_manifest.remove_subset(subset_name)
 
-        # If additionalFields is False for input subsets,
+        # If additionalFields is False for a consumed subset,
         # Remove all fields from that subset that are not listed
-        for subset_name, subset in component_spec.input_subsets.items():
+        for subset_name, subset in component_spec.consumes.items():
             if subset_name in evolved_manifest.subsets:
                 if not subset.additional_fields:
                     for field_name in evolved_manifest.subsets[subset_name].fields:
@@ -231,11 +231,11 @@ class Manifest:
                             )
 
         # For each output subset defined in the component, add or update it
-        for subset_name, subset in component_spec.output_subsets.items():
+        for subset_name, subset in component_spec.produces.items():
             # Subset is already in manifest, update it
             if subset_name in evolved_manifest.subsets:
                 # If additional fields are not allowed, remove the fields not defined in the
-                # component spec output subsets
+                # component spec produces section
                 if not subset.additional_fields:
                     for field_name in evolved_manifest.subsets[subset_name].fields:
                         if field_name not in subset.fields:
@@ -243,7 +243,7 @@ class Manifest:
                                 field_name
                             )
 
-                # Add fields defined in the component spec output subsets
+                # Add fields defined in the component spec produces section
                 # Overwrite to persist changes to the field (eg. type of column)
                 for field in subset.fields.values():
                     evolved_manifest.subsets[subset_name].add_field(

--- a/fondant/pipeline.py
+++ b/fondant/pipeline.py
@@ -199,8 +199,8 @@ class Pipeline:
 
     def _validate_pipeline_definition(self, run_id: str):
         """
-        Validates the pipeline definition by ensuring that the input and output subsets and their
-         associated fields match and are invoked in the correct order.
+        Validates the pipeline definition by ensuring that the consumed and produced subsets and
+        their associated fields match and are invoked in the correct order.
 
         Raises:
             InvalidPipelineDefinition: If a component is trying to invoke a subset that is not
@@ -225,7 +225,7 @@ class Pipeline:
                 for (
                     component_subset_name,
                     component_subset,
-                ) in component_spec.input_subsets.items():
+                ) in component_spec.consumes.items():
                     if component_subset_name not in manifest.subsets:
                         raise InvalidPipelineDefinition(
                             f"Component '{component_spec.name}' "

--- a/fondant/schemas/component_spec.json
+++ b/fondant/schemas/component_spec.json
@@ -20,10 +20,10 @@
       "type": "string",
       "description": "Docker image for the component"
     },
-    "input_subsets": {
+    "consumes": {
       "$ref": "#/definitions/subsets"
     },
-    "output_subsets": {
+    "produces": {
       "$ref": "#/definitions/subsets"
     },
     "args": {

--- a/tests/example_data/components/1.yaml
+++ b/tests/example_data/components/1.yaml
@@ -2,7 +2,7 @@ name: Test component 1
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   properties:
     fields:
       Name:
@@ -16,7 +16,7 @@ input_subsets:
       Type 2:
         type: "string"
 
-output_subsets:
+produces:
   properties:
     fields:
       Name:

--- a/tests/example_pipelines/invalid_pipeline/example_1/first_component.yaml
+++ b/tests/example_pipelines/invalid_pipeline/example_1/first_component.yaml
@@ -2,13 +2,13 @@ name: First component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
 
-output_subsets:
+produces:
   captions:
     fields:
       data:

--- a/tests/example_pipelines/invalid_pipeline/example_1/second_component.yaml
+++ b/tests/example_pipelines/invalid_pipeline/example_1/second_component.yaml
@@ -2,7 +2,7 @@ name: Second component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
@@ -13,7 +13,7 @@ input_subsets:
       data:
         type: string
 
-output_subsets:
+produces:
   embeddings:
     fields:
       data:

--- a/tests/example_pipelines/invalid_pipeline/example_2/first_component.yaml
+++ b/tests/example_pipelines/invalid_pipeline/example_2/first_component.yaml
@@ -2,13 +2,13 @@ name: First component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
 
-output_subsets:
+produces:
   captions:
     fields:
       data:

--- a/tests/example_pipelines/invalid_pipeline/example_2/second_component.yaml
+++ b/tests/example_pipelines/invalid_pipeline/example_2/second_component.yaml
@@ -2,7 +2,7 @@ name: Second component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
@@ -15,7 +15,7 @@ input_subsets:
       description:
         type: binary
 
-output_subsets:
+produces:
   embeddings:
     fields:
       data:

--- a/tests/example_pipelines/valid_pipeline/example_1/first_component.yaml
+++ b/tests/example_pipelines/valid_pipeline/example_1/first_component.yaml
@@ -2,7 +2,7 @@ name: First component
 description: This is an example component
 image: example_component:latest
 
-output_subsets:
+produces:
   images:
     fields:
       data:

--- a/tests/example_pipelines/valid_pipeline/example_1/second_component.yaml
+++ b/tests/example_pipelines/valid_pipeline/example_1/second_component.yaml
@@ -2,13 +2,13 @@ name: Second component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
 
-output_subsets:
+produces:
   embeddings:
     fields:
       data:

--- a/tests/example_pipelines/valid_pipeline/example_1/third_component.yaml
+++ b/tests/example_pipelines/valid_pipeline/example_1/third_component.yaml
@@ -2,7 +2,7 @@ name: Third component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
@@ -18,7 +18,7 @@ input_subsets:
       data:
         type: binary
 
-output_subsets:
+produces:
   images:
     fields:
       data:

--- a/tests/example_specs/component_specs/invalid_component.yaml
+++ b/tests/example_specs/component_specs/invalid_component.yaml
@@ -2,11 +2,11 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     data: binary
 
-output_subsets:
+produces:
   captions:
     data: string
 

--- a/tests/example_specs/component_specs/valid_component.yaml
+++ b/tests/example_specs/component_specs/valid_component.yaml
@@ -2,7 +2,7 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
@@ -13,7 +13,7 @@ input_subsets:
       data:
         type: int8_list
 
-output_subsets:
+produces:
   captions:
     fields:
       data:

--- a/tests/example_specs/component_specs/valid_component_no_args.yaml
+++ b/tests/example_specs/component_specs/valid_component_no_args.yaml
@@ -2,13 +2,13 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
 
-output_subsets:
+produces:
   captions:
     fields:
       data:

--- a/tests/example_specs/evolution_examples/1/component.yaml
+++ b/tests/example_specs/evolution_examples/1/component.yaml
@@ -2,13 +2,13 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
   
-output_subsets:
+produces:
   embeddings:
     fields:
       data:

--- a/tests/example_specs/evolution_examples/2/component.yaml
+++ b/tests/example_specs/evolution_examples/2/component.yaml
@@ -2,14 +2,14 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
   additionalSubsets: false
   
-output_subsets:
+produces:
   embeddings:
     fields:
       data:

--- a/tests/example_specs/evolution_examples/3/component.yaml
+++ b/tests/example_specs/evolution_examples/3/component.yaml
@@ -2,7 +2,7 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
@@ -10,7 +10,7 @@ input_subsets:
     additionalFields: false
   additionalSubsets: false
   
-output_subsets:
+produces:
   embeddings:
     fields:
       data:

--- a/tests/example_specs/evolution_examples/4/component.yaml
+++ b/tests/example_specs/evolution_examples/4/component.yaml
@@ -2,13 +2,13 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
   
-output_subsets:
+produces:
   images:
     fields:
       encoding:

--- a/tests/example_specs/evolution_examples/5/component.yaml
+++ b/tests/example_specs/evolution_examples/5/component.yaml
@@ -2,13 +2,13 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
   
-output_subsets:
+produces:
   images:
     fields:
       encoding:

--- a/tests/example_specs/evolution_examples/6/component.yaml
+++ b/tests/example_specs/evolution_examples/6/component.yaml
@@ -2,13 +2,13 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
   
-output_subsets:
+produces:
   images:
     fields:
       encoding:

--- a/tests/example_specs/evolution_examples/7/component.yaml
+++ b/tests/example_specs/evolution_examples/7/component.yaml
@@ -2,13 +2,13 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:
         type: binary
   
-output_subsets:
+produces:
   images:
     fields:
       data:

--- a/tests/example_specs/evolution_examples/8/component.yaml
+++ b/tests/example_specs/evolution_examples/8/component.yaml
@@ -2,7 +2,7 @@ name: Example component
 description: This is an example component
 image: example_component:latest
 
-input_subsets:
+consumes:
   images:
     fields:
       data:

--- a/tests/test_component_specs.py
+++ b/tests/test_component_specs.py
@@ -53,12 +53,11 @@ def test_attribute_access(valid_fondant_schema):
 
     assert fondant_component.name == "Example component"
     assert fondant_component.description == "This is an example component"
-    assert fondant_component.input_subsets["images"].fields["data"].type == Type.binary
+    assert fondant_component.consumes["images"].fields["data"].type == Type.binary
     assert (
-        fondant_component.input_subsets["embeddings"].fields["data"].type
-        == Type.int8_list
+        fondant_component.consumes["embeddings"].fields["data"].type == Type.int8_list
     )
-    assert fondant_component.input_subsets["embeddings"].fields[
+    assert fondant_component.consumes["embeddings"].fields[
         "data"
     ].type.value == pa.list_(pa.int8())
 


### PR DESCRIPTION
I was working on the component spec documentation and became less and less of a fan of the `input_subsets` and `output_subsets` naming. I think they can more clearly be described using `consumes` and `produces`.
- `consumes` describes which subsets a component actually "consumes", while allowing freedom to "accept" additional input subsets using the `additionalSubsets` flag.
- `produces` describes which subsets a component actually produces, while allowing freedom to "pass along" additional output subsets using the `additionalSubsets` flag.

Once we release, it would be hard or even impossible to change his.