### PR TITLE
Add symlink to prompt_based_laion_retrieval in ControlNet example

### DIFF
--- a/examples/pipelines/controlnet-interior-design/components/prompt_based_laion_retrieval
+++ b/examples/pipelines/controlnet-interior-design/components/prompt_based_laion_retrieval
@@ -1,0 +1,1 @@
+../../../../components/prompt_based_laion_retrieval/


### PR DESCRIPTION
This PR adds a temporary symlink from the ControlNet example pipeline to the `prompt_based_laion_retrieval` component to be able to develop the example pipeline more easily while we develop Fondant. We can now just work as if the component was still located in the example directory.

The symlink should be removed before alpha release.