### PR TITLE
Custom component spec

### DIFF
--- a/components/caption_images/Dockerfile
+++ b/components/caption_images/Dockerfile
@@ -12,8 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the compoent folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/caption_images/src/main.py
+++ b/components/caption_images/src/main.py
@@ -125,5 +125,5 @@ class CaptionImagesComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = CaptionImagesComponent.from_file()
+    component = CaptionImagesComponent.from_args()
     component.run()

--- a/components/download_images/Dockerfile
+++ b/components/download_images/Dockerfile
@@ -12,8 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the component folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -151,5 +151,5 @@ class DownloadImagesComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = DownloadImagesComponent.from_file()
+    component = DownloadImagesComponent.from_args()
     component.run()

--- a/components/embedding_based_laion_retrieval/Dockerfile
+++ b/components/embedding_based_laion_retrieval/Dockerfile
@@ -12,8 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the component folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/embedding_based_laion_retrieval/src/main.py
+++ b/components/embedding_based_laion_retrieval/src/main.py
@@ -96,5 +96,5 @@ class LAIONRetrievalComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = LAIONRetrievalComponent.from_file()
+    component = LAIONRetrievalComponent.from_args()
     component.run()

--- a/components/image_cropping/Dockerfile
+++ b/components/image_cropping/Dockerfile
@@ -12,8 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the compoent folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/image_cropping/src/main.py
+++ b/components/image_cropping/src/main.py
@@ -71,5 +71,5 @@ class ImageCroppingComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = ImageCroppingComponent.from_file()
+    component = ImageCroppingComponent.from_args()
     component.run()

--- a/components/image_embedding/Dockerfile
+++ b/components/image_embedding/Dockerfile
@@ -12,9 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the component folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
-
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/image_embedding/src/main.py
+++ b/components/image_embedding/src/main.py
@@ -112,5 +112,5 @@ class EmbedImagesComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = EmbedImagesComponent.from_file()
+    component = EmbedImagesComponent.from_args()
     component.run()

--- a/components/image_resolution_filtering/Dockerfile
+++ b/components/image_resolution_filtering/Dockerfile
@@ -12,8 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the compoent folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/image_resolution_filtering/src/main.py
+++ b/components/image_resolution_filtering/src/main.py
@@ -43,5 +43,5 @@ class ImageFilterComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = ImageFilterComponent.from_file()
+    component = ImageFilterComponent.from_args()
     component.run()

--- a/components/load_from_hf_hub/Dockerfile
+++ b/components/load_from_hf_hub/Dockerfile
@@ -12,9 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the component folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
-
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/load_from_hf_hub/src/main.py
+++ b/components/load_from_hf_hub/src/main.py
@@ -67,5 +67,5 @@ class LoadFromHubComponent(LoadComponent):
 
 
 if __name__ == "__main__":
-    component = LoadFromHubComponent.from_file()
+    component = LoadFromHubComponent.from_args()
     component.run()

--- a/components/prompt_based_laion_retrieval/Dockerfile
+++ b/components/prompt_based_laion_retrieval/Dockerfile
@@ -12,8 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the component folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/prompt_based_laion_retrieval/src/main.py
+++ b/components/prompt_based_laion_retrieval/src/main.py
@@ -96,5 +96,5 @@ class LAIONRetrievalComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = LAIONRetrievalComponent.from_file()
+    component = LAIONRetrievalComponent.from_args()
     component.run()

--- a/components/segment_images/Dockerfile
+++ b/components/segment_images/Dockerfile
@@ -12,8 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set the working directory to the component folder
 WORKDIR /component/src
 
-# Copy over src-files and spec of the component
+# Copy over src-files
 COPY src/ .
-COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/segment_images/src/main.py
+++ b/components/segment_images/src/main.py
@@ -142,5 +142,5 @@ class SegmentImagesComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = SegmentImagesComponent.from_file()
+    component = SegmentImagesComponent.from_args()
     component.run()

--- a/docs/custom_component.md
+++ b/docs/custom_component.md
@@ -64,7 +64,6 @@ WORKDIR /component/src
 
 # Copy over src-files and spec of the component
 COPY src/ .
-COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]
 ```

--- a/examples/pipelines/controlnet-interior-design/components/generate_prompts/src/main.py
+++ b/examples/pipelines/controlnet-interior-design/components/generate_prompts/src/main.py
@@ -116,5 +116,5 @@ class GeneratePromptsComponent(LoadComponent):
 
 
 if __name__ == "__main__":
-    component = GeneratePromptsComponent.from_file()
+    component = GeneratePromptsComponent.from_args()
     component.run()

--- a/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/src/main.py
+++ b/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/src/main.py
@@ -62,5 +62,5 @@ class WriteToHubComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = WriteToHubComponent.from_file()
+    component = WriteToHubComponent.from_args()
     component.run()

--- a/fondant/component.py
+++ b/fondant/component.py
@@ -40,6 +40,19 @@ class Component(ABC):
         component_spec = ComponentSpec.from_file(path)
         return cls(component_spec)
 
+    @classmethod
+    def from_args(cls) -> "Component":
+        """Create a component from a passed argument containing the specification as a dict."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--component_spec", type=json.loads)
+        args, _ = parser.parse_known_args()
+
+        if not args.component_spec:
+            raise ValueError("Error: The --component_spec argument is required.")
+
+        component_spec = ComponentSpec(args.component_spec)
+        return cls(component_spec)
+
     def _get_component_arguments(self) -> t.Dict[str, Argument]:
         """
         Get the component arguments as a dictionary representation containing both input and output

--- a/fondant/component.py
+++ b/fondant/component.py
@@ -49,19 +49,7 @@ class Component(ABC):
             path: Path to the component spec file
         """
         component_spec = ComponentSpec.from_file(path)
-        args_dict = vars(cls._add_and_parse_args(component_spec))
-        input_manifest_path = args_dict.pop("input_manifest_path")
-        output_manifest_path = args_dict.pop("output_manifest_path")
-        metadata = args_dict.pop("metadata")
-        metadata = json.loads(metadata) if metadata else {}
-
-        return cls(
-            component_spec,
-            input_manifest_path=input_manifest_path,
-            output_manifest_path=output_manifest_path,
-            metadata=metadata,
-            user_arguments=args_dict,
-        )
+        return cls.from_spec(component_spec)
 
     @classmethod
     def from_args(cls) -> "Component":
@@ -75,11 +63,19 @@ class Component(ABC):
 
         component_spec = ComponentSpec(args.component_spec)
 
+        return cls.from_spec(component_spec)
+
+    @classmethod
+    def from_spec(cls, component_spec: ComponentSpec) -> "Component":
+        """Create a component from a component spec."""
         args_dict = vars(cls._add_and_parse_args(component_spec))
+
+        if "component_spec" in args_dict:
+            args_dict.pop("component_spec")
         input_manifest_path = args_dict.pop("input_manifest_path")
         output_manifest_path = args_dict.pop("output_manifest_path")
         metadata = args_dict.pop("metadata")
-        args_dict.pop("component_spec")
+
         metadata = json.loads(metadata) if metadata else {}
 
         return cls(

--- a/fondant/component.py
+++ b/fondant/component.py
@@ -50,16 +50,17 @@ class Component(ABC):
         """
         component_spec = ComponentSpec.from_file(path)
         args_dict = vars(cls._add_and_parse_args(component_spec))
-        user_arguments = cls.get_user_arguments(args_dict, component_spec)
+        input_manifest_path = args_dict.pop("input_manifest_path")
+        output_manifest_path = args_dict.pop("output_manifest_path")
         metadata = args_dict.pop("metadata")
         metadata = json.loads(metadata) if metadata else {}
 
         return cls(
             component_spec,
-            input_manifest_path=args_dict.pop("input_manifest_path"),
-            output_manifest_path=args_dict.pop("output_manifest_path"),
+            input_manifest_path=input_manifest_path,
+            output_manifest_path=output_manifest_path,
             metadata=metadata,
-            user_arguments=user_arguments,
+            user_arguments=args_dict,
         )
 
     @classmethod
@@ -75,16 +76,18 @@ class Component(ABC):
         component_spec = ComponentSpec(args.component_spec)
 
         args_dict = vars(cls._add_and_parse_args(component_spec))
-        user_arguments = cls.get_user_arguments(args_dict, component_spec)
+        input_manifest_path = args_dict.pop("input_manifest_path")
+        output_manifest_path = args_dict.pop("output_manifest_path")
         metadata = args_dict.pop("metadata")
+        args_dict.pop("component_spec")
         metadata = json.loads(metadata) if metadata else {}
 
         return cls(
             component_spec,
-            input_manifest_path=args_dict.pop("input_manifest_path"),
-            output_manifest_path=args_dict.pop("output_manifest_path"),
+            input_manifest_path=input_manifest_path,
+            output_manifest_path=output_manifest_path,
             metadata=metadata,
-            user_arguments=user_arguments,
+            user_arguments=args_dict,
         )
 
     @staticmethod
@@ -107,13 +110,6 @@ class Component(ABC):
     @abstractmethod
     def _add_and_parse_args(cls, spec: ComponentSpec) -> argparse.Namespace:
         """Abstract method to add and parse the component arguments."""
-
-    @staticmethod
-    def get_user_arguments(
-        args: t.Dict[str, t.Any], spec: ComponentSpec
-    ) -> t.Dict[str, t.Any]:
-        """Custom arguments defined by the user in the fondant component spec."""
-        return {key: value for key, value in args.items() if key in spec.args}
 
     @abstractmethod
     def _load_or_create_manifest(self) -> Manifest:

--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -185,6 +185,10 @@ class ComponentSpec:
         }
 
     @property
+    def specification(self) -> t.Dict[str, t.Any]:
+        return copy.deepcopy(self._specification)
+
+    @property
     def kubeflow_specification(self) -> "KubeflowComponentSpec":
         return KubeflowComponentSpec.from_fondant_component_spec(self)
 

--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -222,6 +222,11 @@ class KubeflowComponentSpec:
                     "description": "Metadata arguments containing the run id and base path",
                     "type": "String",
                 },
+                {
+                    "name": "component_spec",
+                    "description": "The component specification as a dictionary",
+                    "type": "JsonObject",
+                },
                 *(
                     {
                         "name": arg.name,
@@ -248,6 +253,8 @@ class KubeflowComponentSpec:
                         {"inputPath": "input_manifest_path"},
                         "--metadata",
                         {"inputValue": "metadata"},
+                        "--component_spec",
+                        {"inputValue": "component_spec"},
                         *cls._dump_args(fondant_component.args.values()),
                         "--output_manifest_path",
                         {"outputPath": "output_manifest_path"},

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -122,13 +122,13 @@ class Manifest:
         return cls(specification)
 
     @classmethod
-    def from_file(cls, path: str) -> "Manifest":
+    def from_file(cls, path: t.Union[str, Path]) -> "Manifest":
         """Load the manifest from the file specified by the provided path."""
         with open(path, encoding="utf-8") as file_:
             specification = json.load(file_)
             return cls(specification)
 
-    def to_file(self, path) -> None:
+    def to_file(self, path: t.Union[str, Path]) -> None:
         """Dump the manifest to the file specified by the provided path."""
         with open(path, "w", encoding="utf-8") as file_:
             json.dump(self._specification, file_)

--- a/fondant/pipeline.py
+++ b/fondant/pipeline.py
@@ -328,16 +328,20 @@ class Pipeline:
             previous_component_task = None
             for operation in self._graph.values():
                 fondant_component_op = operation["fondant_component_op"]
+                component_spec_dict = fondant_component_op.component_spec._specification
+
                 # Get the Kubeflow component based on the fondant component operation.
                 kubeflow_component_op = _get_component_function(fondant_component_op)
 
                 # Execute the Kubeflow component and pass in the output manifest path from
                 # the previous component.
                 component_args = fondant_component_op.arguments
+
                 if previous_component_task is not None:
                     component_task = kubeflow_component_op(
                         input_manifest_path=manifest_path,
                         metadata=metadata,
+                        component_spec=component_spec_dict,
                         **component_args,
                     )
                 else:
@@ -348,6 +352,7 @@ class Pipeline:
                     component_task = kubeflow_component_op(
                         input_manifest_path=manifest_path,
                         metadata=metadata,
+                        component_spec=component_spec_dict,
                         **component_args,
                     )
                     metadata = ""

--- a/fondant/pipeline.py
+++ b/fondant/pipeline.py
@@ -328,7 +328,7 @@ class Pipeline:
             previous_component_task = None
             for operation in self._graph.values():
                 fondant_component_op = operation["fondant_component_op"]
-                component_spec_dict = fondant_component_op.component_spec._specification
+                component_spec_dict = fondant_component_op.component_spec.specification
 
                 # Get the Kubeflow component based on the fondant component operation.
                 kubeflow_component_op = _get_component_function(fondant_component_op)

--- a/tests/example_specs/component_specs/kubeflow_component.yaml
+++ b/tests/example_specs/component_specs/kubeflow_component.yaml
@@ -7,6 +7,9 @@ inputs:
 -   name: metadata
     description: Metadata arguments containing the run id and base path
     type: String
+-   name: component_spec
+    description: The component specification as a dictionary
+    type: JsonObject
 -   name: storage_args
     description: Storage arguments
     type: String
@@ -24,6 +27,8 @@ implementation:
         -   inputPath: input_manifest_path
         - --metadata
         -   inputValue: metadata
+        - --component_spec
+        -   inputValue: component_spec
         - --storage_args
         -   inputValue: storage_args
         - --output_manifest_path

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -59,17 +59,9 @@ def test_component(mock_args):
     )
 
     # test component args
-    component_args = component._get_component_arguments()
-    assert "input_manifest_path" in component_args
-    assert "output_manifest_path" in component_args
-    assert (
-        argparse.Namespace(
-            input_manifest_path=".",
-            output_manifest_path="result.parquet",
-            metadata=metadata,
-        )
-        == component._add_and_parse_args()
-    )
+    assert component.input_manifest_path == "."
+    assert component.output_manifest_path == "result.parquet"
+    assert component.metadata == json.loads(metadata)
 
     # test custom args
     assert list(component.spec.args) == ["storage_args"]


### PR DESCRIPTION
PR that enables adding a custom component spec for each component as described in #174 

The implemented approach differs slightly from the described issue since we forgot to take into account that we need to parse the arguments twice. Once to retrieve the component spec and another time for the other arguments which include things like the `metadata` and `manifest` as well as use specific arguments (which are defined as part of the component spec)

* The component spec is now an exact match to the one passed to the pipeline. We no longer are defining it during the build process. This enables us to use dynamic specs. 
* We still keep the method `from_file()` method as this is used when building and compiling the pipeline. 

We still need to adapt the currently available read and write components to be generic but this should be tackled in a separate PR. 