### PR TITLE
Enable defining nested data types

### DIFF
--- a/components/embedding_based_laion_retrieval/fondant_component.yaml
+++ b/components/embedding_based_laion_retrieval/fondant_component.yaml
@@ -6,7 +6,9 @@ consumes:
   embeddings:
     fields:
       data:
-        type: float32_list
+        type: array
+        items:
+          type: float32
 
 produces:
   images:

--- a/components/image_embedding/fondant_component.yaml
+++ b/components/image_embedding/fondant_component.yaml
@@ -12,7 +12,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: float32_list
+        type: array
+        items:
+          type: float32
 
 args:
   model_id:

--- a/components/segment_images/fondant_component.yaml
+++ b/components/segment_images/fondant_component.yaml
@@ -12,7 +12,9 @@ produces:
   segmentations:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: binary
 
 args:
   model_id:

--- a/docs/component_spec.md
+++ b/docs/component_spec.md
@@ -62,7 +62,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: int8_list
+        type: array
+        items:
+          type: float32
 ...
 ```
 
@@ -220,7 +222,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 ```
 
 </td>
@@ -326,7 +330,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 ```
 
 </td>
@@ -425,7 +431,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 ```
 
 </td>
@@ -516,7 +524,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
   additionalSubsets: false
 ```
 

--- a/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/fondant_component.yaml
+++ b/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/fondant_component.yaml
@@ -16,7 +16,9 @@ consumes:
   segmentations:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: binary
 
 args:
   hf_token:

--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -71,7 +71,7 @@ class ComponentSubset:
     def fields(self) -> t.Mapping[str, Field]:
         return types.MappingProxyType(
             {
-                name: Field(name=name, type=Type[field["type"]])
+                name: Field(name=name, type=Type.from_json(field))
                 for name, field in self._specification["fields"].items()
             }
         )

--- a/fondant/exceptions.py
+++ b/fondant/exceptions.py
@@ -17,3 +17,7 @@ class InvalidComponentSpec(ValidationError, FondantException):
 
 class InvalidPipelineDefinition(ValidationError, FondantException):
     """Thrown when a pipeline definition is invalid."""
+
+
+class InvalidTypeSchema(ValidationError, FondantException):
+    """Thrown when a Type schema definition is invalid."""

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -47,7 +47,7 @@ class Subset:
         if not overwrite and name in self._specification["fields"]:
             raise ValueError(f"A field with name {name} already exists")
 
-        self._specification["fields"][name] = {"type": type_.name}
+        self._specification["fields"][name] = type_.to_json()
 
     def remove_field(self, name: str) -> None:
         del self._specification["fields"][name]
@@ -178,7 +178,7 @@ class Manifest:
 
         self._specification["subsets"][name] = {
             "location": f"/{name}/{self.run_id}/{self.component_id}",
-            "fields": {name: {"type": type_.name} for name, type_ in fields},
+            "fields": {name: type_.to_json() for name, type_ in fields},
         }
 
     def remove_subset(self, name: str) -> None:

--- a/fondant/manifest.py
+++ b/fondant/manifest.py
@@ -38,7 +38,7 @@ class Subset:
         """The fields of the subset returned as an immutable mapping."""
         return types.MappingProxyType(
             {
-                name: Field(name=name, type=Type[field["type"]])
+                name: Field(name=name, type=Type.from_json(field))
                 for name, field in self._specification["fields"].items()
             }
         )
@@ -62,8 +62,8 @@ class Index(Subset):
     @property
     def fields(self) -> t.Dict[str, Field]:
         return {
-            "id": Field(name="id", type=Type.string),
-            "source": Field(name="source", type=Type.string),
+            "id": Field(name="id", type=Type("string")),
+            "source": Field(name="source", type=Type("string")),
         }
 
 

--- a/fondant/schema.py
+++ b/fondant/schema.py
@@ -53,9 +53,26 @@ class Type(enum.Enum):
 
     float32_list = pa.list_(pa.float32())
 
+    @classmethod
+    def list(cls, data_type: "Type") -> pa.DataType:
+        """
+        Create a list type from the given data type. Allows creating nested values
+        Args:
+            data_type: The data type of the elements in the list.
+
+        Returns:
+            The list type.
+        """
+        if isinstance(data_type, Type):
+            return pa.list_(data_type.value)
+        elif isinstance(data_type, pa.DataType):
+            return pa.list_(data_type)
+        else:
+            raise ValueError("Invalid data type")
+
 
 class Field(t.NamedTuple):
     """Class representing a single field or column in a Fondant subset."""
 
     name: str
-    type: Type
+    type: t.Union[Type, pa.DataType]

--- a/fondant/schema.py
+++ b/fondant/schema.py
@@ -2,77 +2,120 @@
 and pipelines.
 """
 
-import enum
 import typing as t
 
 import pyarrow as pa
 
 KubeflowCommandArguments = t.List[t.Union[str, t.Dict[str, str]]]
 
+_TYPES: t.Dict[str, pa.DataType] = {
+    "bool": pa.bool_(),
+    "int8": pa.int8(),
+    "int16": pa.int16(),
+    "int32": pa.int32(),
+    "int64": pa.int64(),
+    "uint8": pa.uint8(),
+    "uint16": pa.uint16(),
+    "uint32": pa.uint32(),
+    "uint64": pa.uint64(),
+    "float16": pa.float16(),
+    "float32": pa.float32(),
+    "float64": pa.float64(),
+    "decimal": pa.decimal128(38),
+    "time32": pa.time32("s"),
+    "time64": pa.time64("us"),
+    "timestamp": pa.timestamp("us"),
+    "date32": pa.date32(),
+    "date64": pa.date64(),
+    "duration": pa.duration("us"),
+    "string": pa.string(),
+    "utf8": pa.utf8(),
+    "binary": pa.binary(),
+}
 
-class Type(enum.Enum):
-    """Supported types.
 
-    Based on:
-    - https://arrow.apache.org/docs/python/api/datatypes.html#api-types
-    - https://pola-rs.github.io/polars/py-polars/html/reference/datatypes.html
-    """
+class Type:
+    def __init__(self, data_type: t.Union[str, pa.DataType]):
+        self.value = self._validate_data_type(data_type)
 
-    bool = pa.bool_()
-
-    int8 = pa.int8()
-    int16 = pa.int16()
-    int32 = pa.int32()
-    int64 = pa.int64()
-
-    uint8 = pa.uint8()
-    uint16 = pa.uint16()
-    uint32 = pa.uint32()
-    uint64 = pa.uint64()
-
-    float16 = pa.float16()
-    float32 = pa.float32()
-    float64 = pa.float64()
-
-    decimal = pa.decimal128(38)
-
-    time32 = pa.time32("s")
-    time64 = pa.time64("us")
-    timestamp = pa.timestamp("us")
-
-    date32 = pa.date32()
-    date64 = pa.date64()
-    duration = pa.duration("us")
-
-    string = pa.string()
-    utf8 = pa.utf8()
-
-    binary = pa.binary()
-
-    int8_list = pa.list_(pa.int8())
-
-    float32_list = pa.list_(pa.float32())
-
-    @classmethod
-    def list(cls, data_type: "Type") -> pa.DataType:
+    @staticmethod
+    def _validate_data_type(data_type: t.Union[str, pa.DataType]):
         """
-        Create a list type from the given data type. Allows creating nested values
+        Validates the provided data type and returns the corresponding data type object.
+
         Args:
-            data_type: The data type of the elements in the list.
+            data_type: The data type to validate.
 
         Returns:
-            The list type.
+            The validated `pa.DataType` object.
         """
-        if isinstance(data_type, Type):
-            return pa.list_(data_type.value)
-        elif isinstance(data_type, pa.DataType):
-            return pa.list_(data_type)
+        if isinstance(data_type, str):
+            try:
+                data_type = _TYPES[data_type]
+            except KeyError:
+                raise ValueError(
+                    f"Invalid schema provided. Current available data types are:"
+                    f" {_TYPES.keys()}"
+                )
+        return data_type
+
+    @classmethod
+    def list(cls, data_type: t.Union[str, pa.DataType, "Type"]) -> "Type":
+        """
+        Creates a new `Type` instance representing a list of the specified data type.
+
+        Args:
+            data_type: The data type for the list elements. It can be a string representing the
+            data type or an existing `pa.DataType` object.
+
+        Returns:
+            A new `Type` instance representing a list of the specified data type.
+        """
+        data_type = cls._validate_data_type(data_type)
+        return cls(
+            pa.list_(data_type.value if isinstance(data_type, Type) else data_type)
+        )
+
+    @classmethod
+    def from_json(cls, json_schema: dict):
+        """
+        Creates a new `Type` instance based on a dictionary representation of the json schema
+          of a data type (https://swagger.io/docs/specification/data-models/data-types/).
+
+        Args:
+            json_schema: The dictionary representation of the data type, can represent nested values
+
+        Returns:
+            A new `Type` instance representing the specified data type.
+        """
+        if json_schema["type"] in _TYPES:
+            return Type(json_schema["type"])
+
+        elif json_schema["type"] == "array":
+            items = json_schema["items"]
+            if isinstance(items, dict):
+                return cls.list(Type.from_json(items))
         else:
-            raise ValueError("Invalid data type")
+            raise ValueError(f"Invalid schema provided: {json_schema}")
+
+    @property
+    def name(self):
+        """Name of the data type."""
+        return str(self.value)
+
+    def __repr__(self):
+        """Returns a string representation of the `Type` instance."""
+        return f"Type({repr(self.value)})"
+
+    def __eq__(self, other):
+        if isinstance(other, Type):
+            return self.value == other.value
+
+        return False
 
 
 class Field(t.NamedTuple):
     """Class representing a single field or column in a Fondant subset."""
 
     name: str
-    type: t.Union[Type, pa.DataType]
+    type: Type

--- a/fondant/schema.py
+++ b/fondant/schema.py
@@ -13,7 +13,6 @@ KubeflowCommandArguments = t.List[t.Union[str, t.Dict[str, str]]]
 """
 Types based on:
 - https://arrow.apache.org/docs/python/api/datatypes.html#api-types
-- https://pola-rs.github.io/polars/py-polars/html/reference/datatypes.html
 """
 _TYPES: t.Dict[str, pa.DataType] = {
     "null": pa.null(),
@@ -64,13 +63,13 @@ class Type:
         Returns:
             The validated `pa.DataType` object.
         """
-        if isinstance(data_type, str):
+        if not isinstance(data_type, (Type, pa.DataType)):
             try:
                 data_type = _TYPES[data_type]
             except KeyError:
                 raise InvalidTypeSchema(
-                    f"Invalid schema provided. Current available data types are:"
-                    f" {_TYPES.keys()}"
+                    f"Invalid schema provided {data_type} with type {type(data_type)}."
+                    f" Current available data types are: {_TYPES.keys()}"
                 )
         return data_type
 
@@ -106,9 +105,9 @@ class Type:
         if json_schema["type"] == "array":
             items = json_schema["items"]
             if isinstance(items, dict):
-                return cls.list(Type.from_json(items))
+                return cls.list(cls.from_json(items))
         else:
-            return Type(json_schema["type"])
+            return cls(json_schema["type"])
 
     def to_json(self) -> dict:
         """

--- a/fondant/schema.py
+++ b/fondant/schema.py
@@ -52,7 +52,7 @@ class Type:
         self.value = self._validate_data_type(data_type)
 
     @staticmethod
-    def _validate_data_type(data_type: t.Union[str, pa.DataType]):
+    def _validate_data_type(data_type: t.Union[str, pa.DataType]) -> pa.DataType:
         """
         Validates the provided data type and returns the corresponding data type object.
 
@@ -110,6 +110,26 @@ class Type:
                 return cls.list(Type.from_json(items))
         else:
             raise ValueError(f"Invalid schema provided: {json_schema}")
+
+    def to_json(self) -> dict:
+        """
+        Converts the `Type` instance to its JSON representation.
+
+        Returns:
+            A dictionary representing the JSON schema of the data type.
+        """
+        if isinstance(self.value, pa.ListType):
+            items = self.value.value_type
+            if isinstance(items, pa.DataType):
+                return {"type": "array", "items": Type(items).to_json()}
+            else:
+                raise ValueError(f"Invalid schema provided: {self.value}")
+
+        for type_name, data_type in _TYPES.items():
+            if self.value.equals(data_type):
+                return {"type": type_name}
+
+        raise ValueError(f"Invalid schema provided: {self.value}")
 
     @property
     def name(self):

--- a/fondant/schema.py
+++ b/fondant/schema.py
@@ -8,7 +8,13 @@ import pyarrow as pa
 
 KubeflowCommandArguments = t.List[t.Union[str, t.Dict[str, str]]]
 
+"""
+Types based on:
+- https://arrow.apache.org/docs/python/api/datatypes.html#api-types
+- https://pola-rs.github.io/polars/py-polars/html/reference/datatypes.html
+"""
 _TYPES: t.Dict[str, pa.DataType] = {
+    "null": pa.null(),
     "bool": pa.bool_(),
     "int8": pa.int8(),
     "int16": pa.int16(),
@@ -21,7 +27,7 @@ _TYPES: t.Dict[str, pa.DataType] = {
     "float16": pa.float16(),
     "float32": pa.float32(),
     "float64": pa.float64(),
-    "decimal": pa.decimal128(38),
+    "decimal128": pa.decimal128(38),
     "time32": pa.time32("s"),
     "time64": pa.time64("us"),
     "timestamp": pa.timestamp("us"),
@@ -31,10 +37,17 @@ _TYPES: t.Dict[str, pa.DataType] = {
     "string": pa.string(),
     "utf8": pa.utf8(),
     "binary": pa.binary(),
+    "large_binary": pa.large_binary(),
+    "large_utf8": pa.large_utf8(),
 }
 
 
 class Type:
+    """
+    The `Type` class provides a way to define and validate data types for various purposes. It
+      supports different data types including primitive types and complex types like lists.
+    """
+
     def __init__(self, data_type: t.Union[str, pa.DataType]):
         self.value = self._validate_data_type(data_type)
 

--- a/fondant/schemas/common.json
+++ b/fondant/schemas/common.json
@@ -26,6 +26,7 @@
         "binary",
         "list",
         "struct",
+        "array",
         "int8_list",
         "float32_list"
       ]
@@ -36,15 +37,26 @@
         "type": {
           "type": "string",
           "$ref": "#/definitions/subset_data_type"
+        },
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/field"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/field"
+              }
+            }
+          ]
         }
       },
-      "required": [
-        "type"
-      ]
+      "required": ["type"],
+      "additionalProperties": false
     },
     "fields": {
       "type": "object",
-      "minProperties": 1,
       "additionalProperties": {
         "$ref": "#/definitions/field"
       }

--- a/fondant/schemas/common.json
+++ b/fondant/schemas/common.json
@@ -26,9 +26,7 @@
         "binary",
         "list",
         "struct",
-        "array",
-        "int8_list",
-        "float32_list"
+        "array"
       ]
     },
     "field": {

--- a/fondant/schemas/common.json
+++ b/fondant/schemas/common.json
@@ -55,6 +55,7 @@
     },
     "fields": {
       "type": "object",
+      "minProperties": 1,
       "additionalProperties": {
         "$ref": "#/definitions/field"
       }

--- a/tests/example_pipelines/invalid_pipeline/example_1/second_component.yaml
+++ b/tests/example_pipelines/invalid_pipeline/example_1/second_component.yaml
@@ -17,7 +17,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 
 args:
   storage_args:

--- a/tests/example_pipelines/invalid_pipeline/example_2/second_component.yaml
+++ b/tests/example_pipelines/invalid_pipeline/example_2/second_component.yaml
@@ -19,7 +19,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 
 args:
   storage_args:

--- a/tests/example_pipelines/valid_pipeline/example_1/second_component.yaml
+++ b/tests/example_pipelines/valid_pipeline/example_1/second_component.yaml
@@ -12,7 +12,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 
 args:
   storage_args:

--- a/tests/example_pipelines/valid_pipeline/example_1/third_component.yaml
+++ b/tests/example_pipelines/valid_pipeline/example_1/third_component.yaml
@@ -16,7 +16,9 @@ consumes:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 
 produces:
   images:

--- a/tests/example_specs/component_specs/valid_component.yaml
+++ b/tests/example_specs/component_specs/valid_component.yaml
@@ -11,7 +11,9 @@ consumes:
   embeddings:
     fields:
       data:
-        type: int8_list
+        type: array
+        items:
+          type: int8
 
 produces:
   captions:

--- a/tests/example_specs/component_specs/valid_component.yaml
+++ b/tests/example_specs/component_specs/valid_component.yaml
@@ -13,7 +13,7 @@ consumes:
       data:
         type: array
         items:
-          type: binary
+          type: float32
 
 produces:
   captions:

--- a/tests/example_specs/component_specs/valid_component.yaml
+++ b/tests/example_specs/component_specs/valid_component.yaml
@@ -13,7 +13,7 @@ consumes:
       data:
         type: array
         items:
-          type: int8
+          type: binary
 
 produces:
   captions:

--- a/tests/example_specs/evolution_examples/1/component.yaml
+++ b/tests/example_specs/evolution_examples/1/component.yaml
@@ -12,7 +12,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 
 args:
   storage_args:

--- a/tests/example_specs/evolution_examples/1/output_manifest.json
+++ b/tests/example_specs/evolution_examples/1/output_manifest.json
@@ -34,7 +34,10 @@
       "location": "/embeddings/12345/example_component",
       "fields": {
         "data": {
-          "type": "binary"
+          "type": "array",
+          "items": {
+            "type": "float32"
+          }
         }
       }
     }

--- a/tests/example_specs/evolution_examples/2/component.yaml
+++ b/tests/example_specs/evolution_examples/2/component.yaml
@@ -13,7 +13,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 
 args:
   storage_args:

--- a/tests/example_specs/evolution_examples/2/output_manifest.json
+++ b/tests/example_specs/evolution_examples/2/output_manifest.json
@@ -26,7 +26,10 @@
       "location": "/embeddings/12345/example_component",
       "fields": {
         "data": {
-          "type": "binary"
+          "type": "array",
+          "items": {
+            "type": "float32"
+          }
         }
       }
     }

--- a/tests/example_specs/evolution_examples/3/component.yaml
+++ b/tests/example_specs/evolution_examples/3/component.yaml
@@ -14,7 +14,9 @@ produces:
   embeddings:
     fields:
       data:
-        type: binary
+        type: array
+        items:
+          type: float32
 
 args:
   storage_args:

--- a/tests/example_specs/evolution_examples/3/output_manifest.json
+++ b/tests/example_specs/evolution_examples/3/output_manifest.json
@@ -20,7 +20,10 @@
       "location": "/embeddings/12345/example_component",
       "fields": {
         "data": {
-          "type": "binary"
+          "type": "array",
+          "items": {
+            "type": "float32"
+          }
         }
       }
     }

--- a/tests/test_component_specs.py
+++ b/tests/test_component_specs.py
@@ -54,7 +54,7 @@ def test_attribute_access(valid_fondant_schema):
     assert fondant_component.description == "This is an example component"
     assert fondant_component.consumes["images"].fields["data"].type == Type("binary")
     assert fondant_component.consumes["embeddings"].fields["data"].type == Type.list(
-        Type("binary")
+        Type("float32")
     )
 
 

--- a/tests/test_component_specs.py
+++ b/tests/test_component_specs.py
@@ -1,7 +1,6 @@
 """Fondant component specs test."""
 from pathlib import Path
 
-import pyarrow as pa
 import pytest
 import yaml
 
@@ -53,13 +52,10 @@ def test_attribute_access(valid_fondant_schema):
 
     assert fondant_component.name == "Example component"
     assert fondant_component.description == "This is an example component"
-    assert fondant_component.consumes["images"].fields["data"].type == Type.binary
-    assert (
-        fondant_component.consumes["embeddings"].fields["data"].type == Type.int8_list
+    assert fondant_component.consumes["images"].fields["data"].type == Type("binary")
+    assert fondant_component.consumes["embeddings"].fields["data"].type == Type.list(
+        Type("binary")
     )
-    assert fondant_component.consumes["embeddings"].fields[
-        "data"
-    ].type.value == pa.list_(pa.int8())
 
 
 def test_kfp_component_creation(valid_fondant_schema, valid_kubeflow_schema):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -60,16 +60,16 @@ def test_subset_fields():
     subset = Subset(specification=subset_spec, base_path="/tmp")
 
     # add a field
-    subset.add_field(name="data2", type_=Type.binary)
+    subset.add_field(name="data2", type_=Type("binary"))
     assert "data2" in subset.fields
 
     # add a duplicate field
     with pytest.raises(ValueError):
-        subset.add_field(name="data2", type_=Type.binary)
+        subset.add_field(name="data2", type_=Type("binary"))
 
     # add a duplicate field but overwrite
-    subset.add_field(name="data2", type_=Type.string, overwrite=True)
-    assert subset.fields["data2"].type == Type.string
+    subset.add_field(name="data2", type_=Type("string"), overwrite=True)
+    assert subset.fields["data2"].type.value == Type("string").value
 
     # remove a field
     subset.remove_field(name="data2")
@@ -111,7 +111,7 @@ def test_attribute_access(valid_manifest):
     assert manifest.metadata == valid_manifest["metadata"]
     assert manifest.index.location == "gs://bucket/index"
     assert manifest.subsets["images"].location == "gs://bucket/images"
-    assert manifest.subsets["images"].fields["data"].type == Type.binary
+    assert manifest.subsets["images"].fields["data"].type == Type("binary")
 
 
 def test_manifest_creation():
@@ -123,8 +123,8 @@ def test_manifest_creation():
     manifest = Manifest.create(
         base_path=base_path, run_id=run_id, component_id=component_id
     )
-    manifest.add_subset("images", [("width", Type.int32), ("height", Type.int32)])
-    manifest.subsets["images"].add_field("data", Type.binary)
+    manifest.add_subset("images", [("width", Type("int32")), ("height", Type("int32"))])
+    manifest.subsets["images"].add_field("data", Type("binary"))
 
     assert manifest._specification == {
         "metadata": {
@@ -166,12 +166,16 @@ def test_manifest_alteration(valid_manifest):
     manifest = Manifest(valid_manifest)
 
     # test adding a subset
-    manifest.add_subset("images2", [("width", Type.int32), ("height", Type.int32)])
+    manifest.add_subset(
+        "images2", [("width", Type("int32")), ("height", Type("int32"))]
+    )
     assert "images2" in manifest.subsets
 
     # test adding a duplicate subset
     with pytest.raises(ValueError):
-        manifest.add_subset("images2", [("width", Type.int32), ("height", Type.int32)])
+        manifest.add_subset(
+            "images2", [("width", Type("int32")), ("height", Type("int32"))]
+        )
 
     # test removing a subset
     manifest.remove_subset("images2")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -69,7 +69,7 @@ def test_subset_fields():
 
     # add a duplicate field but overwrite
     subset.add_field(name="data2", type_=Type("string"), overwrite=True)
-    assert subset.fields["data2"].type.value == Type("string").value
+    assert subset.fields["data2"].type == Type("string")
 
     # remove a field
     subset.remove_field(name="data2")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9,6 +9,11 @@ def test_valid_type():
     assert Type("int8").value == pa.int8()
     assert Type.list(Type("int8")).value == pa.list_(pa.int8())
     assert Type.list(Type.list(Type("string"))).value == pa.list_(pa.list_(pa.string()))
+    assert Type("int8").to_json() == {"type": "int8"}
+    assert Type.list("float32").to_json() == {
+        "type": "array",
+        "items": {"type": "float32"},
+    }
 
 
 def test_valid_json_schema():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,31 @@
+import pyarrow as pa
+import pytest
+
+from fondant.schema import Type
+
+
+def test_valid_type():
+    """Test that a data type specified with the Type class matches the expected pyarrow schema."""
+    assert Type("int8").value == pa.int8()
+    assert Type.list(Type("int8")).value == pa.list_(pa.int8())
+    assert Type.list(Type.list(Type("string"))).value == pa.list_(pa.list_(pa.string()))
+
+
+def test_valid_json_schema():
+    """Test that a json schema specified with the Type class matches the expected pyarrow schema."""
+    assert Type.from_json({"type": "string"}).value == pa.string()
+    assert Type.from_json(
+        {"type": "array", "items": {"type": "int8"}}
+    ).value == pa.list_(pa.int8())
+    assert Type.from_json(
+        {"type": "array", "items": {"type": "array", "items": {"type": "int8"}}}
+    ).value == pa.list_(pa.list_(pa.int8()))
+
+
+def test_invalid_json_schema():
+    """Test that an invalid type specified with the Type class raise an error."""
+    with pytest.raises(ValueError):
+        Type("invalid_type")
+        Type.list(Type("invalid_type"))
+        Type.from_json({"type": "invalid_value", "items": {"type": "int8"}})
+        Type.from_json({"type": "array", "items": {"type": "invalid_type"}})

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,11 +1,13 @@
 import pyarrow as pa
 import pytest
 
+from fondant.exceptions import InvalidTypeSchema
 from fondant.schema import Type
 
 
 def test_valid_type():
     """Test that a data type specified with the Type class matches the expected pyarrow schema."""
+    assert Type("int8").name == "int8"
     assert Type("int8").value == pa.int8()
     assert Type.list(Type("int8")).value == pa.list_(pa.int8())
     assert Type.list(Type.list(Type("string"))).value == pa.list_(pa.list_(pa.string()))
@@ -17,7 +19,7 @@ def test_valid_type():
 
 
 def test_valid_json_schema():
-    """Test that a json schema specified with the Type class matches the expected pyarrow schema."""
+    """Test that Type class initialized with a json schema matches the expected pyarrow schema."""
     assert Type.from_json({"type": "string"}).value == pa.string()
     assert Type.from_json(
         {"type": "array", "items": {"type": "int8"}}
@@ -28,9 +30,23 @@ def test_valid_json_schema():
 
 
 def test_invalid_json_schema():
-    """Test that an invalid type specified with the Type class raise an error."""
-    with pytest.raises(ValueError):
+    """Test that an invalid type or schema specified with the Type class raise an invalid type
+    schema error.
+    """
+    with pytest.raises(InvalidTypeSchema):
         Type("invalid_type")
+        Type("invalid_type").to_json()
         Type.list(Type("invalid_type"))
+        Type.list(Type("invalid_type")).to_json()
+        Type.from_json({"invalid_key": "int8"})
+        Type.from_json({"type": "invalid_value"})
         Type.from_json({"type": "invalid_value", "items": {"type": "int8"}})
         Type.from_json({"type": "array", "items": {"type": "invalid_type"}})
+
+
+def test_equality():
+    """Test equality function to compare schemas."""
+    assert Type("int8") == Type("int8")
+    assert Type("int8") != Type("float64")
+    assert Type("int8").__eq__(Type("int8")) is True
+    assert Type("int8").__eq__(Type("float64")) is False


### PR DESCRIPTION
PR that addresses #178 
Inspiration: https://swagger.io/docs/specification/data-models/data-types/#:~:text=the%20null%20value.-,Arrays,-Arrays%20are%20defined (credit to @GeorgesLorre)

It includes: 
* Changing the common json schema to enable defining array types 
* Changing the `Type` class to be dynamic rather than typed to enable defining nested structures without explicitly defining them
* Adding an addition test file for `schema.py`
* Updating the current existing examples (embedding + segmentation)
