### PR TITLE
Enable default component arguments

### DIFF
--- a/docs/component_spec.md
+++ b/docs/component_spec.md
@@ -122,9 +122,7 @@ Please check the [examples](#examples) below to build a better understanding.
 
 The `args` section describes which arguments the component takes. Each argument is defined by a 
 `description` and a `type`, which should be one of the builtin Python types. Additionally, you can 
-pass an optional argument in the optional `default` field of the arguments. This can be useful in case
-your function has many arguments that could be set to default and that don't need to be explicitly defined when
-initializing your component. 
+set an optional `default` value for each argument.
 
 _Note:_ default iterable arguments such as `dict` and `list` have to be passed as a string 
 (e.g. `'{"foo":1, "bar":2}`, `'["foo","bar]'`)

--- a/docs/component_spec.md
+++ b/docs/component_spec.md
@@ -121,41 +121,52 @@ Please check the [examples](#examples) below to build a better understanding.
 ### Args
 
 The `args` section describes which arguments the component takes. Each argument is defined by a 
-`description` and a `type`, which should be one of the builtin Python types.
+`description` and a `type`, which should be one of the builtin Python types. Additionally, you can 
+pass an optional argument in the optional `default` field of the arguments. This can be useful in case
+your function has many arguments that could be set to default and that don't need to be explicitly defined when
+initializing your component. 
 
+_Note:_ default iterable arguments such as `dict` and `list` have to be passed as a string 
+(e.g. `'{"foo":1, "bar":2}`, `'["foo","bar]'`)
 ```yaml
 args:
   custom_argument:
     description: A custom argument
     type: str
+  default_argument:
+    description: A default argument
+    type: str
+    default: bar
 ``` 
 
-These arguments are passed in when the component is instantiated:
-
+These arguments are passed in when the component is instantiated. Notice that we are not passing the
+default argument specified above. You could override the default value in the component spec by passing
+it as an argument to the component.
 ```python
 from fondant.pipeline import ComponentOp
 
 custom_op = ComponentOp(
     component_spec_path="components/custom_component/fondant_component.yaml",
     arguments={
-        "custom_argument": "foobar"
+        "custom_argument": "foo"
     },
 )
 ```
 
-And passed as a keyword argument to the `transform()` method of the component.
+Afterwards, we pass all keyword arguments to the `transform()` method of the component.
 
 ```python
 from fondant.component import TransformComponent
 
 class ExampleComponent(TransformComponent):
 
-    def transform(self, dataframe, *, custom_argument):
+    def transform(self, dataframe, *, custom_argument, default_argument):
         """Implement your custom logic in this single method
         
         Args:
             dataframe: A Dask dataframe containing the data
             custom_argument: An argument passed to the component
+            default_argument: A default argument passed to the components
         """
 ```
 

--- a/docs/component_spec.md
+++ b/docs/component_spec.md
@@ -137,9 +137,8 @@ args:
     default: bar
 ``` 
 
-These arguments are passed in when the component is instantiated. Notice that we are not passing the
-default argument specified above. You could override the default value in the component spec by passing
-it as an argument to the component.
+These arguments are passed in when the component is instantiated. 
+If an argument is not explicitly provided, the default value will be used instead if available.```
 ```python
 from fondant.pipeline import ComponentOp
 

--- a/fondant/component.py
+++ b/fondant/component.py
@@ -242,7 +242,7 @@ class WriteComponent(Component):
 
     @staticmethod
     def optional_fondant_arguments() -> t.List[str]:
-        return []
+        return ["output_manifest_path"]
 
     def _load_or_create_manifest(self) -> Manifest:
         return Manifest.from_file(self.input_manifest_path)

--- a/fondant/component.py
+++ b/fondant/component.py
@@ -77,7 +77,6 @@ class Component(ABC):
         metadata = args_dict.pop("metadata")
 
         metadata = json.loads(metadata) if metadata else {}
-
         return cls(
             component_spec,
             input_manifest_path=input_manifest_path,
@@ -85,6 +84,38 @@ class Component(ABC):
             metadata=metadata,
             user_arguments=args_dict,
         )
+
+    @classmethod
+    def _add_and_parse_args(cls, spec: ComponentSpec):
+        parser = argparse.ArgumentParser()
+        component_arguments = cls._get_component_arguments(spec)
+
+        for arg in component_arguments.values():
+            # Input manifest is not required for loading component
+            if arg.name in cls.optional_fondant_arguments():
+                input_required = False
+                default = None
+            elif arg.default:
+                input_required = False
+                default = arg.default
+            else:
+                input_required = True
+                default = None
+
+            parser.add_argument(
+                f"--{arg.name}",
+                type=kubeflow2python_type[arg.type],  # type: ignore
+                required=input_required,
+                default=default,
+                help=arg.description,
+            )
+
+        return parser.parse_args()
+
+    @staticmethod
+    @abstractmethod
+    def optional_fondant_arguments() -> t.List[str]:
+        pass
 
     @staticmethod
     def _get_component_arguments(spec: ComponentSpec) -> t.Dict[str, Argument]:
@@ -101,11 +132,6 @@ class Component(ABC):
         component_arguments.update(kubeflow_component_spec.input_arguments)
         component_arguments.update(kubeflow_component_spec.output_arguments)
         return component_arguments
-
-    @classmethod
-    @abstractmethod
-    def _add_and_parse_args(cls, spec: ComponentSpec) -> argparse.Namespace:
-        """Abstract method to add and parse the component arguments."""
 
     @abstractmethod
     def _load_or_create_manifest(self) -> Manifest:
@@ -142,26 +168,9 @@ class Component(ABC):
 class LoadComponent(Component):
     """Base class for a Fondant load component."""
 
-    @classmethod
-    def _add_and_parse_args(cls, spec: ComponentSpec):
-        parser = argparse.ArgumentParser()
-        component_arguments = cls._get_component_arguments(spec)
-
-        for arg in component_arguments.values():
-            # Input manifest is not required for loading component
-            if arg.name == "input_manifest_path":
-                input_required = False
-            else:
-                input_required = True
-
-            parser.add_argument(
-                f"--{arg.name}",
-                type=kubeflow2python_type[arg.type],  # type: ignore
-                required=input_required,
-                help=arg.description,
-            )
-
-        return parser.parse_args()
+    @staticmethod
+    def optional_fondant_arguments() -> t.List[str]:
+        return ["input_manifest_path"]
 
     def _load_or_create_manifest(self) -> Manifest:
         # create initial manifest
@@ -195,20 +204,9 @@ class LoadComponent(Component):
 class TransformComponent(Component):
     """Base class for a Fondant transform component."""
 
-    @classmethod
-    def _add_and_parse_args(cls, spec: ComponentSpec):
-        parser = argparse.ArgumentParser()
-        component_arguments = cls._get_component_arguments(spec)
-
-        for arg in component_arguments.values():
-            parser.add_argument(
-                f"--{arg.name}",
-                type=kubeflow2python_type[arg.type],  # type: ignore
-                required=True,
-                help=arg.description,
-            )
-
-        return parser.parse_args()
+    @staticmethod
+    def optional_fondant_arguments() -> t.List[str]:
+        return []
 
     def _load_or_create_manifest(self) -> Manifest:
         return Manifest.from_file(self.input_manifest_path)
@@ -242,20 +240,9 @@ class TransformComponent(Component):
 class WriteComponent(Component):
     """Base class for a Fondant write component."""
 
-    @classmethod
-    def _add_and_parse_args(cls, spec: ComponentSpec):
-        parser = argparse.ArgumentParser()
-        component_arguments = cls._get_component_arguments(spec)
-
-        for arg in component_arguments.values():
-            parser.add_argument(
-                f"--{arg.name}",
-                type=kubeflow2python_type[arg.type],  # type: ignore
-                required=True,
-                help=arg.description,
-            )
-
-        return parser.parse_args()
+    @staticmethod
+    def optional_fondant_arguments() -> t.List[str]:
+        return []
 
     def _load_or_create_manifest(self) -> Manifest:
         return Manifest.from_file(self.input_manifest_path)

--- a/fondant/component_spec.py
+++ b/fondant/component_spec.py
@@ -46,11 +46,14 @@ class Argument:
         name: name of the argument
         description: argument description
         type: the python argument type (str, int, ...)
+        default: default value of the argument (defaults to None)
+
     """
 
     name: str
     description: str
     type: str
+    default: t.Optional[str] = None
 
 
 class ComponentSubset:
@@ -180,6 +183,7 @@ class ComponentSpec:
                 name=name,
                 description=arg_info["description"],
                 type=arg_info["type"],
+                default=arg_info["default"] if "default" in arg_info else None,
             )
             for name, arg_info in self._specification.get("args", {}).items()
         }
@@ -236,6 +240,7 @@ class KubeflowComponentSpec:
                         "name": arg.name,
                         "description": arg.description,
                         "type": python2kubeflow_type[arg.type],
+                        **({"default": arg.default} if arg.default is not None else {}),
                     }
                     for arg in fondant_component.args.values()
                 ),
@@ -305,6 +310,7 @@ class KubeflowComponentSpec:
                     name=info["name"],
                     description=info["description"],
                     type=info["type"],
+                    default=info["default"] if "default" in info else None,
                 )
                 for info in self._specification["inputs"]
             }

--- a/fondant/schemas/component_spec.json
+++ b/fondant/schemas/component_spec.json
@@ -80,6 +80,49 @@
           },
           "description": {
             "type": "string"
+          },
+          "default_value": {
+            "oneOf": [
+              {
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number",
+                "format": "float"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "array",
+                    "string",
+                    "integer",
+                    {
+                      "type": "number",
+                      "format": "float"
+                    },
+                    "boolean",
+                    "object"
+                  ]
+                },
+                "uniqueItems": true
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [

--- a/fondant/schemas/component_spec.json
+++ b/fondant/schemas/component_spec.json
@@ -81,46 +81,13 @@
           "description": {
             "type": "string"
           },
-          "default_value": {
+          "default": {
             "oneOf": [
-              {
-                "type": "array"
-              },
               {
                 "type": "string"
               },
               {
-                "type": "integer"
-              },
-              {
-                "type": "number",
-                "format": "float"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "object"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": [
-                    "array",
-                    "string",
-                    "integer",
-                    {
-                      "type": "number",
-                      "format": "float"
-                    },
-                    "boolean",
-                    "object"
-                  ]
-                },
-                "uniqueItems": true
-              },
-              {
-                "type": "null"
+                "type": "number"
               }
             ]
           }

--- a/tests/example_specs/components/arguments/component_default_args.yaml
+++ b/tests/example_specs/components/arguments/component_default_args.yaml
@@ -27,3 +27,7 @@ args:
     description: default dict argument
     type: dict
     default: '{"foo":1, "bar":2}'
+  override_default_string_arg:
+    description: default argument that can be overriden
+    type: str
+    default: foo

--- a/tests/example_specs/components/arguments/component_default_args.yaml
+++ b/tests/example_specs/components/arguments/component_default_args.yaml
@@ -1,0 +1,29 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+args:
+  string_default_arg:
+    description: default string argument
+    type: str
+    default: foo
+  integer_default_arg:
+    description: default integer argument
+    type: int
+    default: 1
+  float_default_arg:
+    description: default float argument
+    type: float
+    default: 3.14
+  bool_default_arg:
+    description: default bool argument
+    type: bool
+    default: 'False'
+  list_default_arg:
+    description: default list argument
+    type: list
+    default: '["foo", "bar"]'
+  dict_default_arg:
+    description: default dict argument
+    type: dict
+    default: '{"foo":1, "bar":2}'

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -222,6 +222,7 @@ def test_default_args_component(tmp_path_factory, monkeypatch):
             bool_default_arg,
             list_default_arg,
             dict_default_arg,
+            override_default_string_arg,
         ):
             float_const = 3.14
             # Mock write function that sinks final data to a local directory
@@ -231,6 +232,7 @@ def test_default_args_component(tmp_path_factory, monkeypatch):
             assert bool_default_arg is False
             assert list_default_arg == ["foo", "bar"]
             assert dict_default_arg == {"foo": 1, "bar": 2}
+            assert override_default_string_arg == "bar"
 
     # Mock CLI arguments
     sys.argv = [
@@ -243,6 +245,8 @@ def test_default_args_component(tmp_path_factory, monkeypatch):
         "",
         "--component_spec",
         f"{component_spec_string}",
+        "--override_default_string_arg",
+        "bar",
     ]
 
     # # Instantiate and run component

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -193,8 +193,8 @@ def test_write_component(tmp_path_factory, monkeypatch):
 
 
 def test_default_args_component(tmp_path_factory, monkeypatch):
-    """Test that arguments are passed correctly to `Component.write` method and that valid
-    errors are returned when required arguments are missing.
+    """Test that default arguments defined in the fondant spec are passed correctly and have the
+    proper data type.
     """
 
     # Mock `Dataset.load_dataframe` so no actual data is loaded

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -140,9 +140,6 @@ def test_write_component(tmp_path_factory, monkeypatch):
     errors are returned when required arguments are missing.
     """
 
-    class EarlyStopException(Exception):
-        """Used to stop execution early instead of mocking all later functionality."""
-
     # Mock `Dataset.load_dataframe` so no actual data is loaded
     def mocked_load_dataframe(self):
         return dd.from_dict({"a": [1, 2, 3]}, npartitions=1)
@@ -193,3 +190,61 @@ def test_write_component(tmp_path_factory, monkeypatch):
     # Instantiate and run component
     with pytest.raises(ValueError):
         MyComponent.from_args()
+
+
+def test_default_args_component(tmp_path_factory, monkeypatch):
+    """Test that arguments are passed correctly to `Component.write` method and that valid
+    errors are returned when required arguments are missing.
+    """
+
+    # Mock `Dataset.load_dataframe` so no actual data is loaded
+    def mocked_load_dataframe(self):
+        return dd.from_dict({"a": [1, 2, 3]}, npartitions=1)
+
+    monkeypatch.setattr(DaskDataLoader, "load_dataframe", mocked_load_dataframe)
+
+    # Define paths to specs to instantiate component
+    arguments_dir = components_path / "arguments"
+    component_spec = arguments_dir / "component_default_args.yaml"
+    input_manifest = arguments_dir / "input_manifest.json"
+
+    component_spec_string = yaml_file_to_json_string(component_spec)
+
+    # Implemented Component class
+    class MyComponent(WriteComponent):
+        def write(
+            self,
+            dataframe,
+            *,
+            string_default_arg,
+            integer_default_arg,
+            float_default_arg,
+            bool_default_arg,
+            list_default_arg,
+            dict_default_arg,
+        ):
+            float_const = 3.14
+            # Mock write function that sinks final data to a local directory
+            assert string_default_arg == "foo"
+            assert integer_default_arg == 1
+            assert float_default_arg == float_const
+            assert bool_default_arg is False
+            assert list_default_arg == ["foo", "bar"]
+            assert dict_default_arg == {"foo": 1, "bar": 2}
+
+    # Mock CLI arguments
+    sys.argv = [
+        "",
+        "--input_manifest_path",
+        str(input_manifest),
+        "--metadata",
+        "",
+        "--output_manifest_path",
+        "",
+        "--component_spec",
+        f"{component_spec_string}",
+    ]
+
+    # # Instantiate and run component
+    component = MyComponent.from_args()
+    component.run()


### PR DESCRIPTION
PR that enables adding default arguments as discussed in #179. 

Users can now define default arguments in the component specs. Those arguments do not have to be explicitly defined in the `ComponentOp` but could still be overridden.  

Note: please review this [PR](https://github.com/ml6team/fondant/pull/196) beforehand since I am branched off from it. 

Created a separate ticket to do the necessary changes #198. Best to handle it in a separate PR. 
