### PR TITLE
Provide hierarchical columns in pandas component

### DIFF
--- a/components/embedding_based_laion_retrieval/src/main.py
+++ b/components/embedding_based_laion_retrieval/src/main.py
@@ -67,7 +67,7 @@ class LAIONRetrievalComponent(PandasTransformComponent):
                         self.client.query,
                         embedding
                     )
-                    for embedding in dataframe["embeddings_data"]
+                    for embedding in dataframe["embeddings"]["data"]
                 ]
                 for response in await asyncio.gather(*futures):
                     results.extend(response)
@@ -75,8 +75,8 @@ class LAIONRetrievalComponent(PandasTransformComponent):
         loop.run_until_complete(async_query())
 
         results_df = pd.DataFrame(results)[["id", "url"]]
-        results_df.rename(columns={"url": "images_url"}, inplace=True)
         results_df.set_index("id", inplace=True)
+        results_df.columns = [["images"], ["url"]]
 
         return results_df
 

--- a/components/prompt_based_laion_retrieval/src/main.py
+++ b/components/prompt_based_laion_retrieval/src/main.py
@@ -67,7 +67,7 @@ class LAIONRetrievalComponent(PandasTransformComponent):
                         self.client.query,
                         prompt
                     )
-                    for prompt in dataframe["prompts_text"]
+                    for prompt in dataframe["prompts"]["text"]
                 ]
                 for response in await asyncio.gather(*futures):
                     results.extend(response)
@@ -75,8 +75,8 @@ class LAIONRetrievalComponent(PandasTransformComponent):
         loop.run_until_complete(async_query())
 
         results_df = pd.DataFrame(results)[["id", "url"]]
-        results_df.rename(columns={"url": "images_url"}, inplace=True)
         results_df.set_index("id", inplace=True)
+        results_df.columns = [["images"], ["url"]]
 
         return results_df
 

--- a/docs/custom_component.md
+++ b/docs/custom_component.md
@@ -70,12 +70,11 @@ The `transform` method is called multiple times, each time containing a pandas `
 loaded in memory.
 
 The `dataframes` passed to the `transform` method contains the data specified in the `produces` 
-section of the component specification, with column names formatted as `{subset}_{field}`. So if 
-a component defines that it consumes an `images` subset with a `data` field, the dataframe will 
-contain a column called `images_data`.
+section of the component specification. If a component defines that it consumes an `images` subset 
+with a `data` field, this data can be accessed using `dataframe["images"]["data"]`.
 
 The `transform` method should return a single dataframe, with the columns complying to the 
-`{subset}_{field}` format matching the `produces` section of the component specification.
+`[subset][field]` format matching the `produces` section of the component specification.
 
 Note that the `main.py` script can be split up into several Python scripts in case it would become 
 prohibitively long. See the 

--- a/tests/example_specs/components/input_manifest.json
+++ b/tests/example_specs/components/input_manifest.json
@@ -8,5 +8,14 @@
     "location": "/index/12345/example_component"
   },
   "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+
   }
 }

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -35,7 +35,7 @@ def patched_data_loading(monkeypatch):
     """Mock data loading so no actual data is loaded."""
 
     def mocked_load_dataframe(self):
-        return dd.from_dict({"a": [1, 2, 3]}, npartitions=N_PARTITIONS)
+        return dd.from_dict({"images_data": [1, 2, 3]}, npartitions=N_PARTITIONS)
 
     monkeypatch.setattr(DaskDataLoader, "load_dataframe", mocked_load_dataframe)
 
@@ -181,6 +181,7 @@ def test_pandas_transform_component(patched_data_loading, patched_data_writing):
 
         def transform(self, dataframe):
             assert isinstance(dataframe, pd.DataFrame)
+            return dataframe.rename(columns={"images": "embeddings"})
 
     component = MyPandasComponent.from_args()
     setup = mock.patch.object(MyPandasComponent, "setup", wraps=component.setup)


### PR DESCRIPTION
Fixes #204 

Unfortunately, wasn't able to propagate this through Dask. I got the Dask code to work with hierarchical columns as long as the index was not hierarchical, but I run into issues when trying to write this data to parquet.

So this means that only the pandas component gets hierarchical columns and I do the translation when we switch from Dask to Pandas.

I would propose to change our `_` for the flat column names to a symbol which we expect to be less frequently used in the names of data columns or fields. Eg. `images_data` could become `images+data` instead. This will have no impact on users using the `PandasTransformComponent`, but it will change for users using the `DaskTransformComponent` (which is not clear yet how much there would be).

Retrieving the data using hierarchical columns is easy, but building a dataframe with hierarchical columns is harder, we might want to add some "cookbook" style examples for this.