### PR TITLE
add remote credentials and manifest loading

### DIFF
--- a/data_explorer/app/.streamlit/config.toml
+++ b/data_explorer/app/.streamlit/config.toml
@@ -9,7 +9,7 @@ textColor="#262730"
 font="sans serif"
 
 [logger]
-level = "error"
+level = "info"
 
 [client]
 toolbarMode = "auto"

--- a/data_explorer/app/data.py
+++ b/data_explorer/app/data.py
@@ -1,10 +1,15 @@
 """This file contains data loading logic"""
+import json
+import logging
 from typing import List
 
 import dask.dataframe as dd
 import streamlit as st
+from fsspec import open as fs_open
 
 from fondant.manifest import Manifest
+
+LOGGER = logging.getLogger(__name__)
 
 
 @st.cache_data
@@ -17,7 +22,11 @@ def load_manifest(path: str) -> Manifest:
     Returns:
         Manifest: loaded manifest
     """
-    manifest = Manifest.from_file(path)
+
+    # open the path and load the manifest
+    with fs_open(path, encoding="utf-8") as file_:
+        specification = json.load(file_)
+    manifest = Manifest(specification=specification)
     return manifest
 
 

--- a/data_explorer/app/widgets.py
+++ b/data_explorer/app/widgets.py
@@ -26,6 +26,7 @@ def build_sidebar() -> Tuple[Optional[str], Optional[str], Optional[Dict]]:
     """
     # text field for manifest path
     st.sidebar.title("Subset loader")
+    # find all the files with filename `manifest.txt` in the `/artifacts` folder
     manifest_path = st.sidebar.text_input("Manifest path", '/artifacts/manifest.txt')
 
     # load manifest
@@ -33,10 +34,11 @@ def build_sidebar() -> Tuple[Optional[str], Optional[str], Optional[Dict]]:
         st.warning("Please provide a manifest path")
         manifest = None
     else:
-        if os.path.exists(manifest_path):
+        try:
             manifest = load_manifest(manifest_path)
-        else:
+        except Exception as e:
             st.warning("This file path does not exist")
+            LOGGER.debug(e)
             manifest = None
 
     # choose subset

--- a/data_explorer/requirements.txt
+++ b/data_explorer/requirements.txt
@@ -4,3 +4,5 @@ streamlit-aggrid==0.3.4
 pyarrow>=7.0
 matplotlib==3.7.1
 plotly==5.15.0
+fsspec==2023.4.0
+gcsfs==2023.4.0

--- a/fondant/cli.py
+++ b/fondant/cli.py
@@ -34,7 +34,11 @@ def run_data_explorer():
     parser.add_argument(
         "--data-directory",
         "-d",
-        help="Path to the source directory that contains the data produced by a fondant pipeline.",
+        help="Path to the source directory that contains the data produced by a fondant pipeline. \
+            Google cloud credentials: \
+            https://cloud.google.com/docs/authentication/application-default-credentials \
+            AWS credentials: https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html \
+            ",
     )
     parser.add_argument(
         "--registry", "-r", default=DEFAULT_REGISTRY, help="Docker registry to use."
@@ -44,6 +48,9 @@ def run_data_explorer():
     )
     parser.add_argument(
         "--port", "-p", default=DEFAULT_PORT, help="Port to expose the container on."
+    )
+    parser.add_argument(
+        "--credentials", "-c", default=DEFAULT_PORT, help="Cloud credentials."
     )
     args = parser.parse_args()
 
@@ -64,12 +71,25 @@ def run_data_explorer():
         f"{args.port}:8501",
         "--mount",
         f"type=bind,source={shlex.quote(args.data_directory)},target=/artifacts",
-        f"{shlex.quote(args.registry)}:{shlex.quote(args.tag)}",
     ]
+
+    if args.credentials:
+        cmd.extend(
+            [
+                "-v",
+                f"{args.credentials}:/root/.config/gcloud/application_default_credentials.json:ro",
+            ]
+        )
+
+    cmd.extend(
+        [
+            f"{shlex.quote(args.registry)}:{shlex.quote(args.tag)}",
+        ]
+    )
 
     logging.info(
         f"Running image from registry: {args.registry} with tag: {args.tag} on port: {args.port}"
     )
     logging.info(f"Access the explorer at http://localhost:{args.port}")
 
-    subprocess.call(cmd, stdout=subprocess.PIPE)  # nosec
+    subprocess.call(cmd)  # nosec


### PR DESCRIPTION
Add support to the data explorer for remote files. Uses fsspec to load in the file before passing it to the manifest.

Use the -c or --credentials to pass your google credentials json file

For testing, you can use this remote manifest
```
gs://soy-audio-379412_datasets/data_explorer/manifest_gcs.txt
```