### PR TITLE
Change default fondant version to latest and update docs

### DIFF
--- a/components/caption_images/requirements.txt
+++ b/components/caption_images/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ml6team/fondant.git@main
+fondant
 gcsfs==2023.4.0
 Pillow==9.4.0
 torch==2.0.1

--- a/components/download_images/requirements.txt
+++ b/components/download_images/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ml6team/fondant.git@main
+fondant
 albumentations==1.3.0
 opencv-python-headless>=4.5.5.62,<5
 gcsfs==2023.4.0

--- a/components/embedding_based_laion_retrieval/requirements.txt
+++ b/components/embedding_based_laion_retrieval/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/ml6team/fondant.git@main
+fondant
 gcsfs==2023.4.0

--- a/components/filter_comments/requirements.txt
+++ b/components/filter_comments/requirements.txt
@@ -1,3 +1,3 @@
-fondant==0.1.0
+fondant
 pyarrow>=7.0
 gcsfs==2023.4.00

--- a/components/filter_line_length/requirements.txt
+++ b/components/filter_line_length/requirements.txt
@@ -1,3 +1,3 @@
-fondant==0.1.0
+fondant
 pyarrow>=7.0
 gcsfs==2023.4.00

--- a/components/image_cropping/requirements.txt
+++ b/components/image_cropping/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ml6team/fondant.git
+fondant
 pyarrow>=7.0
 gcsfs==2023.4.0
 Pillow==9.4.0

--- a/components/image_embedding/requirements.txt
+++ b/components/image_embedding/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ml6team/fondant.git@main
+fondant
 gcsfs==2023.4.0
 Pillow==9.4.0
 torch==2.0.0

--- a/components/image_resolution_filtering/requirements.txt
+++ b/components/image_resolution_filtering/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/ml6team/fondant.git
+fondant
 pyarrow>=7.0
 gcsfs==2023.4.0

--- a/components/load_from_hf_hub/requirements.txt
+++ b/components/load_from_hf_hub/requirements.txt
@@ -1,5 +1,5 @@
 huggingface_hub==0.14.1
-git+https://github.com/ml6team/fondant.git
+fondant
 pyarrow>=7.0
 Pillow==9.4.0
 gcsfs==2023.4.0

--- a/components/pii_redaction/requirements.txt
+++ b/components/pii_redaction/requirements.txt
@@ -1,4 +1,4 @@
-fondant==0.1.0
+fondant
 pyarrow>=7.0
 gcsfs==2023.4.0
 regex==2023.5.5

--- a/components/prompt_based_laion_retrieval/requirements.txt
+++ b/components/prompt_based_laion_retrieval/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/ml6team/fondant.git@main
+fondant
 gcsfs==2023.4.0

--- a/components/segment_images/requirements.txt
+++ b/components/segment_images/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ml6team/fondant.git@main
+fondant
 gcsfs==2023.4.0
 transformers==4.29.2
 Pillow==9.4.0

--- a/docs/custom_component.md
+++ b/docs/custom_component.md
@@ -113,7 +113,7 @@ ENTRYPOINT ["python", "main.py"]
 A `requirements.txt` file lists the Python dependencies of the component. Note that any Fondant component will always have `Fondant` as the minimum requirement. It's important to also pin the version of each dependency to make sure the component remains working as expected. Below is an example of a component that relies on several Python libraries such as Pillow, PyTorch and Transformers.
 
 ```
-git+https://github.com/ml6team/fondant.git@main
+fondant
 Pillow==9.4.0
 torch==2.0.1
 transformers==4.29.2

--- a/examples/pipelines/controlnet-interior-design/README.md
+++ b/examples/pipelines/controlnet-interior-design/README.md
@@ -132,7 +132,6 @@ There are 5 components in total, these are:
 ### Requirements
 
 ```
-pip install git+https://github.com/ml6team/fondant.git
 pip install fondant[pipelines]
 ```
 

--- a/examples/pipelines/controlnet-interior-design/components/generate_prompts/requirements.txt
+++ b/examples/pipelines/controlnet-interior-design/components/generate_prompts/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/ml6team/fondant.git@main
+fondant
 gcsfs==2023.4.0

--- a/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/requirements.txt
+++ b/examples/pipelines/controlnet-interior-design/components/write_to_hub_controlnet/requirements.txt
@@ -1,5 +1,5 @@
 huggingface_hub==0.14.1
-git+https://github.com/ml6team/fondant.git
+fondant
 pyarrow>=7.0
 Pillow==9.4.0
 gcsfs==2023.4.0

--- a/examples/pipelines/starcoder/components/load_from_hub_stack/requirements.txt
+++ b/examples/pipelines/starcoder/components/load_from_hub_stack/requirements.txt
@@ -1,4 +1,4 @@
 huggingface_hub==0.14.1
-fondant==0.1.0
+fondant
 pyarrow>=7.0
 gcsfs==2023.4.0


### PR DESCRIPTION
PR to change the fondant version in the component build to the latest + update some docs to refer to installing fondant from the official pip package 