### PR TITLE
Include component spec in non-generic reusable components

### DIFF
--- a/components/caption_images/Dockerfile
+++ b/components/caption_images/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/caption_images/src/main.py
+++ b/components/caption_images/src/main.py
@@ -119,5 +119,5 @@ class CaptionImagesComponent(DaskTransformComponent):
 
 
 if __name__ == "__main__":
-    component = CaptionImagesComponent.from_args()
+    component = CaptionImagesComponent.from_file()
     component.run()

--- a/components/download_images/Dockerfile
+++ b/components/download_images/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -152,5 +152,5 @@ class DownloadImagesComponent(DaskTransformComponent):
 
 
 if __name__ == "__main__":
-    component = DownloadImagesComponent.from_args()
+    component = DownloadImagesComponent.from_file()
     component.run()

--- a/components/embedding_based_laion_retrieval/Dockerfile
+++ b/components/embedding_based_laion_retrieval/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/embedding_based_laion_retrieval/src/main.py
+++ b/components/embedding_based_laion_retrieval/src/main.py
@@ -73,5 +73,5 @@ class LAIONRetrievalComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = LAIONRetrievalComponent.from_args()
+    component = LAIONRetrievalComponent.from_file()
     component.run()

--- a/components/filter_comments/Dockerfile
+++ b/components/filter_comments/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/filter_comments/src/main.py
+++ b/components/filter_comments/src/main.py
@@ -45,5 +45,5 @@ class FilterCommentsComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = FilterCommentsComponent.from_args()
+    component = FilterCommentsComponent.from_file()
     component.run()

--- a/components/filter_line_length/Dockerfile
+++ b/components/filter_line_length/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/filter_line_length/src/main.py
+++ b/components/filter_line_length/src/main.py
@@ -43,5 +43,5 @@ class FilterLineLengthComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = FilterLineLengthComponent.from_args()
+    component = FilterLineLengthComponent.from_file()
     component.run()

--- a/components/image_cropping/Dockerfile
+++ b/components/image_cropping/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/image_cropping/src/main.py
+++ b/components/image_cropping/src/main.py
@@ -66,5 +66,5 @@ class ImageCroppingComponent(DaskTransformComponent):
 
 
 if __name__ == "__main__":
-    component = ImageCroppingComponent.from_args()
+    component = ImageCroppingComponent.from_file()
     component.run()

--- a/components/image_embedding/Dockerfile
+++ b/components/image_embedding/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/image_embedding/src/main.py
+++ b/components/image_embedding/src/main.py
@@ -108,5 +108,5 @@ class EmbedImagesComponent(DaskTransformComponent):
 
 
 if __name__ == "__main__":
-    component = EmbedImagesComponent.from_args()
+    component = EmbedImagesComponent.from_file()
     component.run()

--- a/components/image_resolution_filtering/Dockerfile
+++ b/components/image_resolution_filtering/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/image_resolution_filtering/src/main.py
+++ b/components/image_resolution_filtering/src/main.py
@@ -39,5 +39,5 @@ class ImageFilterComponent(DaskTransformComponent):
 
 
 if __name__ == "__main__":
-    component = ImageFilterComponent.from_args()
+    component = ImageFilterComponent.from_file()
     component.run()

--- a/components/pii_redaction/Dockerfile
+++ b/components/pii_redaction/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/pii_redaction/src/main.py
+++ b/components/pii_redaction/src/main.py
@@ -63,5 +63,5 @@ class RemovePIIComponent(TransformComponent):
 
 
 if __name__ == "__main__":
-    component = RemovePIIComponent.from_args()
+    component = RemovePIIComponent.from_file()
     component.run()

--- a/components/prompt_based_laion_retrieval/Dockerfile
+++ b/components/prompt_based_laion_retrieval/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/prompt_based_laion_retrieval/src/main.py
+++ b/components/prompt_based_laion_retrieval/src/main.py
@@ -79,5 +79,5 @@ class LAIONRetrievalComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = LAIONRetrievalComponent.from_args()
+    component = LAIONRetrievalComponent.from_file()
     component.run()

--- a/components/segment_images/Dockerfile
+++ b/components/segment_images/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /component/src
 
 # Copy over src-files
 COPY src/ .
+COPY fondant_component.yaml ../
 
 ENTRYPOINT ["python", "main.py"]

--- a/components/segment_images/src/main.py
+++ b/components/segment_images/src/main.py
@@ -137,5 +137,5 @@ class SegmentImagesComponent(DaskTransformComponent):
 
 
 if __name__ == "__main__":
-    component = SegmentImagesComponent.from_args()
+    component = SegmentImagesComponent.from_file()
     component.run()


### PR DESCRIPTION
Currently running a pipeline with reusable components fails as the component spec is no longer included in the image, but also not provided by the pipeline. We should assume that we have no access to the individual files of these components, as the goal is to move them out of the repository in the future. Since these components are not generic, we can keep including the component spec in the image.