### PR TITLE
[WIP] Add component type to spec

### DIFF
--- a/fondant/schemas/component_spec.json
+++ b/fondant/schemas/component_spec.json
@@ -5,7 +5,8 @@
   "required": [
     "name",
     "description",
-    "image"
+    "image",
+    "type"
   ],
   "properties": {
     "name": {
@@ -19,6 +20,11 @@
     "image": {
       "type": "string",
       "description": "Docker image for the component"
+    },
+    "type": {
+      "type": "string",
+      "description": "Type of the component",
+      "enum": ["load", "transform", "write"]
     },
     "consumes": {
       "$ref": "#/definitions/subsets"

--- a/tests/example_specs/component_specs/invalid_component.yaml
+++ b/tests/example_specs/component_specs/invalid_component.yaml
@@ -1,5 +1,6 @@
 name: Example component
 description: This is an example component
+type: transform
 image: example_component:latest
 
 consumes:

--- a/tests/example_specs/component_specs/kubeflow_component.yaml
+++ b/tests/example_specs/component_specs/kubeflow_component.yaml
@@ -1,16 +1,12 @@
 name: Example component
 description: This is an example component
 inputs:
--   name: input_manifest_path
-    description: Path to the input manifest
-    type: String
--   name: metadata
-    description: Metadata arguments containing the run id and base path
-    type: String
 -   name: component_spec
     description: The component specification as a dictionary
     type: JsonObject
-    default: None
+-   name: input_manifest_path
+    description: Path to the input manifest
+    type: String
 -   name: storage_args
     description: Storage arguments
     type: String
@@ -24,13 +20,11 @@ implementation:
         command:
         - python3
         - main.py
-        - --input_manifest_path
-        -   inputPath: input_manifest_path
-        - --metadata
-        -   inputValue: metadata
         - --component_spec
         -   inputValue: component_spec
-        - --storage_args
-        -   inputValue: storage_args
+        - --input_manifest_path
+        -   inputPath: input_manifest_path
         - --output_manifest_path
         -   outputPath: output_manifest_path
+        - --storage_args
+        -   inputValue: storage_args

--- a/tests/example_specs/component_specs/valid_component.yaml
+++ b/tests/example_specs/component_specs/valid_component.yaml
@@ -1,5 +1,6 @@
 name: Example component
 description: This is an example component
+type: transform
 image: example_component:latest
 
 consumes:

--- a/tests/example_specs/component_specs/valid_component_no_args.yaml
+++ b/tests/example_specs/component_specs/valid_component_no_args.yaml
@@ -1,5 +1,6 @@
 name: Example component
 description: This is an example component
+type: transform
 image: example_component:latest
 
 consumes:

--- a/tests/test_component_specs.py
+++ b/tests/test_component_specs.py
@@ -2,7 +2,6 @@
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import yaml
@@ -38,16 +37,10 @@ def invalid_fondant_schema() -> dict:
         return yaml.safe_load(f)
 
 
-@patch("pkgutil.get_data", return_value=None)
-def test_component_spec_pkgutil_error(mock_get_data):
-    """Test that FileNotFoundError is raised when pkgutil.get_data returns None."""
-    with pytest.raises(FileNotFoundError):
-        ComponentSpec("example_component.yaml")
-
-
 def test_component_spec_validation(valid_fondant_schema, invalid_fondant_schema):
     """Test that the manifest is validated correctly on instantiation."""
-    ComponentSpec(valid_fondant_schema)
+    a = ComponentSpec(valid_fondant_schema)
+    print(a.kubeflow_specification)
     with pytest.raises(InvalidComponentSpec):
         ComponentSpec(invalid_fondant_schema)
 
@@ -75,13 +68,17 @@ def test_kfp_component_creation(valid_fondant_schema, valid_kubeflow_schema):
     assert kubeflow_component._specification == valid_kubeflow_schema
 
 
-def test_component_spec_no_args(valid_fondant_schema_no_args):
+def test_transform_component_spec_no_args(valid_fondant_schema_no_args):
     """Test that a component spec without args is supported."""
     fondant_component = ComponentSpec(valid_fondant_schema_no_args)
 
     assert fondant_component.name == "Example component"
     assert fondant_component.description == "This is an example component"
-    assert fondant_component.args == {}
+    assert list(fondant_component.args.keys()) == [
+        "component_spec",
+        "input_manifest_path",
+        "output_manifest_path",
+    ]
 
 
 def test_component_spec_to_file(valid_fondant_schema):


### PR DESCRIPTION
PR that implement a component type per spec as discussed [here](https://github.com/ml6team/fondant/pull/196/files#r1227898938) to explicitly define the kubeflow/fondant input and output arguments per component type. This is still work in progress, current changes include adding the necessary changes to the schema and component spec script. 

What still needs to be done: 

- [ ] Add `type` field to all the affected components 
- [ ] Add relevant tests 