### PR TITLE
Update from_registry

### DIFF
--- a/examples/pipelines/controlnet-interior-design/pipeline.py
+++ b/examples/pipelines/controlnet-interior-design/pipeline.py
@@ -64,8 +64,7 @@ segment_images_op = ComponentOp.from_registry(
     node_pool_name="model-inference-pool",
 )
 
-write_to_hub_controlnet = ComponentOp.from_registry(
-    name="write_to_hf_hub",
+write_to_hub_controlnet = ComponentOp(
     component_spec_path="components/write_to_hub_controlnet/fondant_component.yaml",
     arguments={
         "username": "test-user",

--- a/fondant/pipeline.py
+++ b/fondant/pipeline.py
@@ -83,9 +83,8 @@ class ComponentOp:
     @classmethod
     def from_registry(
         cls,
-        name: str,
+        name: t.Optional[str] = None,
         *,
-        component_spec_path: t.Optional[t.Union[str, Path]] = None,
         arguments: t.Optional[t.Dict[str, t.Any]] = None,
         number_of_gpus: t.Optional[int] = None,
         node_pool_name: t.Optional[str] = None,
@@ -95,12 +94,10 @@ class ComponentOp:
         """Load a reusable component by its name.
 
         Args:
-            name: Name of the component to load
-            component_spec_path: The path to the specification file defining the component, defaults
-                to path defined within the component but can be specified to define custom
-                specification file
+            name: Name of the reusable component to load. Should be one of the folder names present
+                here: https://github.com/ml6team/fondant/tree/main/components).
             arguments: A dictionary containing the argument name and value for the operation.
-            number_of_gpus: The number of gpus to assign to the operation
+            number_of_gpus: The number of gpus to assign to the operation.
             node_pool_name: The name of the node pool to which the operation will be assigned.
             p_volumes: Collection of persistent volumes in a Kubernetes cluster. Keys are mount
                 paths, values are Kubernetes volumes or inherited types(e.g. PipelineVolumes).
@@ -108,14 +105,13 @@ class ComponentOp:
                 Defined by string which can be a number or a number followed by one of “E”, “P”,
                 “T”, “G”, “M”, “K”. (e.g. 2T for 2 Terabytes)
         """
-        if not component_spec_path:
-            component_spec_path = (
-                files("fondant") / f"components/{name}/fondant_component.yaml"  # type: ignore
-            )
-            component_spec_path = t.cast(Path, component_spec_path)
+        component_spec_path = (
+            files("fondant") / f"components/{name}/fondant_component.yaml"  # type: ignore
+        )
+        component_spec_path = t.cast(Path, component_spec_path)
 
-            if not (component_spec_path.exists() and component_spec_path.is_file()):
-                raise ValueError(f"No reusable component with name {name} found.")
+        if not (component_spec_path.exists() and component_spec_path.is_file()):
+            raise ValueError(f"No reusable component with name {name} found.")
 
         return ComponentOp(
             component_spec_path,


### PR DESCRIPTION
Currently the `from_registry` method accepts both `name` and `component_spec` arguments, and as seen [here](https://github.com/ml6team/fondant/blob/3e47ef7b1fe6fd1141d74713264297f66347e526/examples/pipelines/controlnet-interior-design/pipeline.py#L68-L69) both are provided.

However, the `name` is only being used in case the user doesn't specify a `component_spec_path` as seen [here](https://github.com/ml6team/fondant/blob/3e47ef7b1fe6fd1141d74713264297f66347e526/fondant/pipeline.py#L111-L118). 

Hence - please correct me if I'm wrong - there are 3 ways to create a component:

1. use a custom component spec:

```
generate_prompts_op = ComponentOp(
    component_spec_path="components/generate_prompts/fondant_component.yaml",
    arguments={"n_rows_to_load": None},
)
```

2. use a reusable component:
 ```
generate_prompts_op = ComponentOp.from_registry(
    name="load_from_hf_hub",
    arguments={"n_rows_to_load": None},
)
```

3.
now there's a third case, in which you want to use a reusable component (like `load_from_hf_hub`) but want to provide a custom component spec. I guess for this use case you can just use `ComponentOp` with your own spec that you overwrote from one of the existing ones, or do you need to use `from_registry`?