### PR TITLE
Leverage manifest instead of component spec in component data validation

### DIFF
--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -127,8 +127,7 @@ class DownloadImagesComponent(PandasTransformComponent):
             axis=1,
             result_type="expand",
         )
-
-        return dataframe[[("images", "data"), ("images", "width"), ("images", "height")]]
+        return dataframe
 
 
 if __name__ == "__main__":

--- a/examples/pipelines/datacomp/components/filter_text_complexity/src/main.py
+++ b/examples/pipelines/datacomp/components/filter_text_complexity/src/main.py
@@ -70,11 +70,7 @@ class FilterTextComplexity(PandasTransformComponent):
         )
         mask = mask.to_numpy()
 
-        dataframe = dataframe[mask]
-
-        dataframe = dataframe.drop(("text", "data"), axis=1)
-
-        return dataframe
+        return dataframe[mask]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR does 2 things
- It leverages the manifest instead of the component spec for data validation in the `PandasTransformComponent` class. This is better since the output manifest is evolved based on the input manifest and component spec, taking into account things such as `additionalSubsets` and `additionalFields`
- It filters out data not in the manifest from the pandas dataframe returned by the user. Previously, returning additional columns would raise an error. (see https://github.com/ml6team/fondant/pull/223#issuecomment-1602233930)