### PR TITLE
Don't validate returned Pandas dataframe strictly

### DIFF
--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -128,7 +128,7 @@ class DownloadImagesComponent(PandasTransformComponent):
             result_type="expand",
         )
 
-        return dataframe[[("images", "data"), ("images", "width"), ("images", "height")]]
+        return dataframe
 
 
 if __name__ == "__main__":

--- a/examples/pipelines/datacomp/components/filter_text_complexity/src/main.py
+++ b/examples/pipelines/datacomp/components/filter_text_complexity/src/main.py
@@ -70,11 +70,7 @@ class FilterTextComplexity(PandasTransformComponent):
         )
         mask = mask.to_numpy()
 
-        dataframe = dataframe[mask]
-
-        dataframe = dataframe.drop(("text", "data"), axis=1)
-
-        return dataframe
+        return dataframe[mask]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR filters out data from the pandas dataframe returned by the user that is not defined in the component spec. Previously, returning additional columns would raise an error. (see https://github.com/ml6team/fondant/pull/223#issuecomment-1602233930)