### PR TITLE
Enforce binding of absolute path

### DIFF
--- a/fondant/compiler.py
+++ b/fondant/compiler.py
@@ -92,6 +92,7 @@ class DockerCompiler(Compiler):
             logger.info(
                 f"Base path found on local system, setting up {base_path} as mount volume"
             )
+            p_base_path = p_base_path.resolve()
             volume = DockerVolume(
                 type="bind", source=str(p_base_path), target=f"/{p_base_path.stem}"
             )


### PR DESCRIPTION
If someone initializes the pipeline with a local base path and uses a relative path, `docker-compose up` will fail because the volume bindings require an absolute path.

To avoid this, I propose resolving the absolute path during the generation of the `docker-compose.yaml`.