### PR TITLE
Promote package from test.PyPI to PyPI without rebuilding

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -1,0 +1,48 @@
+name: Build Python 🐍 distributions 📦 and publish to TestPyPI
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+jobs:
+  build-n-publish:
+    name: Build Python 🐍 distributions 📦 and publish to TestPyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build components
+        run: ./scripts/build_components.sh -t $GITHUB_REF_NAME
+
+      - name: Build data explorer
+        run: ./scripts/build_explorer.sh -t $GITHUB_REF_NAME
+
+      - name: Update version in pyproject.toml with tag version
+        run: sed -i "s/^version = .*/version = '${{github.ref_name}}'/" pyproject.toml
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          pip install poetry
+          ./scripts/pre-build.sh
+          poetry build
+
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.6
+        with:
+          name: testpypi
+          repository_url: https://test.pypi.org/legacy/
+          url: https://test.pypi.org/p/fondant

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,26 +1,16 @@
-name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distributions 📦 to PyPI
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+*'
   release:
     types:
       - published
 jobs:
   build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    name: Publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       packages: write
     steps:
-    - uses: actions/checkout@master
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.9
-
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -28,41 +18,18 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build components
-      if: github.event_name == 'push'
-      run: ./scripts/build_components.sh -t $GITHUB_REF_NAME
-
     - name: Tag components
-      if: github.event_name == 'release'
       run: ./scripts/tag_components.sh -o $GITHUB_REF_NAME -n latest
     
-    - name: Build data explorer
-      if: github.event_name == 'push'
-      run: ./scripts/build_explorer.sh -t $GITHUB_REF_NAME
-
     - name: Tag data explorer
-      if: github.event_name == 'release'
       run: ./scripts/tag_explorer.sh -o $GITHUB_REF_NAME -n latest
 
-    - name: Update version in pyproject.toml with tag version
-      run: sed -i "s/^version = .*/version = '${{github.ref_name}}'/" pyproject.toml
-
-    - name: Build a binary wheel and a source tarball
+    - name: Download distributions from test.PyPI
       run: |
-        pip install poetry
-        ./scripts/pre-build.sh
-        poetry build
-
-    - name: Publish distribution 📦 to Test PyPI
-      if: github.event_name == 'push'
-      uses: pypa/gh-action-pypi-publish@v1.8.6
-      with:
-        name: testpypi
-        repository_url: https://test.pypi.org/legacy/
-        url: https://test.pypi.org/p/fondant
+        curl -LO https://test.pypi.org/fondant/fondant-$GITHUB_REF_NAME.tar.gz --output-dir dist --create-dirs
+        curl -LO https://test.pypi.org/fondant/fondant-$GITHUB_REF_NAME-py3-none-any.whl --output-dir dist --create-dirs
 
     - name: Publish distribution 📦 to PyPI if triggered by release
-      if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         name: pypi


### PR DESCRIPTION
Fixes #255 

We were rebuilding the fondant package when publishing to PyPI, which doesn't follow the "build once" mantra, and we were already suffering the consequences. Our `build_components.sh` script updates the image version in the component spec of the reusable components, which are included in the fondant python package. However this script only runs in the pipeline pushing to test.PyPI, not in the actual release pipeline pushing to PyPI.

This PR now downloads the package from test.PyPI and pushes it to PyPI instead of rebuilding, which should fix this issue.

Since the pipelines diverged further, I split them into separate files and removed the conditionals. 