### PR TITLE
Install buildx in prep-release pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,15 +15,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Set buildx alias
+        run: docker buildx install
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set buildx alias
-        run: docker buildx install
 
       - name: Build components
         run: ./scripts/build_components.sh --cache -t $GITHUB_SHA -t dev

--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -18,6 +18,12 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set buildx alias
+        run: docker buildx install
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
[The prep-release pipeline failed](https://github.com/ml6team/fondant/actions/runs/5452193633) because the new build script requires buildx.