### PR TITLE
Bump jsonschema version to 4.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 python = ">= 3.8"
 dask = {extras = ["dataframe"], version = ">= 2023.4.1"}
 importlib-resources = { version = ">= 1.3", python = "<3.9" }
-jsonschema = ">= 4.17.3"
+jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 
 gcsfs = { version = ">= 2023.4.0", optional = true }


### PR DESCRIPTION
I fixed a deprecation warning from `jsonschema` in #280. This means we are no longer compatible with `jsonschema` versions < 4.18.0, so we should bump it in the `pyproject.toml`.