### PR TITLE
Revert src/fondant/components after testing with tox

### DIFF
--- a/scripts/post-build.sh
+++ b/scripts/post-build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# This script reverts the src/fondant/components directory to a symlink to the components/
+# directory.
+# It should be run after running scripts/pre-build.sh and building the fondant package
+set -e
+
+scripts_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+root_path=$(dirname "$scripts_path")
+
+pushd "$root_path"
+rm -rf src/fondant/components
+pushd src/fondant
+ln -s ../../components
+popd
+popd

--- a/scripts/pre-build.sh
+++ b/scripts/pre-build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# This script copies the components/ directory to src/fondant/components, replacing the symlink
-# It should be run before building the fondant package'
-# This script makes changes to the local files, which should not be committed to git
+# This script copies the components/ directory to src/fondant/components, replacing the symlink.
+# It should be run before building the fondant package.
+# This script makes changes to the local files, which should not be committed to git. Run
+# scripts/post-build.sh to clean them up.
 set -e
 
 scripts_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )

--- a/src/fondant/components
+++ b/src/fondant/components
@@ -1,0 +1,1 @@
+../../components

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 python =
     3.8: py38
     3.9: py39
-    3.10: pre-commit,check-licenses, py310
+    3.10: pre-commit,check-licenses,py310
     3.11: py311
 
 [testenv:pre-commit]
@@ -42,3 +42,4 @@ commands=
     poetry install --all-extras
     poetry show
     poetry run python -m pytest tests --cov fondant --cov-report term-missing
+    bash ./scripts/post-build.sh


### PR DESCRIPTION
This PR adds a `post-build.sh` script which reverts the actions of the `pre-build.sh` script and runs it after testing with tox to revert the original state of the src/fondant/components symlink.