### PR TITLE
Add fsspec as explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ importlib-resources = { version = ">= 1.3", python = "<3.9" }
 jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 
+fsspec = { version = ">= 2023.4.0", optional = true}
 gcsfs = { version = ">= 2023.4.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }
 adlfs = { version = ">= 2023.4.0", optional = true }
@@ -55,9 +56,9 @@ kubernetes = { version = ">= 18.20.0", optional = true }
 pandas = { version = ">= 1.3.5", optional = true }
 
 [tool.poetry.extras]
-aws = ["s3fs"]
-azure = ["adlfs"]
-gcp = ["gcsfs"]
+aws = ["fsspec", "s3fs"]
+azure = ["fsspec", "adlfs"]
+gcp = ["fsspec", "gcsfs"]
 pipelines = ["kfp", "kubernetes"]
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
We use `fsspec` [directly](https://github.com/ml6team/fondant/blob/main/src/fondant/manifest.py#L10) in fondant, so we should add it as a dependency.