### PR TITLE
Split component implementation and execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,24 +222,39 @@ args:
     type: str
 ```
 
-Once you have your component specification, all you need to do is implement a single `.transform` 
-method and Fondant will do the rest. You will get the data defined in your specification as a 
-[Dask](https://www.dask.org/) dataframe, which is evaluated lazily.
+Once you have your component specification, all you need to do is implement a constructor 
+and a single `.transform` method and Fondant will do the rest. You will get the data defined in 
+your specification partition by partition as a Pandas dataframe.
 
 ```python
-from fondant.component import TransformComponent
+import pandas as pd
+from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
-class ExampleComponent(TransformComponent):
 
-    def transform(self, dataframe, *, argument1, argument2):
-        """Implement your custom logic in this single method
-        
+class ExampleComponent(PandasTransformComponent):
+
+    def __init__(self, *args, argument1, argument2) -> None:
+        """
         Args:
-            dataframe: A Dask dataframe containing the data
             argumentX: An argument passed to the component
         """
+        # Initialize your component here based on the arguments
+
+    def transform(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+        """Implement your custom logic in this single method
+        Args:
+            dataframe: A Pandas dataframe containing the data
+        Returns:
+            A pandas dataframe containing the transformed data
+        """
+
+if __name__ == "__main__":
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(ExampleComponent)
 ```
 
+For more advanced use cases, you can use the `DaskTransformComponent` instead.
 
 ###  Running your pipeline
 

--- a/components/caption_images/src/main.py
+++ b/components/caption_images/src/main.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import torch
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 from PIL import Image
 from transformers import BatchEncoding, BlipForConditionalGeneration, BlipProcessor
 
@@ -52,7 +53,7 @@ def caption_image_batch(
 class CaptionImagesComponent(PandasTransformComponent):
     """Component that captions images using a model from the Hugging Face hub."""
 
-    def setup(self, *, model_id: str, batch_size: int, max_new_tokens: int) -> None:
+    def __init__(self, *args, model_id: str, batch_size: int, max_new_tokens: int) -> None:
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         logger.info(f"Device: {self.device}")
 
@@ -85,5 +86,5 @@ class CaptionImagesComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = CaptionImagesComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(CaptionImagesComponent)

--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -12,6 +12,7 @@ import urllib
 
 import dask.dataframe as dd
 from fondant.component import DaskTransformComponent
+from fondant.executor import DaskTransformExecutor
 from resizer import Resizer
 
 logger = logging.getLogger(__name__)
@@ -88,21 +89,19 @@ def download_image_with_retry(
 class DownloadImagesComponent(DaskTransformComponent):
     """Component that downloads images based on URLs."""
 
-    def transform(
-            self,
-            dataframe: dd.DataFrame,
-            *,
-            timeout: int,
-            retries: int,
-            image_size: int,
-            resize_mode: str,
-            resize_only_if_bigger: bool,
-            min_image_size: int,
-            max_aspect_ratio: float,
-    ) -> dd.DataFrame:
-        """Function that downloads images from a list of URLs and executes filtering and resizing
+    def __init__(self,
+                 *_,
+                 timeout: int,
+                 retries: int,
+                 image_size: int,
+                 resize_mode: str,
+                 resize_only_if_bigger: bool,
+                 min_image_size: int,
+                 max_aspect_ratio: float,
+                 ):
+        """Component that downloads images from a list of URLs and executes filtering and resizing.
+
         Args:
-            dataframe: Dask dataframe
             timeout: Maximum time (in seconds) to wait when trying to download an image.
             retries: Number of times to retry downloading an image if it fails.
             image_size: Size of the images after resizing.
@@ -114,8 +113,9 @@ class DownloadImagesComponent(DaskTransformComponent):
         Returns:
             Dask dataframe
         """
-        logger.info("Instantiating resizer...")
-        resizer = Resizer(
+        self.timeout = timeout
+        self.retries = retries
+        self.resizer = Resizer(
             image_size=image_size,
             resize_mode=resize_mode,
             resize_only_if_bigger=resize_only_if_bigger,
@@ -123,15 +123,21 @@ class DownloadImagesComponent(DaskTransformComponent):
             max_aspect_ratio=max_aspect_ratio,
         )
 
+    def transform(
+            self,
+            dataframe: dd.DataFrame,
+    ) -> dd.DataFrame:
+        logger.info("Instantiating resizer...")
+
         # Remove duplicates from laion retrieval
         dataframe = dataframe.drop_duplicates()
 
         dataframe = dataframe.apply(
             lambda example: download_image_with_retry(
                 url=example.images_url,
-                timeout=timeout,
-                retries=retries,
-                resizer=resizer,
+                timeout=self.timeout,
+                retries=self.retries,
+                resizer=self.resizer,
             ),
             axis=1,
             result_type="expand",
@@ -150,5 +156,5 @@ class DownloadImagesComponent(DaskTransformComponent):
 
 
 if __name__ == "__main__":
-    component = DownloadImagesComponent.from_args()
-    component.run()
+    executor = DaskTransformExecutor.from_args()
+    executor.execute(DownloadImagesComponent)

--- a/components/embedding_based_laion_retrieval/src/main.py
+++ b/components/embedding_based_laion_retrieval/src/main.py
@@ -8,6 +8,7 @@ import typing as t
 import pandas as pd
 from clip_client import ClipClient, Modality
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 class LAIONRetrievalComponent(PandasTransformComponent):
     """Component that retrieves image URLs from LAION-5B based on a set of CLIP embeddings."""
 
-    def setup(
+    def __init__(
             self,
             *,
             num_images: int,
@@ -70,5 +71,5 @@ class LAIONRetrievalComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = LAIONRetrievalComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(LAIONRetrievalComponent)

--- a/components/filter_image_resolution/src/main.py
+++ b/components/filter_image_resolution/src/main.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 import pandas as pd
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -13,20 +14,16 @@ logger = logging.getLogger(__name__)
 class FilterImageResolutionComponent(PandasTransformComponent):
     """Component that filters images based on height and width."""
 
-    def setup(self, *, min_image_dim: int, max_aspect_ratio: float) -> None:
+    def __init__(self, *_, min_image_dim: int, max_aspect_ratio: float) -> None:
+        """
+        Args:
+            min_image_dim: minimum image dimension.
+            max_aspect_ratio: maximum aspect ratio.
+        """
         self.min_image_dim = min_image_dim
         self.max_aspect_ratio = max_aspect_ratio
 
     def transform(self, dataframe: pd.DataFrame) -> pd.DataFrame:
-        """
-        Args:
-            dataframe: Pandas dataframe
-            min_image_dim: minimum image dimension.
-            min_aspect_ratio: minimum aspect ratio.
-
-        Returns:
-            filtered Pandas dataframe
-        """
         width = dataframe["image"]["width"]
         height = dataframe["image"]["height"]
         min_image_dim = np.minimum(width, height)
@@ -38,5 +35,5 @@ class FilterImageResolutionComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = FilterImageResolutionComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(FilterImageResolutionComponent)

--- a/components/filter_line_length/src/main.py
+++ b/components/filter_line_length/src/main.py
@@ -1,42 +1,45 @@
 """This component filters code based on a set of metadata associated with it."""
 import logging
 
-import dask.dataframe as dd
-from fondant.component import DaskTransformComponent
+import pandas as pd
+from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
 
-class FilterLineLengthComponent(DaskTransformComponent):
+class FilterLineLengthComponent(PandasTransformComponent):
     """
     This component filters code based on a set of metadata associated with it:
     average line length, maximum line length and alphanum fraction.
     """
 
-    def transform(
-        self,
-        *,
-        dataframe: dd.DataFrame,
+    def __init__(self, *_,
         avg_line_length_threshold: int,
         max_line_length_threshold: int,
         alphanum_fraction_threshold: float,
-    ) -> dd.DataFrame:
+    ) -> None:
         """
         Args:
-            dataframe: Dask dataframe
             avg_line_length_threshold: Threshold for average line length to filter on
             max_line_length_threshold: Threshold for max line length to filter on
-            alphanum_fraction_threshold: Alphanum fraction to filter on
-        Returns:
-            Filtered dask dataframe.
+            alphanum_fraction_threshold: Alphanum fraction to filter on.
         """
+        self.avg_line_length_threshold = avg_line_length_threshold
+        self.max_line_length_threshold = max_line_length_threshold
+        self.alphanum_fraction_threshold = alphanum_fraction_threshold
+
+    def transform(
+        self,
+        dataframe: pd.DataFrame,
+    ) -> pd.DataFrame:
         return dataframe[
-            (dataframe["code_avg_line_length"] > avg_line_length_threshold)
-            & (dataframe["code_max_line_length"] > max_line_length_threshold)
-            & (dataframe["code_alphanum_fraction"] > alphanum_fraction_threshold)
+            (dataframe["code_avg_line_length"] > self.avg_line_length_threshold)
+            & (dataframe["code_max_line_length"] > self.max_line_length_threshold)
+            & (dataframe["code_alphanum_fraction"] > self.alphanum_fraction_threshold)
         ]
 
 
 if __name__ == "__main__":
-    component = FilterLineLengthComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(FilterLineLengthComponent)

--- a/components/image_embedding/src/main.py
+++ b/components/image_embedding/src/main.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import torch
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 from PIL import Image
 from transformers import CLIPProcessor, CLIPVisionModelWithProjection
 
@@ -49,9 +50,9 @@ def embed_image_batch(image_batch: pd.DataFrame, *, model: CLIPVisionModelWithPr
 class EmbedImagesComponent(PandasTransformComponent):
     """Component that captions images using a model from the Hugging Face hub."""
 
-    def setup(
+    def __init__(
         self,
-        *,
+        *_,
         model_id: str,
         batch_size: int,
     ):
@@ -85,5 +86,5 @@ class EmbedImagesComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = EmbedImagesComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(EmbedImagesComponent)

--- a/components/image_resolution_extraction/src/main.py
+++ b/components/image_resolution_extraction/src/main.py
@@ -7,6 +7,7 @@ import imagesize
 import numpy as np
 import pandas as pd
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -46,5 +47,5 @@ class ImageResolutionExtractionComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = ImageResolutionExtractionComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(ImageResolutionExtractionComponent)

--- a/components/language_filter/src/main.py
+++ b/components/language_filter/src/main.py
@@ -4,6 +4,7 @@ import logging
 import fasttext
 import pandas as pd
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class LanguageIdentification:
 class LanguageFilterComponent(PandasTransformComponent):
     """Component that filter columns based on provided language."""
 
-    def setup(self, *, language):
+    def __init__(self, *_, language):
         """Setup language filter component.
 
         Args:
@@ -67,5 +68,5 @@ class LanguageFilterComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = LanguageFilterComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(LanguageFilterComponent)

--- a/components/load_from_hf_hub/src/main.py
+++ b/components/load_from_hf_hub/src/main.py
@@ -3,18 +3,20 @@ import logging
 import typing as t
 
 import dask.dataframe as dd
-from fondant.component import LoadComponent
+from fondant.component import DaskLoadComponent
+from fondant.executor import DaskLoadExecutor
 
 logger = logging.getLogger(__name__)
 
 
-class LoadFromHubComponent(LoadComponent):
-    def load(self,
-             *,
+class LoadFromHubComponent(DaskLoadComponent):
+
+    def __init__(self, *_,
              dataset_name: str,
              column_name_mapping: dict,
              image_column_names: t.Optional[list],
-             n_rows_to_load: t.Optional[int]) -> dd.DataFrame:
+             n_rows_to_load: t.Optional[int],
+    ) -> None:
         """
         Args:
             dataset_name: name of the dataset to load.
@@ -22,33 +24,36 @@ class LoadFromHubComponent(LoadComponent):
             image_column_names: A list containing the original hub image column names. Used to
                 format the image from HF hub format to a byte string
             n_rows_to_load: optional argument that defines the number of rows to load. Useful for
-              testing pipeline runs on a small scale
-        Returns:
-            Dataset: HF dataset.
+              testing pipeline runs on a small scale.
         """
+        self.dataset_name = dataset_name
+        self.column_name_mapping = column_name_mapping
+        self.image_column_names = image_column_names
+        self.n_rows_to_load = n_rows_to_load
+
+    def load(self) -> dd.DataFrame:
         # 1) Load data, read as Dask dataframe
         logger.info("Loading dataset from the hub...")
-        dask_df = dd.read_parquet(f"hf://datasets/{dataset_name}")
+        dask_df = dd.read_parquet(f"hf://datasets/{self.dataset_name}")
 
         # 2) Make sure images are bytes instead of dicts
-        if image_column_names is not None:
-            for image_column_name in image_column_names:
+        if self.image_column_names is not None:
+            for image_column_name in self.image_column_names:
                 dask_df[image_column_name] = dask_df[image_column_name].map(
                     lambda x: x["bytes"], meta=("bytes", bytes),
                 )
 
         # 3) Rename columns
-        dask_df = dask_df.rename(columns=column_name_mapping)
+        dask_df = dask_df.rename(columns=self.column_name_mapping)
 
         # 4) Optional: only return specific amount of rows
-
-        if n_rows_to_load:
-            dask_df = dask_df.head(n_rows_to_load)
+        if self.n_rows_to_load:
+            dask_df = dask_df.head(self.n_rows_to_load)
             dask_df = dd.from_pandas(dask_df, npartitions=1)
 
         return dask_df
 
 
 if __name__ == "__main__":
-    component = LoadFromHubComponent.from_args()
-    component.run()
+    executor = DaskLoadExecutor.from_args()
+    executor.execute(LoadFromHubComponent)

--- a/components/minhash_generator/src/main.py
+++ b/components/minhash_generator/src/main.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from datasketch import MinHash
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 from nltk.util import ngrams
 
 logger = logging.getLogger(__name__)
@@ -31,7 +32,7 @@ def compute_minhash(shingles: list) -> np.ndarray:
 class MinHashGeneratorComponent(PandasTransformComponent):
     """Component generates minhashes of text."""
 
-    def setup(self, *, shingle_ngram_size: int):
+    def __init__(self, *_, shingle_ngram_size: int):
         """Setup component.
 
         Args:
@@ -60,5 +61,5 @@ class MinHashGeneratorComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = MinHashGeneratorComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(MinHashGeneratorComponent)

--- a/components/prompt_based_laion_retrieval/src/main.py
+++ b/components/prompt_based_laion_retrieval/src/main.py
@@ -7,6 +7,7 @@ import typing as t
 import pandas as pd
 from clip_client import ClipClient, Modality
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +15,9 @@ logger = logging.getLogger(__name__)
 class LAIONRetrievalComponent(PandasTransformComponent):
     """Component that retrieves image URLs from LAION-5B based on a set of prompts."""
 
-    def setup(
+    def __init__(
             self,
-            *,
+            *_,
             num_images: int,
             aesthetic_score: int,
             aesthetic_weight: float,
@@ -71,5 +72,5 @@ class LAIONRetrievalComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = LAIONRetrievalComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(LAIONRetrievalComponent)

--- a/components/segment_images/src/main.py
+++ b/components/segment_images/src/main.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import torch
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 from palette import palette
 from PIL import Image
 from transformers import AutoModelForSemanticSegmentation, BatchFeature, SegformerImageProcessor
@@ -85,7 +86,7 @@ def segment_image_batch(image_batch: pd.DataFrame,
 class SegmentImagesComponent(PandasTransformComponent):
     """Component that segments images using a model from the Hugging Face hub."""
 
-    def setup(self, model_id: str, batch_size: int) -> None:
+    def __init__(self, *_, model_id: str, batch_size: int) -> None:
         """
         Args:
             model_id: id of the model on the Hugging Face hub
@@ -121,5 +122,5 @@ class SegmentImagesComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = SegmentImagesComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(SegmentImagesComponent)

--- a/components/text_length_filter/src/main.py
+++ b/components/text_length_filter/src/main.py
@@ -4,6 +4,7 @@ import logging
 import fasttext
 import pandas as pd
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 class TextLengthFilterComponent(PandasTransformComponent):
     """A component that filters out text based on their length."""
 
-    def setup(self, *, min_characters_length: int, min_words_length: int):
+    def __init__(self, *_, min_characters_length: int, min_words_length: int):
         """Setup component.
 
         Args:
@@ -22,15 +23,7 @@ class TextLengthFilterComponent(PandasTransformComponent):
         self.min_words_length = min_words_length
 
     def transform(self, dataframe: pd.DataFrame) -> pd.DataFrame:
-        """
-        Filter out text based on their length.
-
-        Args:
-            dataframe: Pandas dataframe.
-
-        Returns:
-            Pandas dataframe.
-        """
+        """Filter out text based on their length."""
         caption_num_words = dataframe["text"]["data"].apply(lambda x: len(fasttext.tokenize(x)))
         caption_num_chars = dataframe["text"]["data"].apply(len)
 
@@ -41,5 +34,5 @@ class TextLengthFilterComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = TextLengthFilterComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(TextLengthFilterComponent)

--- a/components/text_normalization/src/main.py
+++ b/components/text_normalization/src/main.py
@@ -6,6 +6,7 @@ from typing import List
 
 import pandas as pd
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 class TextNormalizationComponent(PandasTransformComponent):
     """Component that normalizes text."""
 
-    def setup(self, *, apply_nfc: bool, do_lowercase: bool, characters_to_remove: List[str]):
+    def __init__(self, *args, apply_nfc: bool, do_lowercase: bool, characters_to_remove: List[str]):
         self.apply_nfc = apply_nfc
         self.do_lowercase = do_lowercase
         self.characters_to_remove = characters_to_remove
@@ -60,5 +61,5 @@ class TextNormalizationComponent(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = TextNormalizationComponent.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(TextNormalizationComponent)

--- a/docs/component_spec.md
+++ b/docs/component_spec.md
@@ -150,22 +150,38 @@ custom_op = ComponentOp(
 )
 ```
 
-Afterwards, we pass all keyword arguments to the `transform()` method of the component.
+Afterwards, we pass all keyword arguments to the `__init__()` method of the component.
 
 ```python
-from fondant.component import TransformComponent
+import pandas as pd
+from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
-class ExampleComponent(TransformComponent):
 
-    def transform(self, dataframe, *, custom_argument, default_argument):
-        """Implement your custom logic in this single method
+class ExampleComponent(PandasTransformComponent):
+
+  def __init__(self, *args, custom_argument, default_argument) -> None:
+    """
+    Args:
+        x_argument: An argument passed to the component
+    """
+    # Initialize your component here based on the arguments
+
+  def transform(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+    """Implement your custom logic in this single method
+    
+    Args:
+        dataframe: A Pandas dataframe containing the data
         
-        Args:
-            dataframe: A Dask dataframe containing the data
-            custom_argument: An argument passed to the component
-            default_argument: A default argument passed to the components
-        """
+    Returns:
+        A pandas dataframe containing the transformed data
+    """
+
+if __name__ == "__main__":
+  executor = PandasTransformExecutor.from_args()
+  executor.execute(ExampleComponent)
 ```
+
 
 ## Examples
 

--- a/docs/custom_component.md
+++ b/docs/custom_component.md
@@ -56,7 +56,7 @@ class ExampleComponent(PandasTransformComponent):
     def transform(self, dataframe: pd.DataFrame) -> pd.DataFrame:
         """Implement your custom logic in this single method
         Args:
-            dataframe: A Pandas dataframe containing the data
+            dataframe: A Pandas dataframe containing one partition of your data
         Returns:
             A pandas dataframe containing the transformed data
         """
@@ -71,7 +71,7 @@ The `__init__` method is called once for each component class with custom argume
 `args` section of the [component specification](component_spec).)
 
 The `transform` method is called multiple times, each time containing a pandas `dataframe` 
-loaded in memory.
+with a partition of your data loaded in memory.
 
 The `dataframes` passed to the `transform` method contains the data specified in the `produces` 
 section of the component specification. If a component defines that it consumes an `images` subset 

--- a/docs/custom_component.md
+++ b/docs/custom_component.md
@@ -39,31 +39,35 @@ The easiest way to implement a `TransformComponent` is to subclass the provided
 chunks as pandas dataframes.
 
 ```python
+import pandas as pd
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
+
 
 class ExampleComponent(PandasTransformComponent):
-    
-    def setup(self, argument1, argument2):
-        """This method is called once per component with any custom arguments it received. Use 
-        it for component wide setup or to store your arguments as instance attributes to access 
-        them in the `transform` method.
-        
-        Args:
-            argumentX: A custom argument passed to the component
-        """ 
 
-    def transform(self, dataframe):
-        """Implement your custom transformation logic in this single method
-        
-        Args:
-            dataframe: A Pandas dataframe containing one partition of your data
-            
-        Returns:
-            A pandas dataframe with the transformed data
+    def __init__(self, *args, argument1, argument2) -> None:
         """
+        Args:
+            argumentX: An argument passed to the component
+        """
+        # Initialize your component here based on the arguments
+
+    def transform(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+        """Implement your custom logic in this single method
+        Args:
+            dataframe: A Pandas dataframe containing the data
+        Returns:
+            A pandas dataframe containing the transformed data
+        """
+
+if __name__ == "__main__":
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(ExampleComponent)
 ```
 
-The `setup` method is called once for each component class with custom arguments defined in the 
+
+The `__init__` method is called once for each component class with custom arguments defined in the 
 `args` section of the [component specification](component_spec).)
 
 The `transform` method is called multiple times, each time containing a pandas `dataframe` 

--- a/examples/pipelines/datacomp/components/filter_text_complexity/src/main.py
+++ b/examples/pipelines/datacomp/components/filter_text_complexity/src/main.py
@@ -12,6 +12,7 @@ import spacy
 from spacy.symbols import nsubj, VERB
 
 from fondant.component import PandasTransformComponent
+from fondant.executor import PandasTransformExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -41,9 +42,9 @@ class FilterTextComplexity(PandasTransformComponent):
     - complexity of the dependency parse tree
     - number of actions"""
 
-    def setup(
+    def __init__(
         self,
-        *,
+        *args,
         spacy_pipeline,
         batch_size: int,
         min_complexity: int,
@@ -72,5 +73,5 @@ class FilterTextComplexity(PandasTransformComponent):
 
 
 if __name__ == "__main__":
-    component = FilterTextComplexity.from_args()
-    component.run()
+    executor = PandasTransformExecutor.from_args()
+    executor.execute(FilterTextComplexity)

--- a/src/fondant/component.py
+++ b/src/fondant/component.py
@@ -1,260 +1,51 @@
-"""
-This Python module defines abstract base class for components in the Fondant data processing
-framework, providing a standardized interface for extending loading and transforming components.
-The loading component is the first component that loads the initial dataset and the transform
-components take care of processing, filtering and extending the data.
-"""
+"""This module defines interfaces which components should implement to be executed by fondant."""
 
-import argparse
-import json
-import logging
 import typing as t
-from abc import ABC, abstractmethod
-from pathlib import Path
 
 import dask.dataframe as dd
 import pandas as pd
 
-from fondant.component_spec import Argument, ComponentSpec, kubeflow2python_type
-from fondant.data_io import DaskDataLoader, DaskDataWriter
-from fondant.manifest import Manifest
-
-logger = logging.getLogger(__name__)
+from fondant.component_spec import ComponentSpec
 
 
-class Component(ABC):
-    """Abstract base class for a Fondant component."""
+class BaseComponent:
+    """Base interface for each component, specifying only the constructor.
 
-    def __init__(
-        self,
-        spec: ComponentSpec,
-        *,
-        input_manifest_path: t.Union[str, Path],
-        output_manifest_path: t.Union[str, Path],
-        metadata: t.Dict[str, t.Any],
-        user_arguments: t.Dict[str, Argument],
-    ) -> None:
-        self.spec = spec
-        self.input_manifest_path = input_manifest_path
-        self.output_manifest_path = output_manifest_path
-        self.metadata = metadata
-        self.user_arguments = user_arguments
+    Args:
+        spec: The specification of the component
+        **kwargs: The provided user arguments are passed in as keyword arguments
+    """
 
-    @classmethod
-    def from_file(
-        cls,
-        path: t.Union[str, Path] = "../fondant_component.yaml",
-    ) -> "Component":
-        """Create a component from a component spec file.
-
-        Args:
-            path: Path to the component spec file
-        """
-        component_spec = ComponentSpec.from_file(path)
-        return cls.from_spec(component_spec)
-
-    @classmethod
-    def from_args(cls) -> "Component":
-        """Create a component from a passed argument containing the specification as a dict."""
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--component_spec", type=json.loads)
-        args, _ = parser.parse_known_args()
-
-        if "component_spec" not in args:
-            msg = "Error: The --component_spec argument is required."
-            raise ValueError(msg)
-
-        component_spec = ComponentSpec(args.component_spec)
-
-        return cls.from_spec(component_spec)
-
-    @classmethod
-    def from_spec(cls, component_spec: ComponentSpec) -> "Component":
-        """Create a component from a component spec."""
-        args_dict = vars(cls._add_and_parse_args(component_spec))
-
-        if "component_spec" in args_dict:
-            args_dict.pop("component_spec")
-        input_manifest_path = args_dict.pop("input_manifest_path")
-        output_manifest_path = args_dict.pop("output_manifest_path")
-        metadata = args_dict.pop("metadata")
-
-        metadata = json.loads(metadata) if metadata else {}
-
-        return cls(
-            component_spec,
-            input_manifest_path=input_manifest_path,
-            output_manifest_path=output_manifest_path,
-            metadata=metadata,
-            user_arguments=args_dict,
-        )
-
-    @classmethod
-    def _add_and_parse_args(cls, spec: ComponentSpec):
-        parser = argparse.ArgumentParser()
-        component_arguments = cls._get_component_arguments(spec)
-
-        for arg in component_arguments.values():
-            if arg.name in cls.optional_fondant_arguments():
-                input_required = False
-                default = None
-            elif arg.default:
-                input_required = False
-                default = arg.default
-            else:
-                input_required = True
-                default = None
-
-            parser.add_argument(
-                f"--{arg.name}",
-                type=kubeflow2python_type(arg.type),  # type: ignore
-                required=input_required,
-                default=default,
-                help=arg.description,
-            )
-
-        return parser.parse_args()
-
-    @staticmethod
-    def optional_fondant_arguments() -> t.List[str]:
-        return []
-
-    @staticmethod
-    def _get_component_arguments(spec: ComponentSpec) -> t.Dict[str, Argument]:
-        """
-        Get the component arguments as a dictionary representation containing both input and output
-            arguments of a component
-        Args:
-            spec: the component spec
-        Returns:
-            Input and output arguments of the component.
-        """
-        component_arguments: t.Dict[str, Argument] = {}
-        kubeflow_component_spec = spec.kubeflow_specification
-        component_arguments.update(kubeflow_component_spec.input_arguments)
-        component_arguments.update(kubeflow_component_spec.output_arguments)
-        return component_arguments
-
-    @abstractmethod
-    def _load_or_create_manifest(self) -> Manifest:
-        """Abstract method that returns the dataset manifest."""
-
-    @abstractmethod
-    def _process_dataset(self, manifest: Manifest) -> t.Union[None, dd.DataFrame]:
-        """Abstract method that processes the manifest and
-        returns another dataframe.
-        """
-
-    def _write_data(self, dataframe: dd.DataFrame, *, manifest: Manifest):
-        """Create a data writer given a manifest and writes out the index and subsets."""
-        data_writer = DaskDataWriter(manifest=manifest, component_spec=self.spec)
-        data_writer.write_dataframe(dataframe)
-
-    def run(self):
-        """Runs the component."""
-        input_manifest = self._load_or_create_manifest()
-
-        output_df = self._process_dataset(manifest=input_manifest)
-
-        output_manifest = input_manifest.evolve(component_spec=self.spec)
-
-        self._write_data(dataframe=output_df, manifest=output_manifest)
-
-        self.upload_manifest(output_manifest, save_path=self.output_manifest_path)
-
-    def upload_manifest(self, manifest: Manifest, save_path: str):
-        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
-        manifest.to_file(save_path)
+    def __init__(self, spec: ComponentSpec, **kwargs):
+        pass
 
 
-class LoadComponent(Component):
-    """Base class for a Fondant load component."""
+class DaskLoadComponent(BaseComponent):
+    """Component that loads data and returns a Dask DataFrame."""
 
-    @staticmethod
-    def optional_fondant_arguments() -> t.List[str]:
-        return ["input_manifest_path"]
-
-    def _load_or_create_manifest(self) -> Manifest:
-        component_id = self.spec.name.lower().replace(" ", "_")
-        return Manifest.create(
-            base_path=self.metadata["base_path"],
-            run_id=self.metadata["run_id"],
-            component_id=component_id,
-        )
-
-    @abstractmethod
-    def load(self, *args, **kwargs) -> dd.DataFrame:
-        """Abstract method that loads the initial dataframe."""
-
-    def _process_dataset(self, manifest: Manifest) -> dd.DataFrame:
-        """This function loads the initial dataframe sing the user-provided `load` method.
-
-        Returns:
-            A `dd.DataFrame` instance with initial data'.
-        """
-        # Load the dataframe according to the custom function provided to the user
-        return self.load(**self.user_arguments)
+    def load(self) -> dd.DataFrame:
+        raise NotImplementedError
 
 
-class TransformComponent(Component):
-    """Base class for a Fondant transform component."""
+class DaskTransformComponent(BaseComponent):
+    """Component that transforms an incoming Dask DataFrame."""
 
-    def _load_or_create_manifest(self) -> Manifest:
-        return Manifest.from_file(self.input_manifest_path)
-
-    @abstractmethod
-    def transform(self, *args, **kwargs) -> dd.DataFrame:
+    def transform(self, dataframe: dd.DataFrame) -> dd.DataFrame:
         """
         Abstract method for applying data transformations to the input dataframe.
 
         Args:
-            args: The dataframe will be passed in as a positional argument
-            kwargs: Arguments provided to the component are passed as keyword arguments
+            dataframe: A Dask dataframe containing the data specified in the `consumes` section
+                of the component specification
         """
-
-    def _process_dataset(self, manifest: Manifest) -> dd.DataFrame:
-        """
-        Load the data based on the manifest using a DaskDataloader and call the transform method to
-        process it.
-
-        Returns:
-            A `dd.DataFrame` instance with updated data based on the applied data transformations.
-        """
+        raise NotImplementedError
 
 
-class DaskTransformComponent(TransformComponent):
-    @abstractmethod
-    def transform(self, *args, **kwargs) -> dd.DataFrame:
-        """
-        Abstract method for applying data transformations to the input dataframe.
+class PandasTransformComponent(BaseComponent):
+    """Component that transforms the incoming dataset partition per partition as a pandas
+    DataFrame.
+    """
 
-        Args:
-            args: A Dask dataframe will be passed in as a positional argument
-            kwargs: Arguments provided to the component are passed as keyword arguments
-        """
-
-    def _process_dataset(self, manifest: Manifest) -> dd.DataFrame:
-        """
-        Load the data based on the manifest using a DaskDataloader and call the transform method to
-        process it.
-
-        Returns:
-            A `dd.DataFrame` instance with updated data based on the applied data transformations.
-        """
-        data_loader = DaskDataLoader(manifest=manifest, component_spec=self.spec)
-        dataframe = data_loader.load_dataframe()
-        dataframe = self.transform(dataframe, **self.user_arguments)
-        return dataframe
-
-
-class PandasTransformComponent(TransformComponent):
-    def setup(self, *args, **kwargs):
-        """Called once for each instance of the Component class. Use this to set up resources
-        such as database connections.
-        """
-        return
-
-    @abstractmethod
     def transform(self, dataframe: pd.DataFrame) -> pd.DataFrame:
         """
         Abstract method for applying data transformations to the input dataframe.
@@ -263,135 +54,15 @@ class PandasTransformComponent(TransformComponent):
         Args:
             dataframe: A Pandas dataframe containing a partition of the data
         """
-
-    @staticmethod
-    def wrap_transform(transform: t.Callable, *, spec: ComponentSpec) -> t.Callable:
-        """Factory that creates a function to wrap the component transform function. The wrapper:
-        - Converts the columns to hierarchical format before passing the dataframe to the
-          transform function
-        - Removes extra columns from the returned dataframe which are not defined in the component
-          spec `produces` section
-        - Sorts the columns from the returned dataframe according to the order in the component
-          spec `produces` section to match the order in the `meta` argument passed to Dask's
-          `map_partitions`.
-        - Flattens the returned dataframe columns.
-
-        Args:
-            transform: Transform method to wrap
-            spec: Component specification to base behavior on
-        """
-
-        def wrapped_transform(dataframe: pd.DataFrame) -> pd.DataFrame:
-            # Switch to hierarchical columns
-            dataframe.columns = pd.MultiIndex.from_tuples(
-                tuple(column.split("_")) for column in dataframe.columns
-            )
-
-            # Call transform method
-            dataframe = transform(dataframe)
-
-            # Drop columns not in specification
-            columns = [
-                (subset_name, field)
-                for subset_name, subset in spec.produces.items()
-                for field in subset.fields
-            ]
-            dataframe = dataframe[columns]
-
-            # Switch to flattened columns
-            dataframe.columns = [
-                "_".join(column) for column in dataframe.columns.to_flat_index()
-            ]
-            return dataframe
-
-        return wrapped_transform
-
-    def _process_dataset(self, manifest: Manifest) -> dd.DataFrame:
-        """
-        Load the data based on the manifest using a DaskDataloader and call the transform method to
-        process it.
-
-        Returns:
-            A `dd.DataFrame` instance with updated data based on the applied data transformations.
-        """
-        data_loader = DaskDataLoader(manifest=manifest, component_spec=self.spec)
-        dataframe = data_loader.load_dataframe()
-
-        # Call the component setup method with user provided argument
-        self.setup(**self.user_arguments)
-
-        # Create meta dataframe with expected format
-        meta_dict = {"id": pd.Series(dtype="object")}
-        for subset_name, subset in self.spec.produces.items():
-            for field_name, field in subset.fields.items():
-                meta_dict[f"{subset_name}_{field_name}"] = pd.Series(
-                    dtype=pd.ArrowDtype(field.type.value),
-                )
-        meta_df = pd.DataFrame(meta_dict).set_index("id")
-
-        wrapped_transform = self.wrap_transform(self.transform, spec=self.spec)
-
-        # Call the component transform method for each partition
-        dataframe = dataframe.map_partitions(
-            wrapped_transform,
-            meta=meta_df,
-        )
-
-        # Clear divisions if component spec indicates that the index is changed
-        if self._infer_index_change():
-            dataframe.clear_divisions()
-
-        return dataframe
-
-    def _infer_index_change(self) -> bool:
-        """Infer if this component changes the index based on its component spec."""
-        if not self.spec.accepts_additional_subsets:
-            return True
-        if not self.spec.outputs_additional_subsets:
-            return True
-        for subset in self.spec.consumes.values():
-            if not subset.additional_fields:
-                return True
-        return any(
-            not subset.additional_fields for subset in self.spec.produces.values()
-        )
+        raise NotImplementedError
 
 
-class WriteComponent(Component):
-    """Base class for a Fondant write component."""
+class DaskWriteComponent(BaseComponent):
+    """Component that accepts a Dask DataFrame and writes its contents."""
 
-    @staticmethod
-    def optional_fondant_arguments() -> t.List[str]:
-        return ["output_manifest_path"]
+    def write(self, dataframe: dd.DataFrame) -> None:
+        raise NotImplementedError
 
-    def _load_or_create_manifest(self) -> Manifest:
-        return Manifest.from_file(self.input_manifest_path)
 
-    @abstractmethod
-    def write(self, *args, **kwargs):
-        """
-        Abstract method to write a dataframe to a final custom location.
-
-        Args:
-            args: The dataframe will be passed in as a positional argument
-            kwargs: Arguments provided to the component are passed as keyword arguments
-        """
-
-    def _process_dataset(self, manifest: Manifest) -> None:
-        """
-        Creates a DataLoader using the provided manifest and loads the input dataframe using the
-        `load_dataframe` instance, and  applies data transformations to it using the `transform`
-        method implemented by the derived class. Returns a single dataframe.
-
-        Returns:
-            A `dd.DataFrame` instance with updated data based on the applied data transformations.
-        """
-        data_loader = DaskDataLoader(manifest=manifest, component_spec=self.spec)
-        dataframe = data_loader.load_dataframe()
-        self.write(dataframe, **self.user_arguments)
-
-    def _write_data(self, dataframe: dd.DataFrame, *, manifest: Manifest):
-        """Create a data writer given a manifest and writes out the index and subsets."""
-
-    def upload_manifest(self, manifest: Manifest, save_path: str):
-        pass
+Component = t.TypeVar("Component", bound=BaseComponent)
+"""Component type which can represents any of the subclasses of BaseComponent"""

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -1,0 +1,377 @@
+"""
+This Python module defines abstract base class for components in the Fondant data processing
+framework, providing a standardized interface for extending loading and transforming components.
+The loading component is the first component that loads the initial dataset and the transform
+components take care of processing, filtering and extending the data.
+"""
+
+import argparse
+import json
+import logging
+import typing as t
+from abc import abstractmethod
+from pathlib import Path
+
+import dask.dataframe as dd
+import pandas as pd
+
+from fondant.component import (
+    Component,
+    DaskLoadComponent,
+    DaskTransformComponent,
+    DaskWriteComponent,
+    PandasTransformComponent,
+)
+from fondant.component_spec import Argument, ComponentSpec, kubeflow2python_type
+from fondant.data_io import DaskDataLoader, DaskDataWriter
+from fondant.manifest import Manifest
+
+logger = logging.getLogger(__name__)
+
+
+class Executor(t.Generic[Component]):
+    """An executor executes a Component."""
+
+    def __init__(
+        self,
+        spec: ComponentSpec,
+        *,
+        input_manifest_path: t.Union[str, Path],
+        output_manifest_path: t.Union[str, Path],
+        metadata: t.Dict[str, t.Any],
+        user_arguments: t.Dict[str, Argument],
+    ) -> None:
+        self.spec = spec
+        self.input_manifest_path = input_manifest_path
+        self.output_manifest_path = output_manifest_path
+        self.metadata = metadata
+        self.user_arguments = user_arguments
+
+    @classmethod
+    def from_file(
+        cls,
+        path: t.Union[str, Path] = "../fondant_component.yaml",
+    ) -> "Executor":
+        """Create an executor from a component spec file.
+
+        Args:
+            path: Path to the component spec file
+        """
+        component_spec = ComponentSpec.from_file(path)
+        return cls.from_spec(component_spec)
+
+    @classmethod
+    def from_args(cls) -> "Executor":
+        """Create an executor from a passed argument containing the specification as a dict."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--component_spec", type=json.loads)
+        args, _ = parser.parse_known_args()
+
+        if "component_spec" not in args:
+            msg = "Error: The --component_spec argument is required."
+            raise ValueError(msg)
+
+        component_spec = ComponentSpec(args.component_spec)
+
+        return cls.from_spec(component_spec)
+
+    @classmethod
+    def from_spec(cls, component_spec: ComponentSpec) -> "Executor":
+        """Create an executor from a component spec."""
+        args_dict = vars(cls._add_and_parse_args(component_spec))
+
+        if "component_spec" in args_dict:
+            args_dict.pop("component_spec")
+        input_manifest_path = args_dict.pop("input_manifest_path")
+        output_manifest_path = args_dict.pop("output_manifest_path")
+        metadata = args_dict.pop("metadata")
+
+        metadata = json.loads(metadata) if metadata else {}
+
+        return cls(
+            component_spec,
+            input_manifest_path=input_manifest_path,
+            output_manifest_path=output_manifest_path,
+            metadata=metadata,
+            user_arguments=args_dict,
+        )
+
+    @classmethod
+    def _add_and_parse_args(cls, spec: ComponentSpec):
+        parser = argparse.ArgumentParser()
+        component_arguments = cls._get_component_arguments(spec)
+
+        for arg in component_arguments.values():
+            if arg.name in cls.optional_fondant_arguments():
+                input_required = False
+                default = None
+            elif arg.default:
+                input_required = False
+                default = arg.default
+            else:
+                input_required = True
+                default = None
+
+            parser.add_argument(
+                f"--{arg.name}",
+                type=kubeflow2python_type(arg.type),  # type: ignore
+                required=input_required,
+                default=default,
+                help=arg.description,
+            )
+
+        return parser.parse_args()
+
+    @staticmethod
+    def optional_fondant_arguments() -> t.List[str]:
+        return []
+
+    @staticmethod
+    def _get_component_arguments(spec: ComponentSpec) -> t.Dict[str, Argument]:
+        """
+        Get the component arguments as a dictionary representation containing both input and output
+            arguments of a component
+        Args:
+            spec: the component spec
+        Returns:
+            Input and output arguments of the component.
+        """
+        component_arguments: t.Dict[str, Argument] = {}
+        kubeflow_component_spec = spec.kubeflow_specification
+        component_arguments.update(kubeflow_component_spec.input_arguments)
+        component_arguments.update(kubeflow_component_spec.output_arguments)
+        return component_arguments
+
+    @abstractmethod
+    def _load_or_create_manifest(self) -> Manifest:
+        """Abstract method that returns the dataset manifest."""
+
+    @abstractmethod
+    def _execute_component(
+        self,
+        component: Component,
+        *,
+        manifest: Manifest,
+    ) -> t.Union[None, dd.DataFrame]:
+        """
+        Abstract method to execute a component with the provided manifest.
+
+        Args:
+            component: Component instance to execute
+            manifest: Manifest describing the input data
+
+        Returns:
+            A Dask DataFrame containing the output data
+        """
+
+    def _write_data(self, dataframe: dd.DataFrame, *, manifest: Manifest):
+        """Create a data writer given a manifest and writes out the index and subsets."""
+        data_writer = DaskDataWriter(manifest=manifest, component_spec=self.spec)
+        data_writer.write_dataframe(dataframe)
+
+    def execute(self, component_cls: t.Type[Component]) -> None:
+        """Execute a component.
+
+        Args:
+            component_cls: The class of the component to execute
+        """
+        input_manifest = self._load_or_create_manifest()
+
+        component = component_cls(self.spec, **self.user_arguments)
+        output_df = self._execute_component(component, manifest=input_manifest)
+
+        output_manifest = input_manifest.evolve(component_spec=self.spec)
+
+        self._write_data(dataframe=output_df, manifest=output_manifest)
+
+        self.upload_manifest(output_manifest, save_path=self.output_manifest_path)
+
+    def upload_manifest(self, manifest: Manifest, save_path: t.Union[str, Path]):
+        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+        manifest.to_file(save_path)
+
+
+class DaskLoadExecutor(Executor[DaskLoadComponent]):
+    """Base class for a Fondant load component."""
+
+    @staticmethod
+    def optional_fondant_arguments() -> t.List[str]:
+        return ["input_manifest_path"]
+
+    def _load_or_create_manifest(self) -> Manifest:
+        component_id = self.spec.name.lower().replace(" ", "_")
+        return Manifest.create(
+            base_path=self.metadata["base_path"],
+            run_id=self.metadata["run_id"],
+            component_id=component_id,
+        )
+
+    def _execute_component(
+        self,
+        component: DaskLoadComponent,
+        *,
+        manifest: Manifest,
+    ) -> dd.DataFrame:
+        """This function loads the initial dataframe using the user-provided `load` method.
+
+        Returns:
+            A `dd.DataFrame` instance with initial data.
+        """
+        return component.load()
+
+
+class TransformExecutor(Executor[Component]):
+    """Base class for a Fondant transform component."""
+
+    def _load_or_create_manifest(self) -> Manifest:
+        return Manifest.from_file(self.input_manifest_path)
+
+    def _execute_component(
+        self,
+        component: Component,
+        *,
+        manifest: Manifest,
+    ) -> dd.DataFrame:
+        raise NotImplementedError
+
+
+class DaskTransformExecutor(TransformExecutor[DaskTransformComponent]):
+    def _execute_component(
+        self,
+        component: DaskTransformComponent,
+        *,
+        manifest: Manifest,
+    ) -> dd.DataFrame:
+        """
+        Load the data based on the manifest using a DaskDataloader and call the transform method to
+        process it.
+
+        Returns:
+            A `dd.DataFrame` instance with updated data based on the applied data transformations.
+        """
+        data_loader = DaskDataLoader(manifest=manifest, component_spec=self.spec)
+        dataframe = data_loader.load_dataframe()
+        return component.transform(dataframe)
+
+
+class PandasTransformExecutor(TransformExecutor[PandasTransformComponent]):
+    @staticmethod
+    def wrap_transform(transform: t.Callable, *, spec: ComponentSpec) -> t.Callable:
+        """Factory that creates a function to wrap the component transform function. The wrapper:
+        - Converts the columns to hierarchical format before passing the dataframe to the
+          transform function
+        - Removes extra columns from the returned dataframe which are not defined in the component
+          spec `produces` section
+        - Sorts the columns from the returned dataframe according to the order in the component
+          spec `produces` section to match the order in the `meta` argument passed to Dask's
+          `map_partitions`.
+        - Flattens the returned dataframe columns.
+
+        Args:
+            transform: Transform method to wrap
+            spec: Component specification to base behavior on
+        """
+
+        def wrapped_transform(dataframe: pd.DataFrame) -> pd.DataFrame:
+            # Switch to hierarchical columns
+            dataframe.columns = pd.MultiIndex.from_tuples(
+                tuple(column.split("_")) for column in dataframe.columns
+            )
+
+            # Call transform method
+            dataframe = transform(dataframe)
+
+            # Drop columns not in specification
+            columns = [
+                (subset_name, field)
+                for subset_name, subset in spec.produces.items()
+                for field in subset.fields
+            ]
+            dataframe = dataframe[columns]
+
+            # Switch to flattened columns
+            dataframe.columns = [
+                "_".join(column) for column in dataframe.columns.to_flat_index()
+            ]
+            return dataframe
+
+        return wrapped_transform
+
+    def _execute_component(
+        self,
+        component: PandasTransformComponent,
+        *,
+        manifest: Manifest,
+    ) -> dd.DataFrame:
+        """
+        Load the data based on the manifest using a DaskDataloader and call the component's
+        transform method for each partition of the data.
+
+        Returns:
+            A `dd.DataFrame` instance with updated data based on the applied data transformations.
+        """
+        data_loader = DaskDataLoader(manifest=manifest, component_spec=self.spec)
+        dataframe = data_loader.load_dataframe()
+
+        # Create meta dataframe with expected format
+        meta_dict = {"id": pd.Series(dtype="object")}
+        for subset_name, subset in self.spec.produces.items():
+            for field_name, field in subset.fields.items():
+                meta_dict[f"{subset_name}_{field_name}"] = pd.Series(
+                    dtype=pd.ArrowDtype(field.type.value),
+                )
+        meta_df = pd.DataFrame(meta_dict).set_index("id")
+
+        wrapped_transform = self.wrap_transform(component.transform, spec=self.spec)
+
+        # Call the component transform method for each partition
+        dataframe = dataframe.map_partitions(
+            wrapped_transform,
+            meta=meta_df,
+        )
+
+        # Clear divisions if component spec indicates that the index is changed
+        if self._infer_index_change():
+            dataframe.clear_divisions()
+
+        return dataframe
+
+    def _infer_index_change(self) -> bool:
+        """Infer if this component changes the index based on its component spec."""
+        if not self.spec.accepts_additional_subsets:
+            return True
+        if not self.spec.outputs_additional_subsets:
+            return True
+        for subset in self.spec.consumes.values():
+            if not subset.additional_fields:
+                return True
+        return any(
+            not subset.additional_fields for subset in self.spec.produces.values()
+        )
+
+
+class DaskWriteExecutor(Executor[DaskWriteComponent]):
+    """Base class for a Fondant write component."""
+
+    @staticmethod
+    def optional_fondant_arguments() -> t.List[str]:
+        return ["output_manifest_path"]
+
+    def _load_or_create_manifest(self) -> Manifest:
+        return Manifest.from_file(self.input_manifest_path)
+
+    def _execute_component(
+        self,
+        component: DaskWriteComponent,
+        *,
+        manifest: Manifest,
+    ) -> None:
+        data_loader = DaskDataLoader(manifest=manifest, component_spec=self.spec)
+        dataframe = data_loader.load_dataframe()
+        component.write(dataframe)
+
+    def _write_data(self, dataframe: dd.DataFrame, *, manifest: Manifest):
+        """Create a data writer given a manifest and writes out the index and subsets."""
+
+    def upload_manifest(self, manifest: Manifest, save_path: t.Union[str, Path]):
+        pass

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -11,9 +11,10 @@ try:
 except ImportError:
     from importlib_resources import files  # type: ignore
 
-from fondant.component import ComponentSpec, Manifest
+from fondant.component_spec import ComponentSpec
 from fondant.exceptions import InvalidPipelineDefinition
 from fondant.import_utils import is_kfp_available
+from fondant.manifest import Manifest
 
 if is_kfp_available():
     import kfp

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -9,14 +9,20 @@ import pandas as pd
 import pytest
 import yaml
 from fondant.component import (
-    Component,
+    DaskLoadComponent,
     DaskTransformComponent,
-    LoadComponent,
+    DaskWriteComponent,
     PandasTransformComponent,
-    WriteComponent,
 )
 from fondant.component_spec import ComponentSpec
 from fondant.data_io import DaskDataLoader, DaskDataWriter
+from fondant.executor import (
+    DaskLoadExecutor,
+    DaskTransformExecutor,
+    DaskWriteExecutor,
+    Executor,
+    PandasTransformExecutor,
+)
 from fondant.manifest import Manifest
 
 components_path = Path(__file__).parent / "example_specs/components"
@@ -48,10 +54,24 @@ def _patched_data_writing(monkeypatch):
 
     monkeypatch.setattr(DaskDataWriter, "write_dataframe", mocked_write_dataframe)
     monkeypatch.setattr(
-        Component,
+        Executor,
         "upload_manifest",
         lambda self, manifest, save_path: None,
     )
+
+
+def patch_method_class(method):
+    """Patch a method on a class instead of an instance. The returned method can be passed to
+    `mock.patch.object` as the `wraps` argument.
+    """
+    m = mock.MagicMock()
+
+    def wrapper(self, *args, **kwargs):
+        m(*args, **kwargs)
+        return method(self, *args, **kwargs)
+
+    wrapper.mock = m
+    return wrapper
 
 
 def test_component_arguments():
@@ -74,7 +94,7 @@ def test_component_arguments():
         "None",
     ]
 
-    class MyComponent(Component):
+    class MyExecutor(Executor):
         """Base component with dummy methods so it can be instantiated."""
 
         def _load_or_create_manifest(self) -> Manifest:
@@ -83,8 +103,8 @@ def test_component_arguments():
         def _process_dataset(self, manifest: Manifest) -> t.Union[None, dd.DataFrame]:
             pass
 
-    component = MyComponent.from_args()
-    assert component.user_arguments == {
+    executor = MyExecutor.from_args()
+    assert executor.user_arguments == {
         "string_default_arg": "foo",
         "integer_default_arg": 1,
         "float_default_arg": 3.14,
@@ -121,21 +141,25 @@ def test_load_component():
         yaml_file_to_json_string(components_path / "component.yaml"),
     ]
 
-    class MyLoadComponent(LoadComponent):
-        def load(self, *, flag, value):
-            assert flag == "success"
-            assert value == 1
+    class MyLoadComponent(DaskLoadComponent):
+        def __init__(self, *args, flag, value):
+            self.flag = flag
+            self.value = value
 
+        def load(self):
+            assert self.flag == "success"
+            assert self.value == 1
             data = {
                 "id": [0, 1],
                 "captions_data": ["hello world", "this is another caption"],
             }
             return dd.DataFrame.from_dict(data, npartitions=N_PARTITIONS)
 
-    component = MyLoadComponent.from_args()
-    with mock.patch.object(MyLoadComponent, "load", wraps=component.load) as load:
-        component.run()
-        load.assert_called_once()
+    executor = DaskLoadExecutor.from_args()
+    load = patch_method_class(MyLoadComponent.load)
+    with mock.patch.object(MyLoadComponent, "load", load):
+        executor.execute(MyLoadComponent)
+        load.mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("_patched_data_loading", "_patched_data_writing")
@@ -158,20 +182,25 @@ def test_dask_transform_component():
     ]
 
     class MyDaskComponent(DaskTransformComponent):
-        def transform(self, dataframe, *, flag, value):
-            assert flag == "success"
-            assert value == 1
+        def __init__(self, *args, flag, value):
+            self.flag = flag
+            self.value = value
+
+        def transform(self, dataframe):
+            assert self.flag == "success"
+            assert self.value == 1
             assert isinstance(dataframe, dd.DataFrame)
             return dataframe
 
-    component = MyDaskComponent.from_args()
+    executor = DaskTransformExecutor.from_args()
+    transform = patch_method_class(MyDaskComponent.transform)
     with mock.patch.object(
         MyDaskComponent,
         "transform",
-        wraps=component.transform,
-    ) as transform:
-        component.run()
-        transform.assert_called_once()
+        transform,
+    ):
+        executor.execute(MyDaskComponent)
+        transform.mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("_patched_data_loading", "_patched_data_writing")
@@ -194,7 +223,7 @@ def test_pandas_transform_component():
     ]
 
     class MyPandasComponent(PandasTransformComponent):
-        def setup(self, *, flag, value):
+        def __init__(self, *args, flag, value):
             assert flag == "success"
             assert value == 1
 
@@ -202,17 +231,17 @@ def test_pandas_transform_component():
             assert isinstance(dataframe, pd.DataFrame)
             return dataframe.rename(columns={"images": "embeddings"})
 
-    component = MyPandasComponent.from_args()
-    setup = mock.patch.object(MyPandasComponent, "setup", wraps=component.setup)
-    transform = mock.patch.object(
+    executor = PandasTransformExecutor.from_args()
+    init = patch_method_class(MyPandasComponent.__init__)
+    transform = patch_method_class(MyPandasComponent.transform)
+    with mock.patch.object(MyPandasComponent, "__init__", init), mock.patch.object(
         MyPandasComponent,
         "transform",
-        wraps=component.transform,
-    )
-    with setup as setup, transform as transform:
-        component.run()
-        setup.assert_called_once()
-        assert transform.call_count == N_PARTITIONS
+        transform,
+    ):
+        executor.execute(MyPandasComponent)
+        init.mock.assert_called_once()
+        assert transform.mock.call_count == N_PARTITIONS
 
 
 def test_wrap_transform():
@@ -282,7 +311,7 @@ def test_wrap_transform():
         ]
         return dataframe
 
-    wrapped_transform = PandasTransformComponent.wrap_transform(transform, spec=spec)
+    wrapped_transform = PandasTransformExecutor.wrap_transform(transform, spec=spec)
     output_df = wrapped_transform(input_df)
 
     # Check column flattening, trimming, and ordering
@@ -306,13 +335,18 @@ def test_write_component():
         yaml_file_to_json_string(components_path / "component.yaml"),
     ]
 
-    class MyWriteComponent(WriteComponent):
-        def write(self, dataframe, *, flag, value):
-            assert flag == "success"
-            assert value == 1
+    class MyWriteComponent(DaskWriteComponent):
+        def __init__(self, *args, flag, value):
+            self.flag = flag
+            self.value = value
+
+        def write(self, dataframe):
+            assert self.flag == "success"
+            assert self.value == 1
             assert isinstance(dataframe, dd.DataFrame)
 
-    component = MyWriteComponent.from_args()
-    with mock.patch.object(MyWriteComponent, "write", wraps=component.write) as write:
-        component.run()
-        write.assert_called_once()
+    executor = DaskWriteExecutor.from_args()
+    write = patch_method_class(MyWriteComponent.write)
+    with mock.patch.object(MyWriteComponent, "write", write):
+        executor.execute(MyWriteComponent)
+        write.mock.assert_called_once()


### PR DESCRIPTION
This PR follows up on the PoC presented in #268

---

Fixes #257 

It splits the implementation and execution of components, this has some advantages:

- Pandas components can use `__init__` instead of setup, which is probably more familiar to users
- Other components can use `__init__` as well instead of receiving all arguments to their transform or equivalent method, aligning implementation of different component types
- Component implementation and execution should be easier to test separately

I borrowed the executor terminology from KfP.

---

Fixes #203 

Since I had to update all the components, I also switched some of them to subclass `PandasTransformComponent` instead of `DaskTransformComponent`.

---

These changes open some opportunities for additional improvements, but I propose to tackle those as separate PRs as this PR is already quite huge due to all the changes to the components.

- [ ] #300
- [ ] #301