### PR TITLE
[DataComp] Add image downloading component

### DIFF
--- a/components/download_images/Dockerfile
+++ b/components/download_images/Dockerfile
@@ -11,7 +11,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Install Fondant
 # This is split from other requirements to leverage caching
-ARG FONDANT_VERSION=main
+ARG FONDANT_VERSION=6d2251ea24645a05721d428a01e4a9d8c963baba
 RUN pip3 install fondant[aws,azure,gcp]@git+https://github.com/ml6team/fondant@${FONDANT_VERSION}
 
 # Set the working directory to the component folder

--- a/components/download_images/fondant_component.yaml
+++ b/components/download_images/fondant_component.yaml
@@ -1,15 +1,15 @@
 name: Download images
 description: Component that downloads images based on URLs
-image: ghcr.io/ml6team/download_images:dev
+image: ghcr.io/ml6team/download_images:main
 
 consumes:
-  images:
+  image:
     fields:
       url:
         type: string
 
 produces:
-  images:
+  image:
     fields:
       data:
         type: binary

--- a/components/download_images/fondant_component.yaml
+++ b/components/download_images/fondant_component.yaml
@@ -1,6 +1,6 @@
 name: Download images
 description: Component that downloads images based on URLs
-image: ghcr.io/ml6team/download_images:5a957d4a3acc3af7140adc6766309874ab21e570
+image: ghcr.io/ml6team/download_images:dev
 
 consumes:
   image:

--- a/components/download_images/fondant_component.yaml
+++ b/components/download_images/fondant_component.yaml
@@ -1,6 +1,6 @@
 name: Download images
 description: Component that downloads images based on URLs
-image: ghcr.io/ml6team/download_images:main
+image: ghcr.io/ml6team/download_images:5a957d4a3acc3af7140adc6766309874ab21e570
 
 consumes:
   image:

--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -144,9 +144,9 @@ class DownloadImagesComponent(DaskTransformComponent):
             meta={0: bytes, 1: int, 2: int},
         )
         dataframe.columns = [
-            "images_data",
-            "images_width",
-            "images_height",
+            "image_data",
+            "image_width",
+            "image_height",
         ]
 
         # Remove images that could not be fetched

--- a/examples/pipelines/datacomp/pipeline.py
+++ b/examples/pipelines/datacomp/pipeline.py
@@ -7,14 +7,13 @@ sys.path.append("../")
 
 from pipeline_configs import PipelineConfigs
 
-from fondant.compiler import DockerCompiler
 from fondant.pipeline import ComponentOp, Pipeline, Client
 
 logger = logging.getLogger(__name__)
 
 # Initialize pipeline and client
 pipeline = Pipeline(
-    pipeline_name="Datacomp filtering pipeline",
+    pipeline_name="datacomp",
     pipeline_description="A pipeline for filtering the Datacomp dataset",
     # base_path=PipelineConfigs.BASE_PATH,
     base_path="/Users/nielsrogge/Documents/fondant_artifacts_datacomp",
@@ -69,13 +68,3 @@ pipeline.add_op(filter_image_resolution_op, dependencies=load_from_hub_op)
 pipeline.add_op(filter_complexity_op, dependencies=filter_image_resolution_op)
 pipeline.add_op(cluster_image_embeddings_op, dependencies=filter_complexity_op)
 # TODO add more ops
-
-# compile
-if __name__ == "__main__":
-    compiler = DockerCompiler()
-    # mount the gcloud credentials to the container
-    extra_volumes = [
-        "$HOME/.config/gcloud/application_default_credentials.json:/root/.config/gcloud/application_default_credentials.json:ro"
-    ]
-    compiler.compile(pipeline=pipeline, extra_volumes=extra_volumes)
-    logger.info("Run `docker compose up` to run the pipeline.")

--- a/examples/pipelines/datacomp/pipeline.py
+++ b/examples/pipelines/datacomp/pipeline.py
@@ -41,10 +41,16 @@ load_from_hub_op = ComponentOp(
         "n_rows_to_load": 100,
     },
 )
+
+download_images_op = ComponentOp.from_registry(
+    name="download_images",
+)
+
 filter_image_resolution_op = ComponentOp.from_registry(
     name="filter_image_resolution",
     arguments={"min_image_dim": 200, "max_aspect_ratio": 3},
 )
+
 filter_complexity_op = ComponentOp(
     component_dir="components/filter_text_complexity",
     arguments={
@@ -54,6 +60,7 @@ filter_complexity_op = ComponentOp(
         "min_num_actions": 1,
     },
 )
+
 cluster_image_embeddings_op = ComponentOp(
     component_dir="components/cluster_image_embeddings",
     arguments={
@@ -64,7 +71,8 @@ cluster_image_embeddings_op = ComponentOp(
 
 # add ops to pipeline
 pipeline.add_op(load_from_hub_op)
-pipeline.add_op(filter_image_resolution_op, dependencies=load_from_hub_op)
-pipeline.add_op(filter_complexity_op, dependencies=filter_image_resolution_op)
-pipeline.add_op(cluster_image_embeddings_op, dependencies=filter_complexity_op)
+pipeline.add_op(download_images_op, dependencies=load_from_hub_op)
+# pipeline.add_op(filter_image_resolution_op, dependencies=load_from_hub_op)
+# pipeline.add_op(filter_complexity_op, dependencies=filter_image_resolution_op)
+# pipeline.add_op(cluster_image_embeddings_op, dependencies=filter_complexity_op)
 # TODO add more ops

--- a/scripts/build_components.sh
+++ b/scripts/build_components.sh
@@ -75,7 +75,7 @@ for dir in "${components_to_build[@]}"; do
 
   echo "Updating the image version in the fondant_component.yaml with:"
   echo "${full_image_names[0]}"
-  sed -i "s|^image: .*|image: ${full_image_names[0]}|" fondant_component.yaml
+  sed -i '' "s|^image: .*|image: ${full_image_names[0]}|" fondant_component.yaml
 
   args=()
 

--- a/scripts/build_components.sh
+++ b/scripts/build_components.sh
@@ -7,7 +7,7 @@ function usage {
   echo "  -t,  --tag <value>                 Tag to add to image, repeatable
                                              The first tag is set in the component specifications"
   echo "  -c,  --cache <value>               Use registry caching when building the components (default:false)"
-  echo "  -d,  --component-dirs <value>      Directory containing components to build as subdirectories.
+  echo "  -d,  --components-dir <value>      Directory containing components to build as subdirectories.
                                              The path should be relative to the root directory (default:components)"
   echo "  -n, --namespace <value>            The namespace for the built images, should match the github organization (default: ml6team)"
   echo "  -co, --component <value>           Specific component to build. Pass the component subdirectory name(s) to build


### PR DESCRIPTION
This PR adds an image download component to the DataComp pipeline.

It's required by the subsequent text spotting components.

Some things to include in the docs:

- had to install `docker buildx` to make pushing of components work (run `docker buildx install`)
- small fix in the `build_components.sh` script to fix [this](https://stackoverflow.com/questions/29081799/sed-1-invalid-command-code-f)
- running the pipeline locally worked when running `fondant run pipeline:pipeline --local`