### PR TITLE
Unify manifest save path

### DIFF
--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -206,7 +206,7 @@ class Executor(t.Generic[Component]):
 
     def upload_manifest(self, manifest: Manifest, save_path: t.Union[str, Path]):
         """
-        Uploads a Manifest object to the specified destination.
+        Uploads the manifest to the specified destination.
 
         If the save_path points to the kubeflow output artifact temporary path,
         it will be saved both in a specific base path and the native kfp artifact path.

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -214,6 +214,8 @@ class Executor(t.Generic[Component]):
             save_path_base_path = (
                 f"{self.metadata['base_path']}/{safe_component_name}/manifest.json"
             )
+            print("save")
+            print(save_path_base_path)
             Path(save_path_base_path).parent.mkdir(parents=True, exist_ok=True)
             manifest.to_file(save_path_base_path)
             # Native kfp artifact path

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -205,7 +205,7 @@ class Executor(t.Generic[Component]):
         self.upload_manifest(output_manifest, save_path=self.output_manifest_path)
 
     def upload_manifest(self, manifest: Manifest, save_path: t.Union[str, Path]):
-        print("save path")
+        print("save paths")
         print(save_path)
         kfp_minio_artifact_path = "/tmp/outputs/output_manifest_path/data"  # nosec
         if save_path == kfp_minio_artifact_path:

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -205,8 +205,23 @@ class Executor(t.Generic[Component]):
         self.upload_manifest(output_manifest, save_path=self.output_manifest_path)
 
     def upload_manifest(self, manifest: Manifest, save_path: t.Union[str, Path]):
-        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
-        manifest.to_file(save_path)
+        print("save path")
+        print(save_path)
+        kfp_minio_artifact_path = "/tmp/outputs/output_manifest_path/data"  # nosec
+        if save_path == kfp_minio_artifact_path:
+            # Save copy of manifest to expected directory in the base path if
+            safe_component_name = self.spec.name.replace(" ", "_").lower()
+            save_path_base_path = (
+                f"{self.metadata['base_path']}/{safe_component_name}/manifest.json"
+            )
+            Path(save_path_base_path).parent.mkdir(parents=True, exist_ok=True)
+            manifest.to_file(save_path_base_path)
+            # Native kfp artifact path
+            manifest.to_file(save_path)
+
+        else:
+            Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+            manifest.to_file(save_path)
 
 
 class DaskLoadExecutor(Executor[DaskLoadComponent]):


### PR DESCRIPTION
Related to #313 


The local and remote runner store the manifest in different locations: 

* For the local runner, the manifest save path is set at compile time to a fixed path that we specify `{base_path}/{component_name}/manifest.json"`   

* For the remote runner (kfp), the `output_manifest_path` is set as an output artifact type. This is needed for chaining component together. The save path in this case is save internally within the VM `/tmp/outputs/output_manifest_path/data` and then mapped to minio storage after the component run (which then gets mapped to a cloud storage). The mapping saves the artifact to the specified base path followed by a fixed file structure that cannot be changed and also stored. It is also stored as zip file which contains the written text file (manifest)

Example:
```
minio://soy-audio-379412_kfp-artifacts/artifacts/datacomp-filtering-pipeline-wvglp/2023/07/26/datacomp-filtering-pipeline-wvglp-3788902962/load-from-hub-output_manifest_path.tgz
```

where `/soy-audio-379412_kfp-artifacts` is the artifact bucket specified when deploying KFP. 

This PR unifies the manifest save path for both local and remote runner. It checks whether the `save_path` matches the expected kubeflow path and if so, save it both to the expected kfp artifact path (needed for chaining component) and the custom path that we require for caching. 

It's not the most optimal solution since we're writing the file twice but I don't see any other clear cut solution. 

@ChristiaensBert I think this might also fix some issues with the data explorer.
