### PR TITLE
[Scripts] Fix build_components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ MANIFEST
 
 # docker artifacts
 examples/pipelines/**/docker-compose.yml
+
+# yaml-e files
+*.yaml-e

--- a/scripts/build_components.sh
+++ b/scripts/build_components.sh
@@ -75,7 +75,7 @@ for dir in "${components_to_build[@]}"; do
 
   echo "Updating the image version in the fondant_component.yaml with:"
   echo "${full_image_names[0]}"
-  sed -i "s|^image: .*|image: ${full_image_names[0]}|" fondant_component.yaml
+  sed -i -e "s|^image: .*|image: ${full_image_names[0]}|" fondant_component.yaml
 
   args=()
 


### PR DESCRIPTION
This PR ensures that the `build_components.sh` script can run on both Linux and MacOS.

As suggested by @RobbeSneyders [here](https://github.com/ml6team/fondant/pull/303#discussion_r1269909421), thanks!