### PR TITLE
[Commoncrawl pipeline] Add webpage url filter component

### DIFF
--- a/examples/pipelines/commoncrawl/components/filter_webpage_urls/Dockerfile
+++ b/examples/pipelines/commoncrawl/components/filter_webpage_urls/Dockerfile
@@ -1,0 +1,23 @@
+FROM --platform=linux/amd64 python:3.8-slim
+
+## System dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install git -y
+
+# install requirements
+COPY requirements.txt /
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Install Fondant
+# This is split from other requirements to leverage caching
+ARG FONDANT_VERSION=main
+RUN pip3 install git+https://github.com/ml6team/fondant@${FONDANT_VERSION}#egg=fondant[aws]
+
+# Set the working directory to the component folder
+WORKDIR /component/src
+
+# Copy over src-files
+COPY src/ .
+
+ENTRYPOINT ["python", "main.py"]

--- a/examples/pipelines/commoncrawl/components/filter_webpage_urls/fondant_component.yaml
+++ b/examples/pipelines/commoncrawl/components/filter_webpage_urls/fondant_component.yaml
@@ -1,0 +1,25 @@
+name: Filter webpage urls
+description: Component that filters webpage urls based on given blacklist categories
+# image: ghcr.io/ml6team/filter_webpage_urls:latest
+image: 050243278346.dkr.ecr.us-east-1.amazonaws.com/filter_webpage_urls:latest
+
+consumes:
+  webpage:
+    fields:
+      url:
+        type: string
+      html:
+        type: string
+
+produces:
+  webpage:  
+    fields:
+      url:
+        type: string
+      html:
+        type: string
+
+args:
+  categories:
+    description: Categories of blacklisted webpages to filter out
+    type: list

--- a/examples/pipelines/commoncrawl/components/filter_webpage_urls/requirements.txt
+++ b/examples/pipelines/commoncrawl/components/filter_webpage_urls/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.31.0
+s3fs

--- a/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/main.py
+++ b/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/main.py
@@ -1,0 +1,54 @@
+import os
+import logging
+from typing import List
+
+import dask.dataframe as dd
+from urllib.parse import urlparse
+
+from fondant.component import DaskTransformComponent
+from fondant.executor import DaskTransformExecutor
+
+from utils.file_utils import download_tar_file, get_urls_from_file
+
+logger = logging.getLogger(__name__)
+
+BLACKLIST_DIR = "/tmp/blacklists"
+BLACKLIST_URL = "http://dsi.ut-capitole.fr/blacklists/download/blacklists.tar.gz"
+
+
+def get_blacklisted_domains(blacklist_dir: str, categories: List[str]) -> List[str]:
+    result = []
+    for category in categories:
+        path = os.path.join(blacklist_dir, "blacklists", category, "domains")
+        urls = get_urls_from_file(path)
+        result.extend(urls)
+
+    return result
+
+
+class FilterWebpageUrls(DaskTransformComponent):
+    def __init__(self, *_, categories: List[str] = None):
+        self.categories = categories
+
+    def transform(self, dataframe: dd.DataFrame) -> dd.DataFrame:
+        logger.info("Length of dataframe before filtering: %s", len(dataframe))
+
+        download_tar_file(BLACKLIST_URL, BLACKLIST_DIR)
+        blacklisted_domains = get_blacklisted_domains(BLACKLIST_DIR, self.categories)
+
+        dataframe["webpage_base_url"] = dataframe["webpage_url"].apply(
+            lambda x: urlparse(x).netloc, meta=("webpage_url", "object")
+        )
+
+        filtered_df = dataframe[
+            ~dataframe["webpage_base_url"].isin(blacklisted_domains)
+        ]
+        filtered_df = filtered_df.drop(columns=["webpage_base_url"])
+
+        logger.info("Length of dataframe after filtering: %s", len(filtered_df))
+        return filtered_df
+
+
+if __name__ == "__main__":
+    executor = DaskTransformExecutor.from_args()
+    executor.execute(FilterWebpageUrls)

--- a/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/main.py
+++ b/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/main.py
@@ -28,11 +28,19 @@ def get_blacklisted_domains(blacklist_dir: str, categories: List[str]) -> Set[st
 
 class FilterWebpageUrls(DaskTransformComponent):
     def __init__(self, *_, categories: List[str] = None):
+        """Filters out webpages from the given categories.
+        Args:
+            categories: The categories to filter out.
+        """
         self.categories = categories
 
     def transform(self, dataframe: dd.DataFrame) -> dd.DataFrame:
-        logger.info("Length of dataframe before filtering: %s", len(dataframe))
-
+        """Filters out webpages from the given blacklist categories.
+        Args:
+            dataframe: The dataframe containing the webpages.
+        Returns:
+            The filtered dataframe without blacklist URLs.
+        """
         download_tar_file(BLACKLIST_URL, BLACKLIST_DIR)
         blacklisted_domains = get_blacklisted_domains(BLACKLIST_DIR, self.categories)
 

--- a/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/main.py
+++ b/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/main.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from typing import List
+from typing import List, Set
 
 import dask.dataframe as dd
 from urllib.parse import urlparse
@@ -16,12 +16,12 @@ BLACKLIST_DIR = "/tmp/blacklists"
 BLACKLIST_URL = "http://dsi.ut-capitole.fr/blacklists/download/blacklists.tar.gz"
 
 
-def get_blacklisted_domains(blacklist_dir: str, categories: List[str]) -> List[str]:
-    result = []
+def get_blacklisted_domains(blacklist_dir: str, categories: List[str]) -> Set[str]:
+    result = set()
     for category in categories:
         path = os.path.join(blacklist_dir, "blacklists", category, "domains")
         urls = get_urls_from_file(path)
-        result.extend(urls)
+        result.update(urls)
 
     return result
 

--- a/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/utils/file_utils.py
+++ b/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/utils/file_utils.py
@@ -1,0 +1,29 @@
+import os
+import requests
+import tarfile
+
+from typing import List
+
+
+def download_tar_file(blacklist_url: str, output_folder: str) -> None:
+    """Download the blacklisted urls from the given url and extract them to the given folder."""
+    response = requests.get(blacklist_url)
+    response.raise_for_status()
+
+    temp_file_path = "temp.tar.gz"
+    with open(temp_file_path, "wb") as f:
+        f.write(response.content)
+
+    with tarfile.open(temp_file_path, "r:gz") as tar:
+        tar.extractall(output_folder)
+
+    os.remove(temp_file_path)
+
+
+def get_urls_from_file(blacklist_file: str) -> List[str]:
+    try:
+        with open(blacklist_file) as f:
+            urls = f.readlines()
+            return [url.strip() for url in urls]
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Blacklist file {blacklist_file} does not exist")

--- a/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/utils/file_utils.py
+++ b/examples/pipelines/commoncrawl/components/filter_webpage_urls/src/utils/file_utils.py
@@ -5,8 +5,12 @@ import tarfile
 from typing import List
 
 
-def download_tar_file(blacklist_url: str, output_folder: str) -> None:
-    """Download the blacklisted urls from the given url and extract them to the given folder."""
+def download_tar_file(blacklist_url: str, output_folder: str):
+    """Download the blacklisted urls from the given url and extract them to the given folder.
+    Args:
+        blacklist_url: The url to download the blacklisted urls from.
+        output_folder: The folder to extract the blacklisted urls to.
+    """
     response = requests.get(blacklist_url)
     response.raise_for_status()
 
@@ -21,6 +25,12 @@ def download_tar_file(blacklist_url: str, output_folder: str) -> None:
 
 
 def get_urls_from_file(blacklist_file: str) -> List[str]:
+    """Get the urls from the given file.
+    Args:
+        blacklist_file: The file to get the urls from.
+    Returns:
+        A list of urls.
+    """
     try:
         with open(blacklist_file) as f:
             urls = f.readlines()


### PR DESCRIPTION
This PR adds a URL filter component to filter out webpages from a given category/categories of blacklisted urls. The database of blacklists is from https://dsi.ut-capitole.fr/blacklists.