### PR TITLE
Remove node_pool_name arguments in examples

### DIFF
--- a/examples/pipelines/controlnet-interior-design/pipeline.py
+++ b/examples/pipelines/controlnet-interior-design/pipeline.py
@@ -47,7 +47,6 @@ caption_images_op = ComponentOp.from_registry(
         "max_new_tokens": 50,
     },
     number_of_gpus=1,
-    node_pool_name="model-inference-pool",
 )
 segment_images_op = ComponentOp.from_registry(
     name="segment_images",
@@ -56,7 +55,6 @@ segment_images_op = ComponentOp.from_registry(
         "batch_size": 2,
     },
     number_of_gpus=1,
-    node_pool_name="model-inference-pool",
 )
 
 write_to_hub_controlnet = ComponentOp(

--- a/examples/pipelines/finetune_stable_diffusion/pipeline.py
+++ b/examples/pipelines/finetune_stable_diffusion/pipeline.py
@@ -68,7 +68,6 @@ caption_images_op = ComponentOp.from_registry(
         "max_new_tokens": 50,
     },
     number_of_gpus=1,
-    node_pool_name="model-inference-pool",
 )
 
 write_to_hub = ComponentOp(
@@ -80,7 +79,6 @@ write_to_hub = ComponentOp(
         "image_column_names": ["images_data"],
     },
     number_of_gpus=1,
-    node_pool_name="model-inference-pool",
 )
 
 pipeline = Pipeline(pipeline_name=pipeline_name, base_path=PipelineConfigs.BASE_PATH)


### PR DESCRIPTION
Our current example pipelines don't work anymore out of the box since https://github.com/ml6team/fondant/pull/327 requires `node_pool_label` and `node_pool_name` to either both be set, or neither.

This PR removes the `node_pool_name` since it is very specific to our own kfp cluster anyway.