### PR TITLE
Adjust bandit settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,11 @@ repos:
         files: |
             (?x)^(
                 src/.*|
-                test/.*|
                 examples/.*|
+                tests/.*|
             )$
-        args: ["-f", "custom", "-q"]
+        args: ["-f", "custom", "-q", "-c", "pyproject.toml", "-r"]
+        additional_dependencies: [".[toml]"]
 
   - repo: https://github.com/psf/black
     rev: 23.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,12 @@ repos:
       - id: bandit
         name: bandit
         types: [python]
-        files: "^src/"
+        files: |
+            (?x)^(
+                src/.*|
+                test/.*|
+                examples/.*|
+            )$
         args: ["-f", "custom", "-q"]
 
   - repo: https://github.com/psf/black

--- a/examples/pipelines/commoncrawl/components/extract_image_licenses/src/utils/image_utils.py
+++ b/examples/pipelines/commoncrawl/components/extract_image_licenses/src/utils/image_utils.py
@@ -23,7 +23,7 @@ def get_full_image_url(image_url: str, webpage_url: str) -> str:
             pos = image_url.index("?")
             image_url = image_url[:pos]
         except:
-            pass
+            logger.info("No query parameter found in the image URL.")
 
     return image_url
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,6 @@ line-length = 100  # Only for comments, as code is handled by black at length 88
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
+[tool.bandit]
+skips = ["B101", "B108", "B307", "B404", "B601", "B602"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,4 +98,9 @@ line-length = 100  # Only for comments, as code is handled by black at length 88
 convention = "google"
 
 [tool.bandit]
-skips = ["B101", "B108", "B307", "B404", "B601", "B602"]
+skips = ["B108", "B307", "B404", "B602"]
+
+[tool.bandit.assert_used]
+skips = ["tests/test_*.py"]
+
+


### PR DESCRIPTION
To avoid security breaches bandit should scan the pipeline example folders and tests as well. 