### PR TITLE
Bugfix partitions Load from Hub

### DIFF
--- a/components/load_from_hf_hub/src/main.py
+++ b/components/load_from_hf_hub/src/main.py
@@ -54,14 +54,13 @@ class LoadFromHubComponent(DaskLoadComponent):
         # 4) Optional: only return specific amount of rows
         if self.n_rows_to_load is not None:
             partitions_length = 0
-            npartitions = 0
-            for npartitions, partition in enumerate(dask_df.partitions):
+            npartitions = 1
+            for npartitions, partition in enumerate(dask_df.partitions, start=1):
                 if partitions_length >= self.n_rows_to_load:
                     logger.info(f"""Required number of partitions to load\n
                     {self.n_rows_to_load} is {npartitions}""")
                     break
                 partitions_length += len(partition)
-            npartitions = npartitions + 1
             dask_df = dask_df.head(self.n_rows_to_load, npartitions=npartitions)
             dask_df = dd.from_pandas(dask_df, npartitions=npartitions)
 

--- a/components/load_from_hf_hub/src/main.py
+++ b/components/load_from_hf_hub/src/main.py
@@ -54,12 +54,14 @@ class LoadFromHubComponent(DaskLoadComponent):
         # 4) Optional: only return specific amount of rows
         if self.n_rows_to_load is not None:
             partitions_length = 0
+            npartitions = 0
             for npartitions, partition in enumerate(dask_df.partitions):
                 if partitions_length >= self.n_rows_to_load:
                     logger.info(f"""Required number of partitions to load\n
                     {self.n_rows_to_load} is {npartitions}""")
                     break
                 partitions_length += len(partition)
+            npartitions = npartitions + 1
             dask_df = dask_df.head(self.n_rows_to_load, npartitions=npartitions)
             dask_df = dd.from_pandas(dask_df, npartitions=npartitions)
 

--- a/examples/pipelines/finetune_stable_diffusion/pipeline.py
+++ b/examples/pipelines/finetune_stable_diffusion/pipeline.py
@@ -10,8 +10,10 @@ from fondant.pipeline import ComponentOp, Pipeline
 
 logger = logging.getLogger(__name__)
 # General configs
-pipeline_name = "Test fondant pipeline"
-pipeline_description = "A test pipeline"
+pipeline_name = "stable_diffusion_pipeline"
+pipeline_description = (
+    "Pipeline to prepare and collect data for finetuning stable diffusion"
+)
 
 load_component_column_mapping = {"image": "images_data", "text": "captions_data"}
 
@@ -25,7 +27,7 @@ load_from_hub_op = ComponentOp(
         "dataset_name": "logo-wizard/modern-logo-dataset",
         "column_name_mapping": load_component_column_mapping,
         "image_column_names": ["image"],
-        "nb_rows_to_load": None,
+        "n_rows_to_load": None,
     },
 )
 

--- a/examples/pipelines/finetune_stable_diffusion/pipeline.py
+++ b/examples/pipelines/finetune_stable_diffusion/pipeline.py
@@ -83,12 +83,15 @@ write_to_hub = ComponentOp(
     number_of_gpus=1,
 )
 
-pipeline = Pipeline(pipeline_name=pipeline_name, base_path=PipelineConfigs.BASE_PATH)
+pipeline = Pipeline(
+    pipeline_name=pipeline_name,
+    base_path="/home/philippe/Scripts/express/local_artifact/new",
+)
 
 pipeline.add_op(load_from_hub_op)
-pipeline.add_op(image_resolution_extraction_op, dependencies=load_from_hub_op)
-pipeline.add_op(image_embedding_op, dependencies=image_resolution_extraction_op)
-pipeline.add_op(laion_retrieval_op, dependencies=image_embedding_op)
-pipeline.add_op(download_images_op, dependencies=laion_retrieval_op)
-pipeline.add_op(caption_images_op, dependencies=download_images_op)
-pipeline.add_op(write_to_hub, dependencies=caption_images_op)
+# pipeline.add_op(image_resolution_extraction_op, dependencies=load_from_hub_op)
+# pipeline.add_op(image_embedding_op, dependencies=image_resolution_extraction_op)
+# pipeline.add_op(laion_retrieval_op, dependencies=image_embedding_op)
+# pipeline.add_op(download_images_op, dependencies=laion_retrieval_op)
+# pipeline.add_op(caption_images_op, dependencies=download_images_op)
+# pipeline.add_op(write_to_hub, dependencies=caption_images_op)


### PR DESCRIPTION
A fix for loading the dataset when `n_rows_to_load` is specified. An offset of 1 was missing which caused an issue when there was only 1 partition (npartitions from the enumerate started from 0 and an attempt to call `df.head()` with 0 partitions was made)