### PR TITLE
Implement caching

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -248,3 +248,37 @@ fondant run <pipeline_ref> --local
 NOTE: that the pipeline ref is the path to the compiled pipeline spec OR a reference to an fondant pipeline in which case the compiler will compile the pipeline first before running.
 
 This will start the pipeline and provide logs per component(service).
+
+## Caching pipeline runs
+
+When Fondant runs a pipeline, it checks to see whether an execution exists in the base path based on the cache key of each component. 
+
+The cache key is defined as the combination of the following:
+
+1) The **pipeline step's inputs.** These inputs include the input arguments' value (if any).
+
+2) **The component's specification.** This specification includes the image tag and the fields consumed and produced by each component.
+
+3) **The component resources.** Defines the hardware that was used to run the component (GPU, nodepool).
+
+If there is a matching execution in the base path (checked based on the output manifests),
+the outputs of that execution are used and the step computation is skipped.
+This helps to reduce costs by skipping computations that were completed in a previous pipeline run.
+
+
+Additionally, only the pipelines with the same pipeline name will share the cache. Caching for components
+with the `latest` image tag is disabled by default. This is because using "latest" image tags can lead to unpredictable behavior due to 
+image updates. Moreover, if one component in the pipeline is not cached then caching will be disabled for all 
+subsequent components. 
+
+You can turn off execution caching at component level by setting the following:
+
+```python
+caption_images_op = ComponentOp(  
+    component_dir="...",  
+    arguments={
+        ... 
+    },  
+    cache=False,  
+)
+```

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -335,6 +335,9 @@ class Executor(t.Generic[Component]):
 class DaskLoadExecutor(Executor[DaskLoadComponent]):
     """Base class for a Fondant load component."""
 
+    def _is_previous_cached(self, input_manifest: Manifest) -> bool:
+        return True
+
     @staticmethod
     def optional_fondant_arguments() -> t.List[str]:
         return ["input_manifest_path"]

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -204,7 +204,7 @@ class Executor(t.Generic[Component]):
         """
         matching_manifest_glob_pattern = (
             f"{self.metadata.base_path}/{self.metadata.pipeline_name}/*/"
-            f"{self.metadata.component_id}/manifest_*.json"
+            f"{self.metadata.component_id}/manifest_{self.metadata.cache_key}.json"
         )
 
         matching_manifests = self.filesystem.glob(matching_manifest_glob_pattern)

--- a/src/fondant/filesystem.py
+++ b/src/fondant/filesystem.py
@@ -1,7 +1,5 @@
 """This module defines common filesystem functionalities."""
 import logging
-import typing as t
-from pathlib import Path
 
 import fsspec
 
@@ -40,16 +38,3 @@ def get_filesystem(base_path: str) -> fsspec.spec.AbstractFileSystem:
     )
 
     raise ValueError(msg)
-
-
-def list_files(path: t.Union[str, Path]) -> t.List[str]:
-    """List files in the specified directory.
-
-    Args:
-        path: The path or URI of the directory.
-
-    Returns:
-        A list of absolute file paths in the specified directory.
-    """
-    fs = get_filesystem(str(path))
-    return fs.ls(str(path))

--- a/src/fondant/filesystem.py
+++ b/src/fondant/filesystem.py
@@ -1,0 +1,55 @@
+"""This module defines common filesystem functionalities."""
+import logging
+import typing as t
+from pathlib import Path
+
+import fsspec
+
+logger = logging.getLogger(__name__)
+
+FSSPEC_SCHEME_DICT = {
+    "file": "file",
+    "s3": "s3",
+    "gs": "gcs",
+    "abfs": "abfs",
+}
+
+
+def get_filesystem(base_path: str) -> fsspec.spec.AbstractFileSystem:
+    """Function to create fsspec.filesystem based on path_uri.
+    Creates a abstract handle using fsspec.filesystem to
+    remote or local directories to read files as if they
+    are on device.
+
+    Args:
+        base_path: The base path reference
+    Returns:
+        A fsspec.filesystem (if path_uri is either local or belongs to
+        one of these cloud sources s3, gcs or azure blob storage) or None
+        if path_uri has invalid scheme.
+    """
+    scheme = fsspec.utils.get_protocol(base_path)
+
+    if scheme in FSSPEC_SCHEME_DICT:
+        return fsspec.filesystem(FSSPEC_SCHEME_DICT[scheme])
+
+    msg = (
+        f"Unable to create fsspec filesystem object for url `{base_path}`"
+        f" because of unsupported scheme: {scheme}.\nAvailable schemes "
+        f"are {list(FSSPEC_SCHEME_DICT.keys())}"
+    )
+
+    raise ValueError(msg)
+
+
+def list_files(path: t.Union[str, Path]) -> t.List[str]:
+    """List files in the specified directory.
+
+    Args:
+        path: The path or URI of the directory.
+
+    Returns:
+        A list of absolute file paths in the specified directory.
+    """
+    fs = get_filesystem(str(path))
+    return fs.ls(str(path))

--- a/src/fondant/filesystem.py
+++ b/src/fondant/filesystem.py
@@ -5,13 +5,6 @@ import fsspec
 
 logger = logging.getLogger(__name__)
 
-FSSPEC_SCHEME_DICT = {
-    "file": "file",
-    "s3": "s3",
-    "gs": "gcs",
-    "abfs": "abfs",
-}
-
 
 def get_filesystem(base_path: str) -> fsspec.spec.AbstractFileSystem:
     """Function to create fsspec.filesystem based on path_uri.
@@ -26,15 +19,8 @@ def get_filesystem(base_path: str) -> fsspec.spec.AbstractFileSystem:
         one of these cloud sources s3, gcs or azure blob storage) or None
         if path_uri has invalid scheme.
     """
-    scheme = fsspec.utils.get_protocol(base_path)
-
-    if scheme in FSSPEC_SCHEME_DICT:
-        return fsspec.filesystem(FSSPEC_SCHEME_DICT[scheme])
-
-    msg = (
-        f"Unable to create fsspec filesystem object for url `{base_path}`"
-        f" because of unsupported scheme: {scheme}.\nAvailable schemes "
-        f"are {list(FSSPEC_SCHEME_DICT.keys())}"
-    )
-
-    raise ValueError(msg)
+    protocol = fsspec.utils.get_protocol(base_path)
+    try:
+        return fsspec.filesystem(protocol)
+    except ValueError:
+        raise

--- a/src/fondant/manifest.py
+++ b/src/fondant/manifest.py
@@ -73,12 +73,22 @@ class Index(Subset):
 
 @dataclass
 class Metadata:
-    """Class representing the Metadata of the manifest."""
+    """
+    Class representing the Metadata of the manifest.
+
+    Args:
+        base_path: the base path used to store the artifacts
+        pipeline_name: the name of the pipeline
+        run_id: the run id of the pipeline
+        component_id: the name of the component
+        cache_key: the cache key of the component.
+    """
 
     base_path: str
     pipeline_name: str
     run_id: str
     component_id: str
+    cache_key: str
 
     def to_dict(self):
         return asdict(self)
@@ -140,6 +150,7 @@ class Manifest:
         base_path: str,
         run_id: str,
         component_id: str,
+        cache_key: str,
     ) -> "Manifest":
         """Create an empty manifest.
 
@@ -148,12 +159,14 @@ class Manifest:
             base_path: The base path of the manifest
             run_id: The id of the current pipeline run
             component_id: The id of the current component being executed
+            cache_key: The component cache key
         """
         metadata = Metadata(
             pipeline_name=pipeline_name,
             base_path=base_path,
             run_id=run_id,
             component_id=component_id,
+            cache_key=cache_key,
         )
 
         specification = {
@@ -201,6 +214,10 @@ class Manifest:
     @property
     def pipeline_name(self) -> str:
         return self.metadata["pipeline_name"]
+
+    @property
+    def cache_key(self) -> str:
+        return self.metadata["cache_key"]
 
     @property
     def index(self) -> Index:

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -358,6 +358,7 @@ class Pipeline:
             base_path=self.base_path,
             run_id=run_id,
             component_id=load_component_name,
+            cache_key="42",
         )
         for operation_specs in self._graph.values():
             fondant_component_op = operation_specs["fondant_component_op"]

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -61,14 +61,12 @@ class ComponentOp:
     ) -> None:
         self.component_dir = Path(component_dir)
         self.input_partition_rows = input_partition_rows
-        self.cache = cache
-        self.arguments = self._set_arguments(arguments)
-
         self.component_spec = ComponentSpec.from_file(
             self.component_dir / self.COMPONENT_SPEC_NAME,
         )
         self.name = self.component_spec.name.replace(" ", "_").lower()
-
+        self.cache = self._configure_caching_from_image_tag(cache)
+        self.arguments = self._set_arguments(arguments)
         self.arguments.setdefault("component_spec", self.component_spec.specification)
 
         self.number_of_gpus = number_of_gpus
@@ -76,6 +74,38 @@ class ComponentOp:
             node_pool_label,
             node_pool_name,
         )
+
+    def _configure_caching_from_image_tag(
+        self,
+        cache: t.Optional[bool],
+    ) -> t.Optional[bool]:
+        """
+        Adjusts the caching setting based on the image tag of the component.
+
+        If the `cache` parameter is set to `True`, this function checks the image tag of
+        the component and disables caching (`cache` set to `False`) if the image tag is "latest".
+        This is because using "latest" image tags can lead to unpredictable behavior due to
+         image updates.
+
+        Args:
+            cache: The current caching setting. Set to `True` to enable caching, `False` to disable.
+
+        Returns:
+            The adjusted caching setting based on the image tag.
+
+        """
+        if cache is True:
+            image_tag = self.component_spec.image.rsplit(":")[-1]
+
+            if image_tag == "latest":
+                logger.warning(
+                    f"Component `{self.name}` has an image tag set to latest. "
+                    f"Caching for the component will be disabled to prevent"
+                    f" unpredictable behavior due to images updates",
+                )
+                return False
+
+        return cache
 
     def _set_arguments(
         self,

--- a/tests/example_pipelines/compiled_pipeline/example_1/docker-compose.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/docker-compose.yml
@@ -7,15 +7,15 @@ services:
     command:
     - --metadata
     - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-      "component_id": "first_component"}'
+      "component_id": "first_component", "cache_key": "1"}'
     - --output_manifest_path
-    - /foo/bar/test_pipeline/test_pipeline-20230101000000/first_component/manifest.json
+    - /foo/bar/test_pipeline/test_pipeline-20230101000000/first_component/manifest_1.json
     - --storage_args
     - a dummy string arg
     - --input_partition_rows
     - disable
     - --cache
-    - 'True'
+    - 'False'
     - --component_spec
     - '{"name": "First component", "description": "This is an example component",
       "image": "example_component:latest", "produces": {"images": {"fields": {"data":
@@ -38,15 +38,15 @@ services:
     command:
     - --metadata
     - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-      "component_id": "second_component"}'
+      "component_id": "second_component", "cache_key": "2"}'
     - --output_manifest_path
-    - /foo/bar/test_pipeline/test_pipeline-20230101000000/second_component/manifest.json
+    - /foo/bar/test_pipeline/test_pipeline-20230101000000/second_component/manifest_2.json
     - --storage_args
     - a dummy string arg
     - --input_partition_rows
     - '10'
     - --cache
-    - 'True'
+    - 'False'
     - --component_spec
     - '{"name": "Second component", "description": "This is an example component",
       "image": "example_component:latest", "consumes": {"images": {"fields": {"data":
@@ -54,7 +54,7 @@ services:
       "array", "items": {"type": "float32"}}}}}, "args": {"storage_args": {"description":
       "Storage arguments", "type": "str"}}}'
     - --input_manifest_path
-    - /foo/bar/test_pipeline/test_pipeline-20230101000000/first_component/manifest.json
+    - /foo/bar/test_pipeline/test_pipeline-20230101000000/first_component/manifest_1.json
     depends_on:
       first_component:
         condition: service_completed_successfully
@@ -66,15 +66,15 @@ services:
     command:
     - --metadata
     - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-      "component_id": "third_component"}'
+      "component_id": "third_component", "cache_key": "3"}'
     - --output_manifest_path
-    - /foo/bar/test_pipeline/test_pipeline-20230101000000/third_component/manifest.json
+    - /foo/bar/test_pipeline/test_pipeline-20230101000000/third_component/manifest_3.json
     - --storage_args
     - a dummy string arg
     - --input_partition_rows
     - None
     - --cache
-    - 'True'
+    - 'False'
     - --component_spec
     - '{"name": "Third component", "description": "This is an example component",
       "image": "example_component:latest", "consumes": {"images": {"fields": {"data":
@@ -84,7 +84,7 @@ services:
       false}, "args": {"storage_args": {"description": "Storage arguments", "type":
       "str"}}}'
     - --input_manifest_path
-    - /foo/bar/test_pipeline/test_pipeline-20230101000000/second_component/manifest.json
+    - /foo/bar/test_pipeline/test_pipeline-20230101000000/second_component/manifest_2.json
     depends_on:
       second_component:
         condition: service_completed_successfully

--- a/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
@@ -25,7 +25,7 @@ spec:
       - /tmp/inputs/input_manifest_path/data
       - --metadata
       - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-        "component_id": "first_component"}'
+        "component_id": "first_component", "cache_key": "1"}'
       - --component_spec
       - '{"args": {"storage_args": {"description": "Storage arguments", "type": "str"}},
         "description": "This is an example component", "image": "example_component:latest",
@@ -34,7 +34,7 @@ spec:
       - --input_partition_rows
       - disable
       - --cache
-      - 'True'
+      - 'False'
       - --storage_args
       - a dummy string arg
       - --output_manifest_path
@@ -51,7 +51,7 @@ spec:
           data: ''
     metadata:
       annotations:
-        pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "component_spec":
+        pipelines.kubeflow.org/arguments.parameters: '{"cache": "False", "component_spec":
           "{\"args\": {\"storage_args\": {\"description\": \"Storage arguments\",
           \"type\": \"str\"}}, \"description\": \"This is an example component\",
           \"image\": \"example_component:latest\", \"name\": \"First component\",
@@ -59,7 +59,8 @@ spec:
           \"images\": {\"fields\": {\"data\": {\"type\": \"binary\"}}}}}", "input_partition_rows":
           "disable", "metadata": "{\"base_path\": \"/foo/bar\", \"pipeline_name\":
           \"test_pipeline\", \"run_id\": \"test_pipeline-20230101000000\", \"component_id\":
-          \"first_component\"}", "storage_args": "a dummy string arg"}'
+          \"first_component\", \"cache_key\": \"1\"}", "storage_args": "a dummy string
+          arg"}'
         pipelines.kubeflow.org/component_ref: '{"digest": "99e50abb5261d2381b8d7ab61eadb9feff6c3d90f9a7b3ed89e69cda31c39d9b"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",
@@ -99,7 +100,7 @@ spec:
       - /tmp/inputs/input_manifest_path/data
       - --metadata
       - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-        "component_id": "second_component"}'
+        "component_id": "second_component", "cache_key": "2"}'
       - --component_spec
       - '{"args": {"storage_args": {"description": "Storage arguments", "type": "str"}},
         "consumes": {"images": {"fields": {"data": {"type": "binary"}}}}, "description":
@@ -109,7 +110,7 @@ spec:
       - --input_partition_rows
       - '10'
       - --cache
-      - 'True'
+      - 'False'
       - --storage_args
       - a dummy string arg
       - --output_manifest_path
@@ -121,7 +122,7 @@ spec:
         path: /tmp/inputs/input_manifest_path/data
     metadata:
       annotations:
-        pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "component_spec":
+        pipelines.kubeflow.org/arguments.parameters: '{"cache": "False", "component_spec":
           "{\"args\": {\"storage_args\": {\"description\": \"Storage arguments\",
           \"type\": \"str\"}}, \"consumes\": {\"images\": {\"fields\": {\"data\":
           {\"type\": \"binary\"}}}}, \"description\": \"This is an example component\",
@@ -129,8 +130,8 @@ spec:
           \"produces\": {\"embeddings\": {\"fields\": {\"data\": {\"items\": {\"type\":
           \"float32\"}, \"type\": \"array\"}}}}}", "input_partition_rows": "10", "metadata":
           "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\", \"run_id\":
-          \"test_pipeline-20230101000000\", \"component_id\": \"second_component\"}",
-          "storage_args": "a dummy string arg"}'
+          \"test_pipeline-20230101000000\", \"component_id\": \"second_component\",
+          \"cache_key\": \"2\"}", "storage_args": "a dummy string arg"}'
         pipelines.kubeflow.org/component_ref: '{"digest": "e157b93359593b46563237b985194771d9a8f106a3577a7c5f4746b170fe5b23"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",
@@ -191,7 +192,7 @@ spec:
       - /tmp/inputs/input_manifest_path/data
       - --metadata
       - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-        "component_id": "third_component"}'
+        "component_id": "third_component", "cache_key": "3"}'
       - --component_spec
       - '{"args": {"storage_args": {"description": "Storage arguments", "type": "str"}},
         "consumes": {"captions": {"fields": {"data": {"type": "string"}}}, "embeddings":
@@ -203,7 +204,7 @@ spec:
       - --input_partition_rows
       - None
       - --cache
-      - 'True'
+      - 'False'
       - --storage_args
       - a dummy string arg
       - --output_manifest_path
@@ -215,7 +216,7 @@ spec:
         path: /tmp/inputs/input_manifest_path/data
     metadata:
       annotations:
-        pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "component_spec":
+        pipelines.kubeflow.org/arguments.parameters: '{"cache": "False", "component_spec":
           "{\"args\": {\"storage_args\": {\"description\": \"Storage arguments\",
           \"type\": \"str\"}}, \"consumes\": {\"captions\": {\"fields\": {\"data\":
           {\"type\": \"string\"}}}, \"embeddings\": {\"fields\": {\"data\": {\"items\":
@@ -225,8 +226,8 @@ spec:
           component\", \"produces\": {\"additionalSubsets\": false, \"images\": {\"fields\":
           {\"data\": {\"type\": \"binary\"}}}}}", "input_partition_rows": "None",
           "metadata": "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\",
-          \"run_id\": \"test_pipeline-20230101000000\", \"component_id\": \"third_component\"}",
-          "storage_args": "a dummy string arg"}'
+          \"run_id\": \"test_pipeline-20230101000000\", \"component_id\": \"third_component\",
+          \"cache_key\": \"3\"}", "storage_args": "a dummy string arg"}'
         pipelines.kubeflow.org/component_ref: '{"digest": "a8c0d8c46f876326331c3fb551bbf90530abab1e1d070a2cd7725635e7664f06"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",

--- a/tests/example_pipelines/compiled_pipeline/example_2/docker-compose.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/docker-compose.yml
@@ -7,15 +7,15 @@ services:
     command:
     - --metadata
     - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-      "component_id": "first_component"}'
+      "component_id": "first_component", "cache_key": "1"}'
     - --output_manifest_path
-    - /foo/bar/test_pipeline/test_pipeline-20230101000000/first_component/manifest.json
+    - /foo/bar/test_pipeline/test_pipeline-20230101000000/first_component/manifest_1.json
     - --storage_args
     - a dummy string arg
     - --input_partition_rows
     - None
     - --cache
-    - 'True'
+    - 'False'
     - --component_spec
     - '{"name": "First component", "description": "This is an example component",
       "image": "example_component:latest", "produces": {"images": {"fields": {"data":
@@ -27,9 +27,9 @@ services:
     command:
     - --metadata
     - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-      "component_id": "image_cropping"}'
+      "component_id": "image_cropping", "cache_key": "2"}'
     - --output_manifest_path
-    - /foo/bar/test_pipeline/test_pipeline-20230101000000/image_cropping/manifest.json
+    - /foo/bar/test_pipeline/test_pipeline-20230101000000/image_cropping/manifest_2.json
     - --cropping_threshold
     - '0'
     - --padding
@@ -50,7 +50,7 @@ services:
       for the image cropping. The padding is added to all borders of the image.",
       "type": "int", "default": 10}}}'
     - --input_manifest_path
-    - /foo/bar/test_pipeline/test_pipeline-20230101000000/first_component/manifest.json
+    - /foo/bar/test_pipeline/test_pipeline-20230101000000/first_component/manifest_1.json
     depends_on:
       first_component:
         condition: service_completed_successfully

--- a/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
@@ -25,7 +25,7 @@ spec:
       - /tmp/inputs/input_manifest_path/data
       - --metadata
       - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-        "component_id": "first_component"}'
+        "component_id": "first_component", "cache_key": "1"}'
       - --component_spec
       - '{"args": {"storage_args": {"description": "Storage arguments", "type": "str"}},
         "description": "This is an example component", "image": "example_component:latest",
@@ -34,7 +34,7 @@ spec:
       - --input_partition_rows
       - None
       - --cache
-      - 'True'
+      - 'False'
       - --storage_args
       - a dummy string arg
       - --output_manifest_path
@@ -48,15 +48,15 @@ spec:
           data: ''
     metadata:
       annotations:
-        pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "component_spec":
+        pipelines.kubeflow.org/arguments.parameters: '{"cache": "False", "component_spec":
           "{\"args\": {\"storage_args\": {\"description\": \"Storage arguments\",
           \"type\": \"str\"}}, \"description\": \"This is an example component\",
           \"image\": \"example_component:latest\", \"name\": \"First component\",
           \"produces\": {\"captions\": {\"fields\": {\"data\": {\"type\": \"string\"}}},
           \"images\": {\"fields\": {\"data\": {\"type\": \"binary\"}}}}}", "input_partition_rows":
           "None", "metadata": "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\",
-          \"run_id\": \"test_pipeline-20230101000000\", \"component_id\": \"first_component\"}",
-          "storage_args": "a dummy string arg"}'
+          \"run_id\": \"test_pipeline-20230101000000\", \"component_id\": \"first_component\",
+          \"cache_key\": \"1\"}", "storage_args": "a dummy string arg"}'
         pipelines.kubeflow.org/component_ref: '{"digest": "99e50abb5261d2381b8d7ab61eadb9feff6c3d90f9a7b3ed89e69cda31c39d9b"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",
@@ -96,7 +96,7 @@ spec:
       - /tmp/inputs/input_manifest_path/data
       - --metadata
       - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-        "component_id": "image_cropping"}'
+        "component_id": "image_cropping", "cache_key": "2"}'
       - --component_spec
       - '{"args": {"cropping_threshold": {"default": -30, "description": "Threshold
         parameter used for detecting borders. A lower (negative) parameter results
@@ -139,7 +139,8 @@ spec:
           \"height\": {\"type\": \"int32\"}, \"width\": {\"type\": \"int32\"}}}}}",
           "cropping_threshold": "0", "input_partition_rows": "None", "metadata": "{\"base_path\":
           \"/foo/bar\", \"pipeline_name\": \"test_pipeline\", \"run_id\": \"test_pipeline-20230101000000\",
-          \"component_id\": \"image_cropping\"}", "padding": "0"}'
+          \"component_id\": \"image_cropping\", \"cache_key\": \"2\"}", "padding":
+          "0"}'
         pipelines.kubeflow.org/component_ref: '{"digest": "8c3ca8c42706df81bfe28a8f6a8447b5245fe817a4fb5ae4d0872041f1ca7f65"}'
         pipelines.kubeflow.org/component_spec: '{"description": "Component that removes
           single-colored borders around images and crops them appropriately", "implementation":

--- a/tests/example_pipelines/compiled_pipeline/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/kubeflow_pipeline.yml
@@ -25,7 +25,7 @@ spec:
       - /tmp/inputs/input_manifest_path/data
       - --metadata
       - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-        "component_id": "first_component"}'
+        "component_id": "first_component", "cache_key": "c04cb1c34b8c14e4001c992df463eb08"}'
       - --component_spec
       - '{"args": {"storage_args": {"description": "Storage arguments", "type": "str"}},
         "description": "This is an example component", "image": "example_component:latest",
@@ -34,7 +34,7 @@ spec:
       - --input_partition_rows
       - None
       - --cache
-      - 'True'
+      - 'False'
       - --storage_args
       - a dummy string arg
       - --output_manifest_path
@@ -51,15 +51,16 @@ spec:
           data: ''
     metadata:
       annotations:
-        pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "component_spec":
+        pipelines.kubeflow.org/arguments.parameters: '{"cache": "False", "component_spec":
           "{\"args\": {\"storage_args\": {\"description\": \"Storage arguments\",
           \"type\": \"str\"}}, \"description\": \"This is an example component\",
           \"image\": \"example_component:latest\", \"name\": \"First component\",
           \"produces\": {\"captions\": {\"fields\": {\"data\": {\"type\": \"string\"}}},
           \"images\": {\"fields\": {\"data\": {\"type\": \"binary\"}}}}}", "input_partition_rows":
           "None", "metadata": "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\",
-          \"run_id\": \"test_pipeline-20230101000000\", \"component_id\": \"first_component\"}",
-          "storage_args": "a dummy string arg"}'
+          \"run_id\": \"test_pipeline-20230101000000\", \"component_id\": \"first_component\",
+          \"cache_key\": \"c04cb1c34b8c14e4001c992df463eb08\"}", "storage_args": "a
+          dummy string arg"}'
         pipelines.kubeflow.org/component_ref: '{"digest": "99e50abb5261d2381b8d7ab61eadb9feff6c3d90f9a7b3ed89e69cda31c39d9b"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",

--- a/tests/example_specs/components/arguments/input_manifest.json
+++ b/tests/example_specs/components/arguments/input_manifest.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "pipeline_name": "test_pipeline",
+    "pipeline_name": "example_pipeline",
     "base_path": "/bucket",
-    "run_id": "12345",
-    "component_id": "67890"
+    "run_id": "2024",
+    "component_id": "component_1"
   },
   "index": {
     "location": "/index"

--- a/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2022/component_1/manifest_1.json
+++ b/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2022/component_1/manifest_1.json
@@ -1,0 +1,36 @@
+{
+  "metadata": {
+    "pipeline_name": "test_pipeline",
+    "base_path": "gs://bucket",
+    "run_id": "test_pipeline_2022",
+    "component_id": "component_1",
+    "cache_key": "1"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "data": {
+          "type": "binary"
+        },
+        "height": {
+          "type": "int32"
+        },
+        "width": {
+          "type": "int32"
+        }
+      }
+    },
+    "captions": {
+      "location": "/captions",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2022/component_2/manifest_2.json
+++ b/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2022/component_2/manifest_2.json
@@ -1,0 +1,36 @@
+{
+  "metadata": {
+    "pipeline_name": "test_pipeline",
+    "base_path": "gs://bucket",
+    "run_id": "test_pipeline_2022",
+    "component_id": "component_2",
+    "cache_key": "2"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "data": {
+          "type": "binary"
+        },
+        "height": {
+          "type": "int32"
+        },
+        "width": {
+          "type": "int32"
+        }
+      }
+    },
+    "captions": {
+      "location": "/captions",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2023/component_1/manifest_1.json
+++ b/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2023/component_1/manifest_1.json
@@ -1,0 +1,36 @@
+{
+  "metadata": {
+    "pipeline_name": "test_pipeline",
+    "base_path": "gs://bucket",
+    "run_id": "test_pipeline_2023",
+    "component_id": "component_1",
+    "cache_key": "1"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "data": {
+          "type": "binary"
+        },
+        "height": {
+          "type": "int32"
+        },
+        "width": {
+          "type": "int32"
+        }
+      }
+    },
+    "captions": {
+      "location": "/captions",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2023/component_2/manifest_2.json
+++ b/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2023/component_2/manifest_2.json
@@ -1,0 +1,36 @@
+{
+  "metadata": {
+    "pipeline_name": "test_pipeline",
+    "base_path": "gs://bucket",
+    "run_id": "test_pipeline_2023",
+    "component_id": "component_2",
+    "cache_key": "2"
+  },
+  "index": {
+    "location": "/index"
+  },
+  "subsets": {
+    "images": {
+      "location": "/images",
+      "fields": {
+        "data": {
+          "type": "binary"
+        },
+        "height": {
+          "type": "int32"
+        },
+        "width": {
+          "type": "int32"
+        }
+      }
+    },
+    "captions": {
+      "location": "/captions",
+      "fields": {
+        "data": {
+          "type": "binary"
+        }
+      }
+    }
+  }
+}

--- a/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2023/component_2/manifest_2.json
+++ b/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2023/component_2/manifest_2.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "pipeline_name": "test_pipeline",
-    "base_path": "gs://bucket/",
+    "base_path": "gs://bucket",
     "run_id": "test_pipeline_2023",
     "component_id": "component_2",
     "cache_key": "2"

--- a/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2023/component_2/manifest_2.json
+++ b/tests/example_specs/mock_base_path/example_pipeline/example_pipeline_2023/component_2/manifest_2.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "pipeline_name": "test_pipeline",
-    "base_path": "gs://bucket",
+    "base_path": "gs://bucket/",
     "run_id": "test_pipeline_2023",
     "component_id": "component_2",
     "cache_key": "2"

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -16,36 +16,51 @@ TEST_PIPELINES = [
     (
         "example_1",
         [
-            ComponentOp(
-                Path(COMPONENTS_PATH / "example_1" / "first_component"),
-                arguments={"storage_args": "a dummy string arg"},
-                input_partition_rows="disable",
-                number_of_gpus=1,
-            ),
-            ComponentOp(
-                Path(COMPONENTS_PATH / "example_1" / "second_component"),
-                arguments={"storage_args": "a dummy string arg"},
-                input_partition_rows="10",
-            ),
-            ComponentOp(
-                Path(COMPONENTS_PATH / "example_1" / "third_component"),
-                arguments={
-                    "storage_args": "a dummy string arg",
-                },
-            ),
+            {
+                "component_op": ComponentOp(
+                    Path(COMPONENTS_PATH / "example_1" / "first_component"),
+                    arguments={"storage_args": "a dummy string arg"},
+                    input_partition_rows="disable",
+                    number_of_gpus=1,
+                ),
+                "cache_key": "1",
+            },
+            {
+                "component_op": ComponentOp(
+                    Path(COMPONENTS_PATH / "example_1" / "second_component"),
+                    arguments={"storage_args": "a dummy string arg"},
+                    input_partition_rows="10",
+                ),
+                "cache_key": "2",
+            },
+            {
+                "component_op": ComponentOp(
+                    Path(COMPONENTS_PATH / "example_1" / "third_component"),
+                    arguments={
+                        "storage_args": "a dummy string arg",
+                    },
+                ),
+                "cache_key": "3",
+            },
         ],
     ),
     (
         "example_2",
         [
-            ComponentOp(
-                Path(COMPONENTS_PATH / "example_1" / "first_component"),
-                arguments={"storage_args": "a dummy string arg"},
-            ),
-            ComponentOp.from_registry(
-                name="image_cropping",
-                arguments={"cropping_threshold": 0, "padding": 0},
-            ),
+            {
+                "component_op": ComponentOp(
+                    Path(COMPONENTS_PATH / "example_1" / "first_component"),
+                    arguments={"storage_args": "a dummy string arg"},
+                ),
+                "cache_key": "1",
+            },
+            {
+                "component_op": ComponentOp.from_registry(
+                    name="image_cropping",
+                    arguments={"cropping_threshold": 0, "padding": 0},
+                ),
+                "cache_key": "2",
+            },
         ],
     ),
 ]
@@ -73,22 +88,32 @@ def setup_pipeline(request, tmp_path, monkeypatch):
         base_path="/foo/bar",
     )
     example_dir, components = request.param
-
     prev_comp = None
-    for component in components:
+    cache_dict = {}
+    for component_dict in components:
+        component = component_dict["component_op"]
+        cache_key = component_dict["cache_key"]
+        # set the cache_key as a default argument in the lambda function to avoid setting attribute
+        # by reference
+        monkeypatch.setattr(
+            component,
+            "get_component_cache_key",
+            lambda cache_key=cache_key: cache_key,
+        )
         pipeline.add_op(component, dependencies=prev_comp)
         prev_comp = component
+        cache_dict[component.name] = cache_key
 
     # override the default package_path with temporary path to avoid the creation of artifacts
     monkeypatch.setattr(pipeline, "package_path", str(tmp_path / "test_pipeline.tgz"))
 
-    return example_dir, pipeline
+    return example_dir, pipeline, cache_dict
 
 
 @pytest.mark.usefixtures("_freeze_time")
 def test_docker_compiler(setup_pipeline, tmp_path_factory):
     """Test compiling a pipeline to docker-compose."""
-    example_dir, pipeline = setup_pipeline
+    example_dir, pipeline, _ = setup_pipeline
     compiler = DockerCompiler()
     with tmp_path_factory.mktemp("temp") as fn:
         output_path = str(fn / "docker-compose.yml")
@@ -105,7 +130,7 @@ def test_docker_local_path(setup_pipeline, tmp_path_factory):
     # volumes are only created for local existing directories
     with tmp_path_factory.mktemp("temp") as fn:
         # this is the directory mounted in the container
-        _, pipeline = setup_pipeline
+        _, pipeline, cache_dict = setup_pipeline
         work_dir = f"/{fn.stem}"
         pipeline.base_path = str(fn)
         compiler = DockerCompiler()
@@ -118,6 +143,8 @@ def test_docker_local_path(setup_pipeline, tmp_path_factory):
         expected_run_id = "test_pipeline-20230101000000"
         for name, service in spec["services"].items():
             # check if volumes are defined correctly
+
+            cache_key = cache_dict[name]
             assert service["volumes"] == [
                 {
                     "source": str(fn),
@@ -127,9 +154,10 @@ def test_docker_local_path(setup_pipeline, tmp_path_factory):
             ]
             # check if commands are patched to use the working dir
             commands_with_dir = [
-                f"{work_dir}/{pipeline.name}/{expected_run_id}/{name}/manifest.json",
+                f"{work_dir}/{pipeline.name}/{expected_run_id}/{name}/manifest_{cache_key}.json",
                 f'{{"base_path": "{work_dir}", "pipeline_name": "{pipeline.name}",'
-                f' "run_id": "{expected_run_id}", "component_id": "{name}"}}',
+                f' "run_id": "{expected_run_id}", "component_id": "{name}",'
+                f' "cache_key": "{cache_key}"}}',
             ]
             for command in commands_with_dir:
                 assert command in service["command"]
@@ -138,7 +166,7 @@ def test_docker_local_path(setup_pipeline, tmp_path_factory):
 @pytest.mark.usefixtures("_freeze_time")
 def test_docker_remote_path(setup_pipeline, tmp_path_factory):
     """Test that a remote path is applied correctly in the arguments and no volume."""
-    _, pipeline = setup_pipeline
+    _, pipeline, cache_dict = setup_pipeline
     remote_dir = "gs://somebucket/artifacts"
     pipeline.base_path = remote_dir
     compiler = DockerCompiler()
@@ -151,13 +179,15 @@ def test_docker_remote_path(setup_pipeline, tmp_path_factory):
 
         expected_run_id = "test_pipeline-20230101000000"
         for name, service in spec["services"].items():
+            cache_key = cache_dict[name]
             # check that no volumes are created
             assert service["volumes"] == []
             # check if commands are patched to use the remote dir
             commands_with_dir = [
-                f"{remote_dir}/{pipeline.name}/{expected_run_id}/{name}/manifest.json",
+                f"{remote_dir}/{pipeline.name}/{expected_run_id}/{name}/manifest_{cache_key}.json",
                 f'{{"base_path": "{remote_dir}", "pipeline_name": "{pipeline.name}",'
-                f' "run_id": "{expected_run_id}", "component_id": "{name}"}}',
+                f' "run_id": "{expected_run_id}", "component_id": "{name}",'
+                f' "cache_key": "{cache_key}"}}',
             ]
             for command in commands_with_dir:
                 assert command in service["command"]
@@ -168,7 +198,7 @@ def test_docker_extra_volumes(setup_pipeline, tmp_path_factory):
     """Test that extra volumes are applied correctly."""
     with tmp_path_factory.mktemp("temp") as fn:
         # this is the directory mounted in the container
-        _, pipeline = setup_pipeline
+        _, pipeline, _ = setup_pipeline
         pipeline.base_path = str(fn)
         compiler = DockerCompiler()
         # define some extra volumes to be mounted
@@ -191,7 +221,7 @@ def test_docker_extra_volumes(setup_pipeline, tmp_path_factory):
 @pytest.mark.usefixtures("_freeze_time")
 def test_kubeflow_compiler(setup_pipeline, tmp_path_factory):
     """Test compiling a pipeline to kubeflow."""
-    example_dir, pipeline = setup_pipeline
+    example_dir, pipeline, _ = setup_pipeline
     compiler = KubeFlowCompiler()
     with tmp_path_factory.mktemp("temp") as fn:
         output_path = str(fn / "kubeflow_pipeline.yml")

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -42,7 +42,7 @@ def metadata():
         base_path=str(base_path),
         component_id="component_2",
         run_id="2024",
-        cache_key="1",
+        cache_key="2",
     )
 
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -158,12 +158,6 @@ def test_component_caching(metadata):
         "True",
         "--input_partition_rows",
         "100",
-        "--override_default_arg",
-        "bar",
-        "--override_default_none_arg",
-        "3.14",
-        "--override_default_arg_with_none",
-        "None",
     ]
 
     class MyExecutor(Executor):
@@ -176,7 +170,7 @@ def test_component_caching(metadata):
             pass
 
     executor = MyExecutor.from_args()
-    matching_execution_manifest = executor._find_matching_executions()
+    matching_execution_manifest = executor._get_latest_matching_manifest()
     assert matching_execution_manifest.run_id == "test_pipeline_2023"
 
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -23,8 +23,8 @@ from fondant.executor import (
 )
 from fondant.manifest import Manifest, Metadata
 
-components_path = Path("example_specs/components")
-base_path = Path("example_specs/mock_base_path")
+components_path = Path(__file__).parent / "example_specs/components"
+base_path = Path(__file__).parent / "example_specs/mock_base_path"
 
 N_PARTITIONS = 2
 
@@ -40,7 +40,7 @@ def metadata():
     return Metadata(
         pipeline_name="example_pipeline",
         base_path=str(base_path),
-        component_id="component_1",
+        component_id="component_2",
         run_id="2024",
         cache_key="1",
     )
@@ -143,11 +143,12 @@ def test_component_arguments(metadata):
 
 
 def test_component_caching(metadata):
+    input_manifest_path = str(components_path / "arguments/input_manifest.json")
     # Mock CLI arguments
     sys.argv = [
         "",
         "--input_manifest_path",
-        str(components_path / "arguments/input_manifest.json"),
+        input_manifest_path,
         "--metadata",
         metadata.to_json(),
         "--output_manifest_path",
@@ -178,6 +179,9 @@ def test_component_caching(metadata):
     executor = MyExecutor.from_args()
     matching_execution_manifest = executor._get_latest_matching_manifest()
     assert matching_execution_manifest.run_id == "test_pipeline_2023"
+    assert (
+        executor._is_previous_cached(Manifest.from_file(input_manifest_path)) is False
+    )
 
 
 @pytest.mark.usefixtures("_patched_data_writing")

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -23,8 +23,8 @@ from fondant.executor import (
 )
 from fondant.manifest import Manifest, Metadata
 
-components_path = Path(__file__).parent / "example_specs/components"
-base_path = Path(__file__).parent / "example_specs/mock_base_path"
+components_path = Path("example_specs/components")
+base_path = Path("example_specs/mock_base_path")
 
 N_PARTITIONS = 2
 
@@ -158,6 +158,12 @@ def test_component_caching(metadata):
         "True",
         "--input_partition_rows",
         "100",
+        "--override_default_arg",
+        "bar",
+        "--override_default_none_arg",
+        "3.14",
+        "--override_default_arg_with_none",
+        "None",
     ]
 
     class MyExecutor(Executor):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -24,6 +24,8 @@ from fondant.executor import (
 from fondant.manifest import Manifest, Metadata
 
 components_path = Path(__file__).parent / "example_specs/components"
+base_path = Path(__file__).parent / "example_specs/mock_base_path"
+
 N_PARTITIONS = 2
 
 
@@ -36,10 +38,11 @@ def yaml_file_to_json_string(file_path):
 @pytest.fixture()
 def metadata():
     return Metadata(
-        pipeline_name="pipeline",
-        base_path="/bucket",
-        component_id="load_component",
-        run_id="12345",
+        pipeline_name="example_pipeline",
+        base_path=str(base_path),
+        component_id="component_1",
+        run_id="2024",
+        cache_key="1",
     )
 
 
@@ -137,6 +140,44 @@ def test_component_arguments(metadata):
         "override_default_none_arg": 3.14,
         "override_default_arg_with_none": None,
     }
+
+
+def test_component_caching(metadata):
+    # Mock CLI arguments
+    sys.argv = [
+        "",
+        "--input_manifest_path",
+        str(components_path / "arguments/input_manifest.json"),
+        "--metadata",
+        metadata.to_json(),
+        "--output_manifest_path",
+        str(components_path / "arguments/output_manifest.json"),
+        "--component_spec",
+        yaml_file_to_json_string(components_path / "arguments/component.yaml"),
+        "--cache",
+        "True",
+        "--input_partition_rows",
+        "100",
+        "--override_default_arg",
+        "bar",
+        "--override_default_none_arg",
+        "3.14",
+        "--override_default_arg_with_none",
+        "None",
+    ]
+
+    class MyExecutor(Executor):
+        """Base component with dummy methods so it can be instantiated."""
+
+        def _load_or_create_manifest(self) -> Manifest:
+            pass
+
+        def _process_dataset(self, manifest: Manifest) -> t.Union[None, dd.DataFrame]:
+            pass
+
+    executor = MyExecutor.from_args()
+    matching_execution_manifest = executor._find_matching_executions()
+    assert matching_execution_manifest.run_id == "test_pipeline_2023"
 
 
 @pytest.mark.usefixtures("_patched_data_writing")

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -17,11 +17,6 @@ def test_valid_filesystem():
 
 def test_invalid_filesystem():
     """Test that a data type specified with the Type class matches the expected pyarrow schema."""
-    expected_msg = (
-        "Unable to create fsspec filesystem object for url `invalid_protocol://`"
-        " because of unsupported scheme: invalid_protocol.\n"
-        "Available schemes are ['file', 's3', 'gs', 'abfs']"
-    )
-
+    expected_msg = "Protocol not known: invalid_protocol"
     with pytest.raises(ValueError, match=re.escape(expected_msg)):
         get_filesystem("invalid_protocol://")

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,27 @@
+import re
+
+import pytest
+from fondant.filesystem import get_filesystem
+
+
+def test_valid_filesystem():
+    """Test that a data type specified with the Type class matches the expected pyarrow schema."""
+
+    def get_instance_class_name(instance):
+        return instance.__class__.__name__
+
+    assert get_instance_class_name(get_filesystem("/home/foo/bar")) == "LocalFileSystem"
+    assert get_instance_class_name(get_filesystem("gs://foo/bar")) == "GCSFileSystem"
+    assert get_instance_class_name(get_filesystem("s3://foo/bar")) == "S3FileSystem"
+
+
+def test_invalid_filesystem():
+    """Test that a data type specified with the Type class matches the expected pyarrow schema."""
+    expected_msg = (
+        "Unable to create fsspec filesystem object for url `invalid_protocol://`"
+        " because of unsupported scheme: invalid_protocol.\n"
+        "Available schemes are ['file', 's3', 'gs', 'abfs']"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        get_filesystem("invalid_protocol://")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -119,13 +119,16 @@ def test_manifest_creation():
     run_id = "run_id"
     pipeline_name = "pipeline_name"
     component_id = "component_id"
+    cache_key = "42"
 
     manifest = Manifest.create(
         pipeline_name=pipeline_name,
         base_path=base_path,
         run_id=run_id,
         component_id=component_id,
+        cache_key=cache_key,
     )
+
     manifest.add_subset("images", [("width", Type("int32")), ("height", Type("int32"))])
     manifest.subsets["images"].add_field("data", Type("binary"))
 
@@ -135,6 +138,7 @@ def test_manifest_creation():
             "base_path": base_path,
             "run_id": run_id,
             "component_id": component_id,
+            "cache_key": cache_key,
         },
         "index": {"location": f"/{pipeline_name}/{run_id}/{component_id}/index"},
         "subsets": {
@@ -162,11 +166,13 @@ def test_manifest_repr():
         base_path="/",
         run_id="A",
         component_id="1",
+        cache_key="42",
     )
     assert (
         manifest.__repr__()
         == "Manifest({'metadata': {'base_path': '/', 'pipeline_name': 'NAME', 'run_id': 'A',"
-        " 'component_id': '1'}, 'index': {'location': '/NAME/A/1/index'}, 'subsets': {}})"
+        " 'component_id': '1', 'cache_key': '42'},"
+        " 'index': {'location': '/NAME/A/1/index'}, 'subsets': {}})"
     )
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,10 +4,11 @@ from pathlib import Path
 
 import pytest
 import yaml
+from fondant.component_spec import ComponentSpec
 from fondant.exceptions import InvalidPipelineDefinition
 from fondant.pipeline import ComponentOp, Pipeline
 
-valid_pipeline_path = Path(__file__).parent / "example_pipelines/valid_pipeline"
+valid_pipeline_path = Path("example_pipelines/valid_pipeline")
 invalid_pipeline_path = Path(__file__).parent / "example_pipelines/invalid_pipeline"
 
 
@@ -98,6 +99,25 @@ def test_component_op_hash(
         comp_0_op_spec_0.get_component_cache_key()
         != comp_1_op_spec_0.get_component_cache_key()
     )
+
+
+def test_component_op_caching_strategy(monkeypatch):
+    components_path = Path(valid_pipeline_path / "example_1" / "first_component")
+    for tag in ["latest", "dev", "1234"]:
+        monkeypatch.setattr(
+            ComponentSpec,
+            "image",
+            f"ghcr.io/component/test_component:{tag}",
+        )
+        comp_0_op_spec_0 = ComponentOp(
+            components_path,
+            arguments={"storage_args": "a dummy string arg"},
+            cache=True,
+        )
+        if tag == "latest":
+            assert comp_0_op_spec_0.cache is False
+        else:
+            assert comp_0_op_spec_0.cache is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,7 +8,7 @@ from fondant.component_spec import ComponentSpec
 from fondant.exceptions import InvalidPipelineDefinition
 from fondant.pipeline import ComponentOp, Pipeline
 
-valid_pipeline_path = Path("example_pipelines/valid_pipeline")
+valid_pipeline_path = Path(__file__).parent / "example_pipelines/valid_pipeline"
 invalid_pipeline_path = Path(__file__).parent / "example_pipelines/invalid_pipeline"
 
 


### PR DESCRIPTION
PR that implements caching: 

* The component cache is estimated at compile time based on the images tag, input parameters, component spec and component resources (GPU, nodepool). Caching is enabled by default at the componentOp level and disabled if the image has the `latest` tag

* At runtime, the cache key is checked against the base path to check for matching executions based on a the cache key (currently appended to the manifest name). 

*  If multiple matching executions are found, we return the latest one. This makes it easier to develop. For example, if we're working with the `dev` tag and we disable caching to force the execution of a new version of the component (scenario where the spec and parameters are the same). Then when we enable caching again, we would only load the manifest from the latest execution. 
 
* A component is cached only if it's enabled at the Op level, a matching manfiest is found and previous component's run is cached. To check whether the previous component is cached or not. We check if the run-id of the previous component (input manifest) has the same run-id as the current component. If they match, it means that the previous component had to execute (manifest not loaded from previous pipeline run). Note that this implies that we don't change the loaded manifest's run-id to that of the current pipeline run. This might not be ideal for lineage tracking but I see no other way of doing this check. 

