### PR TITLE
Add output default to cli runner

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,7 +130,7 @@ def test_kfp_compile(tmp_path_factory):
 
 def test_local_run(tmp_path_factory):
     """Test that the run command works with different arguments."""
-    args = argparse.Namespace(local=True, ref="some/path")
+    args = argparse.Namespace(local=True, ref="some/path", output_path=None)
     with patch("subprocess.call") as mock_call:
         run(args)
         mock_call.assert_called_once_with(
@@ -176,6 +176,7 @@ def test_kfp_run(tmp_path_factory):
     args = argparse.Namespace(
         kubeflow=True,
         local=False,
+        output_path=None,
         ref="some/path",
         host=None,
     )
@@ -188,6 +189,7 @@ def test_kfp_run(tmp_path_factory):
         args = argparse.Namespace(
             kubeflow=True,
             local=False,
+            output_path=None,
             host="localhost",
             ref="some/path",
         )


### PR DESCRIPTION
Fixes bug that was encountered by @NielsRogge. Issue was that the runner default output was added to the compiler only and not the runner. 