### PR TITLE
Add option to setup preemptible VMs

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -48,7 +48,16 @@ Next, we define two operations: `load_from_hub_op`, which is a based from a reus
     Currently Fondant supports linear DAGs with single dependencies. Support for non-linear DAGs will be available in future releases.
 
 ## Setting Custom node pool parameters
-Each component can optionally be constrained to run on particular node(s) using `node_pool_label` and `node_pool_name`. You can find these under the Kubernetes labels of your cluster. You can use the default node label provided by Kubernetes or attach your own. Note that the value of these labels is cloud provider specific.
+Each component can optionally be constrained to run on particular node(s) using `node_pool_label` and `node_pool_name`. You can find these under the Kubernetes labels of your cluster. 
+You can use the default node label provided by Kubernetes or attach your own. Note that the value of these labels is cloud provider specific.  
+
+Note that you can also setup a component to use a preemptible VM by setting `preemptible` to `True`.
+This Requires the setup and assignment of a preemptible node pool. Note that preemptibles only work
+when KFP is setup on GCP. 
+
+More info here: https://v1-6-branch.kubeflow.org/docs/distributions/gke/pipelines/preemptible/
+
+
 
 ## Setting Custom partitioning parameters
 

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -35,6 +35,10 @@ class ComponentOp:
         node_pool_label: The label of the node pool to which the operation will be assigned.
         node_pool_name: The name of the node pool to which the operation will be assigned.
         cache: Set to False to disable caching, True by default.
+        preemptible: False by default. Set to True to use a preemptible VM.
+         Requires the setup and assignment of a preemptible node pool. Note that preemptibles only
+         work when KFP is setup on GCP. More info here:
+         https://v1-6-branch.kubeflow.org/docs/distributions/gke/pipelines/preemptible/
 
     Note:
         - A Fondant Component operation is created by defining a Fondant Component and its input
@@ -58,6 +62,7 @@ class ComponentOp:
         node_pool_label: t.Optional[str] = None,
         node_pool_name: t.Optional[str] = None,
         cache: t.Optional[bool] = True,
+        preemptible: t.Optional[bool] = False,
     ) -> None:
         self.component_dir = Path(component_dir)
         self.input_partition_rows = input_partition_rows
@@ -74,6 +79,7 @@ class ComponentOp:
             node_pool_label,
             node_pool_name,
         )
+        self.preemptible = preemptible
 
     def _configure_caching_from_image_tag(
         self,
@@ -152,6 +158,7 @@ class ComponentOp:
         node_pool_label: t.Optional[str] = None,
         node_pool_name: t.Optional[str] = None,
         cache: t.Optional[bool] = True,
+        preemptible: t.Optional[bool] = False,
     ) -> "ComponentOp":
         """Load a reusable component by its name.
 
@@ -164,6 +171,11 @@ class ComponentOp:
             node_pool_label: The label of the node pool to which the operation will be assigned.
             node_pool_name: The name of the node pool to which the operation will be assigned.
             cache: Set to False to disable caching, True by default.
+            preemptible: False by default. Set to True to use a preemptible VM.
+             Requires the setup and assignment of a preemptible node pool. Note that preemptibles
+             only work when KFP is setup on GCP. More info here:
+             https://v1-6-branch.kubeflow.org/docs/distributions/gke/pipelines/preemptible/
+
         """
         components_dir: Path = t.cast(Path, files("fondant") / f"components/{name}")
 
@@ -179,6 +191,7 @@ class ComponentOp:
             node_pool_label=node_pool_label,
             node_pool_name=node_pool_name,
             cache=cache,
+            preemptible=preemptible,
         )
 
     def get_component_cache_key(self) -> str:

--- a/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
@@ -15,7 +15,17 @@ spec:
   entrypoint: test-pipeline
   serviceAccountName: pipeline-runner
   templates:
-  - container:
+  - affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+            - key: cloud.google.com/gke-preemptible
+              operator: In
+              values:
+              - 'true'
+          weight: 50
+    container:
       args: []
       command:
       - fondant
@@ -91,6 +101,11 @@ spec:
       artifacts:
       - name: first-component-output_manifest_path
         path: /tmp/outputs/output_manifest_path/data
+    tolerations:
+    - effect: NoSchedule
+      key: preemptible
+      operator: Equal
+      value: 'true'
   - container:
       args: []
       command:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -22,6 +22,7 @@ TEST_PIPELINES = [
                     arguments={"storage_args": "a dummy string arg"},
                     input_partition_rows="disable",
                     number_of_gpus=1,
+                    preemptible=True,
                 ),
                 "cache_key": "1",
             },


### PR DESCRIPTION
PR that adds an option to set a preemptible VM on the component spec level. 
This can be done by setting `preemptible` to True at the `Op` level. Note that you also need to assign a preemptible nodepool. I have already setup some preemptible nodepools in [this PR](https://github.com/ml6team/Express-infra/compare/add-preemtibles-node-pools?expand=1) 

Caveat: seems like kfp currently only enables setting up preemptibles on a GCP cluster since this functionaliteis seems to be tightly integrated with GKE. More info [here](
Preemptible nodepools can only run up to 24 hours [link](https://cloud.google.com/compute/docs/instances/preemptible#:~:text=Compute%20Engine%20always%20stops%20preemptible%20instances%20after%20they%20run%20for%2024%20hours.%20Certain%20actions%20reset%20this%2024%2Dhour%20counter.)

We can think later on incorporating a retry mechanism once the issue with Dask is fixed. For now those VMs can be used to reduce development costs. 