### PR TITLE
Add hardware configs

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -30,7 +30,8 @@ def build_pipeline():
             "batch_size": 2,  
             "max_new_tokens": 50,  
         },  
-        number_of_gpus=1,
+        number_of_accelerators=1,
+        accelerator_name="GPU",
         node_pool_label="node_pool",  
         node_pool_name="model-inference-pool",  
     )

--- a/examples/pipelines/controlnet-interior-design/pipeline.py
+++ b/examples/pipelines/controlnet-interior-design/pipeline.py
@@ -45,7 +45,8 @@ caption_images_op = ComponentOp.from_registry(
         "batch_size": 2,
         "max_new_tokens": 50,
     },
-    number_of_gpus=1,
+    number_of_accelerators=1,
+    accelerator_name="GPU",
 )
 segment_images_op = ComponentOp.from_registry(
     name="segment_images",
@@ -53,7 +54,8 @@ segment_images_op = ComponentOp.from_registry(
         "model_id": "openmmlab/upernet-convnext-small",
         "batch_size": 2,
     },
-    number_of_gpus=1,
+    number_of_accelerators=1,
+    accelerator_name="GPU",
 )
 
 write_to_hub_controlnet = ComponentOp(

--- a/examples/pipelines/datacomp/pipeline.py
+++ b/examples/pipelines/datacomp/pipeline.py
@@ -66,7 +66,8 @@ detect_text_op = ComponentOp(
     },
     node_pool_label="node_pool",
     node_pool_name="model-inference-mega-pool",
-    number_of_gpus=1,
+    number_of_accelerators=1,
+    accelerator_name="GPU",
     cache=False,
 )
 mask_images_op = ComponentOp(
@@ -82,7 +83,8 @@ embed_images_op = ComponentOp.from_registry(
     },
     node_pool_label="node_pool",
     node_pool_name="model-inference-mega-pool",
-    number_of_gpus=1,
+    number_of_accelerators=1,
+    accelerator_name="GPU",
     cache=False,
 )
 add_clip_score_op = ComponentOp(

--- a/examples/pipelines/finetune_stable_diffusion/pipeline.py
+++ b/examples/pipelines/finetune_stable_diffusion/pipeline.py
@@ -69,7 +69,8 @@ caption_images_op = ComponentOp.from_registry(
         "batch_size": 2,
         "max_new_tokens": 50,
     },
-    number_of_gpus=1,
+    number_of_accelerators=1,
+    accelerator_name="GPU",
 )
 
 write_to_hub = ComponentOp(
@@ -80,7 +81,8 @@ write_to_hub = ComponentOp(
         "hf_token": "hf_token",
         "image_column_names": ["images_data"],
     },
-    number_of_gpus=1,
+    number_of_accelerators=1,
+    accelerator_name="GPU",
 )
 
 pipeline = Pipeline(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ fsspec = { version = ">= 2023.4.0", optional = true}
 gcsfs = { version = ">= 2023.4.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }
 adlfs = { version = ">= 2023.4.0", optional = true }
-kfp = { version = "2.0.1", optional = true }
+kfp = { version = "2.0.1", optional = true, extras =["kubernetes"] }
 pandas = { version = ">= 1.3.5", optional = true }
 
 [tool.poetry.extras]

--- a/src/fondant/component_spec.py
+++ b/src/fondant/component_spec.py
@@ -247,7 +247,7 @@ class KubeflowComponentSpec:
 
     @staticmethod
     def sanitize_component_name(name: str) -> str:
-        """Cleans and converts a name to be k8s compatible.
+        """Cleans and converts a name to be kfp V2 compatible.
 
         Taken from https://github.com/kubeflow/pipelines/blob/
         cfe671c485d4ee8514290ee81ca2785e8bda5c9b/sdk/python/kfp/dsl/utils.py#L52

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -55,11 +55,10 @@ class ComponentOp:
         automatic partitioning
         number_of_accelerators: The number of accelerators to assign to the operation (GPU, TPU)
         accelerator_name: The name of the accelerator to assign. If you're using a cluster setup
-          on GKE, select "nvidia.com/gpu" for GPU or "cloud-tpus.google.com/v3" for TPU. Make sure
+          on GKE, select "GPU" for GPU or "TPU" for TPU. Make sure
           that you select a nodepool with the available hardware. If you're running the
           pipeline on Vertex, then select one of the machines specified in the list of
           accelerators here https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec.
-          Defaults to "nvidia.com/gpu".
         node_pool_label: The label of the node pool to which the operation will be assigned.
         node_pool_name: The name of the node pool to which the operation will be assigned.
         cache: Set to False to disable caching, True by default.
@@ -67,7 +66,7 @@ class ComponentOp:
     Note:
         - A Fondant Component operation is created by defining a Fondant Component and its input
           arguments.
-        - The `number_of_gpus`, `node_pool_label`, `node_pool_name`
+        - The `accelerator_name`, `node_pool_label`, `node_pool_name`
          attributes are optional and can be used to specify additional
           configurations for the operation. More information on the optional attributes that can
           be assigned to kfp components here:
@@ -215,11 +214,10 @@ class ComponentOp:
             automatic partitioning
             number_of_accelerators: The number of accelerators to assign to the operation (GPU, TPU)
             accelerator_name: The name of the accelerator to assign. If you're using a cluster setup
-              on GKE, select "nvidia.com/gpu" for GPU or "cloud-tpus.google.com/v3" for TPU. Make
+              on GKE, select "GPU" for GPU or "TPU" for TPU. Make
               sure that you select a nodepool with the available hardware. If you're running the
               pipeline on Vertex, then select one of the machines specified in the list of
               accelerators here https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec.
-              Defaults to "nvidia.com/gpu".
             node_pool_label: The label of the node pool to which the operation will be assigned.
             node_pool_name: The name of the node pool to which the operation will be assigned.
             cache: Set to False to disable caching, True by default.

--- a/tests/example_pipelines/compiled_pipeline/example_1/docker-compose.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/docker-compose.yml
@@ -22,14 +22,6 @@ services:
       {"type": "binary"}}}, "captions": {"fields": {"data": {"type": "string"}}}},
       "args": {"storage_args": {"description": "Storage arguments", "type": "str"}}}'
     depends_on: {}
-    deploy:
-      resources:
-        reservations:
-          devices:
-          - capabilities:
-            - gpu
-            count: 1
-            driver: nvidia
     volumes: []
   second_component:
     build:

--- a/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
@@ -2,185 +2,31 @@
 # Name: testpipeline
 # Description: description of the test pipeline
 components:
-  comp-First_component:
-    executorLabel: exec-First_component
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        storage_args:
-          description: Storage arguments
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
-  comp-Second_component:
-    executorLabel: exec-Second_component
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        storage_args:
-          description: Storage arguments
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
-  comp-Third_component:
-    executorLabel: exec-Third_component
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        storage_args:
-          description: Storage arguments
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-first-component:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: First_component
-      tasks:
-        First_component:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-First_component
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: First_component
+    executorLabel: exec-first-component
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         storage_args:
-          description: Storage arguments
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -188,66 +34,31 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-second-component:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: Second_component
-      tasks:
-        Second_component:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-Second_component
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: Second_component
+    executorLabel: exec-second-component
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         storage_args:
-          description: Storage arguments
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -255,66 +66,31 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-third-component:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: Third_component
-      tasks:
-        Third_component:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-Third_component
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: Third_component
+    executorLabel: exec-third-component
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         storage_args:
-          description: Storage arguments
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -322,10 +98,9 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
 deploymentSpec:
   executors:
-    exec-First_component:
+    exec-first-component:
       container:
         args:
         - --input_manifest_path
@@ -347,7 +122,7 @@ deploymentSpec:
         - execute
         - main
         image: example_component:latest
-    exec-Second_component:
+    exec-second-component:
       container:
         args:
         - --input_manifest_path
@@ -369,7 +144,7 @@ deploymentSpec:
         - execute
         - main
         image: example_component:latest
-    exec-Third_component:
+    exec-third-component:
       container:
         args:
         - --input_manifest_path

--- a/tests/example_pipelines/compiled_pipeline/example_1/vertex_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/vertex_pipeline.yml
@@ -2,185 +2,31 @@
 # Name: testpipeline
 # Description: description of the test pipeline
 components:
-  comp-First_component:
-    executorLabel: exec-First_component
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        storage_args:
-          description: Storage arguments
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
-  comp-Second_component:
-    executorLabel: exec-Second_component
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        storage_args:
-          description: Storage arguments
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
-  comp-Third_component:
-    executorLabel: exec-Third_component
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        storage_args:
-          description: Storage arguments
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-first-component:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: First_component
-      tasks:
-        First_component:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-First_component
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: First_component
+    executorLabel: exec-first-component
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         storage_args:
-          description: Storage arguments
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -188,66 +34,31 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-second-component:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: Second_component
-      tasks:
-        Second_component:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-Second_component
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: Second_component
+    executorLabel: exec-second-component
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         storage_args:
-          description: Storage arguments
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -255,66 +66,31 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-third-component:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: Third_component
-      tasks:
-        Third_component:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-Third_component
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: Third_component
+    executorLabel: exec-third-component
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         storage_args:
-          description: Storage arguments
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -322,10 +98,9 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
 deploymentSpec:
   executors:
-    exec-First_component:
+    exec-first-component:
       container:
         args:
         - --input_manifest_path
@@ -347,7 +122,7 @@ deploymentSpec:
         - execute
         - main
         image: example_component:latest
-    exec-Second_component:
+    exec-second-component:
       container:
         args:
         - --input_manifest_path
@@ -369,7 +144,7 @@ deploymentSpec:
         - execute
         - main
         image: example_component:latest
-    exec-Third_component:
+    exec-third-component:
       container:
         args:
         - --input_manifest_path

--- a/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
@@ -2,155 +2,31 @@
 # Name: testpipeline
 # Description: description of the test pipeline
 components:
-  comp-First_component:
-    executorLabel: exec-First_component
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        storage_args:
-          description: Storage arguments
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
-  comp-Image_cropping:
-    executorLabel: exec-Image_cropping
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        cropping_threshold:
-          defaultValue: -30.0
-          description: Threshold parameter used for detecting borders. A lower (negative)
-            parameter results in a more performant border detection, but can cause
-            overcropping. Default is -30
-          isOptional: true
-          parameterType: NUMBER_INTEGER
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        padding:
-          defaultValue: 10.0
-          description: Padding for the image cropping. The padding is added to all
-            borders of the image.
-          isOptional: true
-          parameterType: NUMBER_INTEGER
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-first-component:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: First_component
-      tasks:
-        First_component:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-First_component
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: First_component
+    executorLabel: exec-first-component
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         storage_args:
-          description: Storage arguments
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -158,75 +34,36 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-image-cropping:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: Image_cropping
-      tasks:
-        Image_cropping:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-Image_cropping
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: Image_cropping
+    executorLabel: exec-image-cropping
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         cropping_threshold:
           defaultValue: -30.0
-          description: Threshold parameter used for detecting borders. A lower (negative)
-            parameter results in a more performant border detection, but can cause
-            overcropping. Default is -30
           isOptional: true
           parameterType: NUMBER_INTEGER
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         padding:
           defaultValue: 10.0
-          description: Padding for the image cropping. The padding is added to all
-            borders of the image.
           isOptional: true
           parameterType: NUMBER_INTEGER
     outputDefinitions:
@@ -235,10 +72,9 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
 deploymentSpec:
   executors:
-    exec-First_component:
+    exec-first-component:
       container:
         args:
         - --input_manifest_path
@@ -260,7 +96,7 @@ deploymentSpec:
         - execute
         - main
         image: example_component:latest
-    exec-Image_cropping:
+    exec-image-cropping:
       container:
         args:
         - --input_manifest_path

--- a/tests/example_pipelines/compiled_pipeline/example_2/vertex_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/vertex_pipeline.yml
@@ -2,155 +2,31 @@
 # Name: testpipeline
 # Description: description of the test pipeline
 components:
-  comp-First_component:
-    executorLabel: exec-First_component
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        storage_args:
-          description: Storage arguments
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
-  comp-Image_cropping:
-    executorLabel: exec-Image_cropping
-    inputDefinitions:
-      artifacts:
-        input_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the input manifest
-          isOptional: true
-      parameters:
-        cache:
-          defaultValue: true
-          description: Set to False to disable caching, True by default.
-          isOptional: true
-          parameterType: BOOLEAN
-        component_spec:
-          defaultValue: {}
-          description: The component specification as a dictionary
-          isOptional: true
-          parameterType: STRUCT
-        cropping_threshold:
-          defaultValue: -30.0
-          description: Threshold parameter used for detecting borders. A lower (negative)
-            parameter results in a more performant border detection, but can cause
-            overcropping. Default is -30
-          isOptional: true
-          parameterType: NUMBER_INTEGER
-        input_partition_rows:
-          defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
-          isOptional: true
-          parameterType: STRING
-        metadata:
-          description: Metadata arguments containing the run id and base path
-          parameterType: STRING
-        padding:
-          defaultValue: 10.0
-          description: Padding for the image cropping. The padding is added to all
-            borders of the image.
-          isOptional: true
-          parameterType: NUMBER_INTEGER
-    outputDefinitions:
-      artifacts:
-        output_manifest_path:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-first-component:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: First_component
-      tasks:
-        First_component:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-First_component
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: First_component
+    executorLabel: exec-first-component
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         storage_args:
-          description: Storage arguments
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -158,75 +34,36 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
   comp-image-cropping:
-    dag:
-      outputs:
-        artifacts:
-          output_manifest_path:
-            artifactSelectors:
-            - outputArtifactKey: output_manifest_path
-              producerSubtask: Image_cropping
-      tasks:
-        Image_cropping:
-          cachingOptions:
-            enableCache: true
-          componentRef:
-            name: comp-Image_cropping
-          inputs:
-            artifacts:
-              input_manifest_path:
-                componentInputArtifact: input_manifest_path
-            parameters:
-              cache:
-                componentInputParameter: cache
-              component_spec:
-                componentInputParameter: component_spec
-              input_partition_rows:
-                componentInputParameter: input_partition_rows
-              metadata:
-                componentInputParameter: metadata
-          taskInfo:
-            name: Image_cropping
+    executorLabel: exec-image-cropping
     inputDefinitions:
       artifacts:
         input_manifest_path:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the input manifest
           isOptional: true
       parameters:
         cache:
           defaultValue: true
-          description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
         component_spec:
           defaultValue: {}
-          description: The component specification as a dictionary
           isOptional: true
           parameterType: STRUCT
         cropping_threshold:
           defaultValue: -30.0
-          description: Threshold parameter used for detecting borders. A lower (negative)
-            parameter results in a more performant border detection, but can cause
-            overcropping. Default is -30
           isOptional: true
           parameterType: NUMBER_INTEGER
         input_partition_rows:
           defaultValue: None
-          description: The number of rows to load per partition. Set to override the
-            automatic partitioning
           isOptional: true
           parameterType: STRING
         metadata:
-          description: Metadata arguments containing the run id and base path
           parameterType: STRING
         padding:
           defaultValue: 10.0
-          description: Padding for the image cropping. The padding is added to all
-            borders of the image.
           isOptional: true
           parameterType: NUMBER_INTEGER
     outputDefinitions:
@@ -235,10 +72,9 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path to the output manifest
 deploymentSpec:
   executors:
-    exec-First_component:
+    exec-first-component:
       container:
         args:
         - --input_manifest_path
@@ -260,7 +96,7 @@ deploymentSpec:
         - execute
         - main
         image: example_component:latest
-    exec-Image_cropping:
+    exec-image-cropping:
       container:
         args:
         - --input_manifest_path

--- a/tests/example_pipelines/compiled_pipeline/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/kubeflow_pipeline.yml
@@ -1,9 +1,9 @@
 {
   "components":
     {
-      "comp-Example_component":
+      "comp-example-component":
         {
-          "executorLabel": "exec-Example_component",
+          "executorLabel": "exec-example-component",
           "inputDefinitions":
             {
               "artifacts":
@@ -75,7 +75,7 @@
     {
       "executors":
         {
-          "exec-Example_component":
+          "exec-example-component":
             {
               "container":
                 {
@@ -102,7 +102,7 @@
             },
         },
     },
-  "pipelineInfo": { "name": "Example_component" },
+  "pipelineInfo": { "name": "example-component" },
   "root":
     {
       "dag":
@@ -117,7 +117,7 @@
                         [
                           {
                             "outputArtifactKey": "output_manifest_path",
-                            "producerSubtask": "Example_component",
+                            "producerSubtask": "example-component",
                           },
                         ],
                     },
@@ -125,10 +125,10 @@
             },
           "tasks":
             {
-              "Example_component":
+              "example-component":
                 {
                   "cachingOptions": { "enableCache": True },
-                  "componentRef": { "name": "comp-Example_component" },
+                  "componentRef": { "name": "comp-example-component" },
                   "inputs":
                     {
                       "artifacts":
@@ -148,7 +148,7 @@
                           "cache": { "componentInputParameter": "cache" },
                         },
                     },
-                  "taskInfo": { "name": "Example_component" },
+                  "taskInfo": { "name": "example-component" },
                 },
             },
         },

--- a/tests/example_specs/component_specs/kubeflow_component.yaml
+++ b/tests/example_specs/component_specs/kubeflow_component.yaml
@@ -1,9 +1,9 @@
 {
     "components":
         {
-            "comp-Example_component":
+            "comp-example-component":
                 {
-                    "executorLabel": "exec-Example_component",
+                    "executorLabel": "exec-example-component",
                     "inputDefinitions":
                         {
                             "artifacts":
@@ -75,7 +75,7 @@
         {
             "executors":
                 {
-                    "exec-Example_component":
+                    "exec-example-component":
                         {
                             "container":
                                 {
@@ -102,7 +102,7 @@
                         },
                 },
         },
-    "pipelineInfo": { "name": "Example_component" },
+    "pipelineInfo": { "name": "example-component" },
     "root":
         {
             "dag":
@@ -117,7 +117,7 @@
                                                 [
                                                     {
                                                         "outputArtifactKey": "output_manifest_path",
-                                                        "producerSubtask": "Example_component",
+                                                        "producerSubtask": "example-component",
                                                     },
                                                 ],
                                         },
@@ -125,11 +125,11 @@
                         },
                     "tasks":
                         {
-                            "Example_component":
+                            "example-component":
                                 {
                                     "cachingOptions": { "enableCache": True },
                                     "componentRef":
-                                        { "name": "comp-Example_component" },
+                                        { "name": "comp-example-component" },
                                     "inputs":
                                         {
                                             "artifacts":
@@ -159,7 +159,7 @@
                                                         },
                                                 },
                                         },
-                                    "taskInfo": { "name": "Example_component" },
+                                    "taskInfo": { "name": "example-component" },
                                 },
                         },
                 },

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 import yaml
 from fondant.compiler import DockerCompiler, KubeFlowCompiler, VertexCompiler
+from fondant.exceptions import InvalidPipelineDefinition
 from fondant.pipeline import ComponentOp, Pipeline
 
 COMPONENTS_PATH = Path("./tests/example_pipelines/valid_pipeline")
@@ -21,7 +22,6 @@ TEST_PIPELINES = [
                     Path(COMPONENTS_PATH / "example_1" / "first_component"),
                     arguments={"storage_args": "a dummy string arg"},
                     input_partition_rows="disable",
-                    number_of_gpus=1,
                 ),
                 "cache_key": "1",
             },
@@ -221,6 +221,68 @@ def test_docker_extra_volumes(setup_pipeline, tmp_path_factory):
 
 
 @pytest.mark.usefixtures("_freeze_time")
+def test_docker_configuration(tmp_path_factory):
+    """Test that extra volumes are applied correctly."""
+    pipeline = Pipeline(
+        pipeline_name="test_pipeline",
+        pipeline_description="description of the test pipeline",
+        base_path="/foo/bar",
+    )
+    component_1 = ComponentOp(
+        Path(COMPONENTS_PATH / "example_1" / "first_component"),
+        arguments={"storage_args": "a dummy string arg"},
+        number_of_accelerators=1,
+        accelerator_name="GPU",
+    )
+
+    expected_resources = {
+        "reservations": {
+            "devices": [
+                {
+                    "capabilities": ["gpu"],
+                    "count": 1,
+                    "driver": "nvidia",
+                },
+            ],
+        },
+    }
+
+    pipeline.add_op(component_1)
+    compiler = DockerCompiler()
+    with tmp_path_factory.mktemp("temp") as fn:
+        output_path = str(fn / "docker-compose.yaml")
+        compiler.compile(pipeline=pipeline, output_path=output_path)
+        # read the generated docker-compose file
+        with open(output_path) as f_spec:
+            spec = yaml.safe_load(f_spec)
+        assert (
+            spec["services"]["first_component"]["deploy"]["resources"]
+            == expected_resources
+        )
+
+
+@pytest.mark.usefixtures("_freeze_time")
+def test_invalid_docker_configuration(tmp_path_factory):
+    """Test that extra volumes are applied correctly."""
+    pipeline = Pipeline(
+        pipeline_name="test_pipeline",
+        pipeline_description="description of the test pipeline",
+        base_path="/foo/bar",
+    )
+    component_1 = ComponentOp(
+        Path(COMPONENTS_PATH / "example_1" / "first_component"),
+        arguments={"storage_args": "a dummy string arg"},
+        number_of_accelerators=1,
+        accelerator_name="unknown resource",
+    )
+
+    pipeline.add_op(component_1)
+    compiler = DockerCompiler()
+    with pytest.raises(InvalidPipelineDefinition):
+        compiler.compile(pipeline=pipeline, output_path="kubeflow_pipeline.yml")
+
+
+@pytest.mark.usefixtures("_freeze_time")
 def test_kubeflow_compiler(setup_pipeline, tmp_path_factory):
     """Test compiling a pipeline to kubeflow."""
     example_dir, pipeline, _ = setup_pipeline
@@ -234,13 +296,71 @@ def test_kubeflow_compiler(setup_pipeline, tmp_path_factory):
             assert yaml.safe_load(src) == yaml.safe_load(truth)
 
 
-# @pytest.mark.usefixtures("_freeze_time")
-# def test_kubeflow_configuration(tmp_path_factory):
-#     """Test that the kubeflow pipeline can be configured."""
-#     with tmp_path_factory.mktemp("temp") as fn:
-#         with open(output_path) as src, open(
-#             VALID_PIPELINE / "kubeflow_pipeline.yml",
-#         ) as truth:
+@pytest.mark.usefixtures("_freeze_time")
+def test_kubeflow_configuration(tmp_path_factory):
+    """Test that the kubeflow pipeline can be configured."""
+    node_pool_label = "dummy_label"
+    node_pool_name = "dummy_label"
+
+    pipeline = Pipeline(
+        pipeline_name="test_pipeline",
+        pipeline_description="description of the test pipeline",
+        base_path="/foo/bar",
+    )
+    component_1 = ComponentOp(
+        Path(COMPONENTS_PATH / "example_1" / "first_component"),
+        arguments={"storage_args": "a dummy string arg"},
+        node_pool_label=node_pool_label,
+        node_pool_name=node_pool_name,
+        number_of_accelerators=1,
+        accelerator_name="GPU",
+    )
+    pipeline.add_op(component_1)
+    compiler = KubeFlowCompiler()
+    with tmp_path_factory.mktemp("temp") as fn:
+        output_path = str(fn / "kubeflow_pipeline.yml")
+        compiler.compile(pipeline=pipeline, output_path=output_path)
+        with open(output_path) as src:
+            # Two specs are present and loaded in the yaml file (component spec and k8s specs)
+            compiled_specs = yaml.load_all(src, Loader=yaml.FullLoader)
+            for spec in compiled_specs:
+                if "platforms" in spec:
+                    component_kubernetes_spec = spec["platforms"]["kubernetes"][
+                        "deploymentSpec"
+                    ]["executors"]["exec-first-component"]
+                    assert component_kubernetes_spec["nodeSelector"]["labels"] == {
+                        node_pool_label: node_pool_name,
+                    }
+
+                elif "deploymentSpec" in spec:
+                    component_resources = spec["deploymentSpec"]["executors"][
+                        "exec-first-component"
+                    ]["container"]["resources"]
+                    assert component_resources["accelerator"]["count"] == "1"
+                    assert (
+                        component_resources["accelerator"]["type"] == "nvidia.com/gpu"
+                    )
+
+
+@pytest.mark.usefixtures("_freeze_time")
+def test_invalid_kubeflow_configuration(tmp_path_factory):
+    """Test that an error is returned when an invalid resource is provided."""
+    pipeline = Pipeline(
+        pipeline_name="test_pipeline",
+        pipeline_description="description of the test pipeline",
+        base_path="/foo/bar",
+    )
+    component_1 = ComponentOp(
+        Path(COMPONENTS_PATH / "example_1" / "first_component"),
+        arguments={"storage_args": "a dummy string arg"},
+        number_of_accelerators=1,
+        accelerator_name="unknown resource",
+    )
+
+    pipeline.add_op(component_1)
+    compiler = KubeFlowCompiler()
+    with pytest.raises(InvalidPipelineDefinition):
+        compiler.compile(pipeline=pipeline, output_path="kubeflow_pipeline.yml")
 
 
 def test_kfp_import():
@@ -264,3 +384,54 @@ def test_vertex_compiler(setup_pipeline, tmp_path_factory):
             VALID_PIPELINE / example_dir / "vertex_pipeline.yml",
         ) as truth:
             assert yaml.safe_load(src) == yaml.safe_load(truth)
+
+
+@pytest.mark.usefixtures("_freeze_time")
+def test_vertex_configuration(tmp_path_factory):
+    """Test that the kubeflow pipeline can be configured."""
+    pipeline = Pipeline(
+        pipeline_name="test_pipeline",
+        pipeline_description="description of the test pipeline",
+        base_path="/foo/bar",
+    )
+    component_1 = ComponentOp(
+        Path(COMPONENTS_PATH / "example_1" / "first_component"),
+        arguments={"storage_args": "a dummy string arg"},
+        number_of_accelerators=1,
+        accelerator_name="NVIDIA_TESLA_K80",
+    )
+    pipeline.add_op(component_1)
+    compiler = VertexCompiler()
+    with tmp_path_factory.mktemp("temp") as fn:
+        output_path = str(fn / "vertex_pipeline.yml")
+        compiler.compile(pipeline=pipeline, output_path=output_path)
+        with open(output_path) as src:
+            # Two specs are present and loaded in the yaml file (component spec and k8s specs)
+            compiled_specs = yaml.safe_load(src)
+
+        component_resources = compiled_specs["deploymentSpec"]["executors"][
+            "exec-first-component"
+        ]["container"]["resources"]
+        assert component_resources["accelerator"]["count"] == "1"
+        assert component_resources["accelerator"]["type"] == "NVIDIA_TESLA_K80"
+
+
+@pytest.mark.usefixtures("_freeze_time")
+def test_invalid_vertex_configuration(tmp_path_factory):
+    """Test that extra volumes are applied correctly."""
+    pipeline = Pipeline(
+        pipeline_name="test_pipeline",
+        pipeline_description="description of the test pipeline",
+        base_path="/foo/bar",
+    )
+    component_1 = ComponentOp(
+        Path(COMPONENTS_PATH / "example_1" / "first_component"),
+        arguments={"storage_args": "a dummy string arg"},
+        number_of_accelerators=1,
+        accelerator_name="unknown resource",
+    )
+
+    pipeline.add_op(component_1)
+    compiler = VertexCompiler()
+    with pytest.raises(InvalidPipelineDefinition):
+        compiler.compile(pipeline=pipeline, output_path="kubeflow_pipeline.yml")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -53,6 +53,13 @@ def test_component_op(
             node_pool_label="dummy_label",
         )
 
+    with pytest.raises(InvalidPipelineDefinition):
+        ComponentOp(
+            Path(components_path / component_names[0]),
+            arguments=component_args,
+            number_of_accelerators=1,
+        )
+
 
 @pytest.mark.parametrize(
     "valid_pipeline_example",


### PR DESCRIPTION
PR that adds option to set hardware accelerators to KFP V2 (nodepool 

Notes: 
* Each component was previously configured as a sub-pipeline because of an error in detecting a certain field in the V2 spec (`exec-<sanitizied_component_name`) which forces to kubeflow to compile component to a pipeline spec instead of a component spec [link](https://github.com/kubeflow/pipelines/blob/ad058b5321f5fe74bbd10845778e6627fb9aa5cb/sdk/python/kfp/dsl/structures.py#L462). This was resolved by adding the same custom method used by KFP to format the component name to Fondant.

This makes it possible to assign resources to each component since KFP does not allow assigning resources on a pipeline level 
* Setting up and running nodepools is still to be tested on native KFP
