### PR TITLE
Fix v2 defaults

### DIFF
--- a/components/download_images/fondant_component.yaml
+++ b/components/download_images/fondant_component.yaml
@@ -39,7 +39,7 @@ args:
   resize_only_if_bigger: 
     description: If True, resize only if image is bigger than image_size.
     type: bool
-    default: 'False'
+    default: False
   min_image_size:
     description: Minimum size of the images.
     type: int

--- a/docs/component_spec.md
+++ b/docs/component_spec.md
@@ -124,8 +124,6 @@ The `args` section describes which arguments the component takes. Each argument 
 `description` and a `type`, which should be one of the builtin Python types. Additionally, you can 
 set an optional `default` value for each argument.
 
-_Note:_ default iterable arguments such as `dict` and `list` have to be passed as a string 
-(e.g. `'{"foo":1, "bar":2}`, `'["foo","bar]'`)
 ```yaml
 args:
   custom_argument:

--- a/src/fondant/compiler.py
+++ b/src/fondant/compiler.py
@@ -419,7 +419,6 @@ class VertexCompiler(Compiler):
                     k: v for k, v in component_op.arguments.items() if v is not None
                 }
 
-                # Ren
                 metadata = Metadata(
                     pipeline_name=pipeline.name,
                     run_id=run_id,

--- a/src/fondant/compiler.py
+++ b/src/fondant/compiler.py
@@ -297,10 +297,14 @@ class KubeFlowCompiler(Compiler):
                     text=component_op.component_spec.kubeflow_specification.to_string(),
                 )
 
+                # Remove None values from arguments
+                component_args = {
+                    k: v for k, v in component_op.arguments.items() if v is not None
+                }
+
                 # # Set image pull policy to always
                 # Execute the Kubeflow component and pass in the output manifest path from
                 # the previous component.
-                component_args = component_op.arguments
 
                 if previous_component_task is not None:
                     component_task = kubeflow_component_op(
@@ -410,10 +414,12 @@ class VertexCompiler(Compiler):
                     text=component_op.component_spec.kubeflow_specification.to_string(),
                 )
 
-                # Execute the Kubeflow component and pass in the output manifest path from
-                # the previous component.
+                # Remove None values from arguments
+                component_args = {
+                    k: v for k, v in component_op.arguments.items() if v is not None
+                }
 
-                component_args = component_op.arguments
+                # Ren
                 metadata = Metadata(
                     pipeline_name=pipeline.name,
                     run_id=run_id,
@@ -424,6 +430,8 @@ class VertexCompiler(Compiler):
                 # Set the execution order of the component task to be after the previous
                 # component task.
                 if previous_component_task is not None:
+                    # Execute the Kubeflow component and pass in the output manifest path from
+                    # the previous component.
                     component_task = kubeflow_component_op(
                         input_manifest_path=manifest_path,
                         metadata=metadata.to_json(),

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -121,7 +121,7 @@ class Executor(t.Generic[Component]):
             if arg.name in cls.optional_fondant_arguments():
                 input_required = False
                 default = None
-            elif arg.default is not None:
+            elif arg.default is not None or arg.optional is True:
                 input_required = False
                 default = arg.default
             else:

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -152,7 +152,7 @@ class ComponentOp:
 
         input_partition_rows = validate_partition_number(self.input_partition_rows)
 
-        arguments["input_partition_rows"] = str(input_partition_rows)
+        arguments["input_partition_rows"] = input_partition_rows
         arguments["cache"] = self.cache
 
         return arguments

--- a/src/fondant/schemas/component_spec.json
+++ b/src/fondant/schemas/component_spec.json
@@ -88,6 +88,15 @@
               },
               {
                 "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array"
+              },
+              {
+                "type": "object"
               }
             ]
           }

--- a/tests/example_pipelines/compiled_pipeline/example_1/docker-compose.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     - --storage_args
     - a dummy string arg
     - --input_partition_rows
-    - disable
+    - '10'
     - --cache
     - 'False'
     - --component_spec

--- a/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
@@ -1,6 +1,3 @@
-# PIPELINE DEFINITION
-# Name: testpipeline
-# Description: description of the test pipeline
 components:
   comp-first-component:
     executorLabel: exec-first-component
@@ -21,9 +18,8 @@ components:
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         storage_args:
@@ -53,9 +49,8 @@ components:
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         storage_args:
@@ -85,9 +80,8 @@ components:
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         storage_args:
@@ -203,7 +197,7 @@ root:
                           type: binary
             input_partition_rows:
               runtimeValue:
-                constant: disable
+                constant: 10.0
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -255,7 +249,7 @@ root:
                           type: array
             input_partition_rows:
               runtimeValue:
-                constant: '10'
+                constant: 10.0
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -314,9 +308,6 @@ root:
                       fields:
                         data:
                           type: binary
-            input_partition_rows:
-              runtimeValue:
-                constant: None
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",

--- a/tests/example_pipelines/compiled_pipeline/example_1/vertex_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/vertex_pipeline.yml
@@ -1,6 +1,3 @@
-# PIPELINE DEFINITION
-# Name: testpipeline
-# Description: description of the test pipeline
 components:
   comp-first-component:
     executorLabel: exec-first-component
@@ -21,9 +18,8 @@ components:
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         storage_args:
@@ -53,9 +49,8 @@ components:
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         storage_args:
@@ -85,9 +80,8 @@ components:
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         storage_args:
@@ -203,7 +197,7 @@ root:
                           type: binary
             input_partition_rows:
               runtimeValue:
-                constant: disable
+                constant: 10.0
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -255,7 +249,7 @@ root:
                           type: array
             input_partition_rows:
               runtimeValue:
-                constant: '10'
+                constant: 10.0
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -314,9 +308,6 @@ root:
                       fields:
                         data:
                           type: binary
-            input_partition_rows:
-              runtimeValue:
-                constant: None
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",

--- a/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
@@ -1,6 +1,3 @@
-# PIPELINE DEFINITION
-# Name: testpipeline
-# Description: description of the test pipeline
 components:
   comp-first-component:
     executorLabel: exec-first-component
@@ -21,9 +18,8 @@ components:
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         storage_args:
@@ -57,9 +53,8 @@ components:
           isOptional: true
           parameterType: NUMBER_INTEGER
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         padding:
@@ -155,9 +150,6 @@ root:
                       fields:
                         data:
                           type: binary
-            input_partition_rows:
-              runtimeValue:
-                constant: None
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -221,9 +213,6 @@ root:
             cropping_threshold:
               runtimeValue:
                 constant: 0.0
-            input_partition_rows:
-              runtimeValue:
-                constant: None
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",

--- a/tests/example_pipelines/compiled_pipeline/example_2/vertex_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/vertex_pipeline.yml
@@ -1,6 +1,3 @@
-# PIPELINE DEFINITION
-# Name: testpipeline
-# Description: description of the test pipeline
 components:
   comp-first-component:
     executorLabel: exec-first-component
@@ -21,9 +18,8 @@ components:
           isOptional: true
           parameterType: STRUCT
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         storage_args:
@@ -57,9 +53,8 @@ components:
           isOptional: true
           parameterType: NUMBER_INTEGER
         input_partition_rows:
-          defaultValue: None
           isOptional: true
-          parameterType: STRING
+          parameterType: NUMBER_INTEGER
         metadata:
           parameterType: STRING
         padding:
@@ -155,9 +150,6 @@ root:
                       fields:
                         data:
                           type: binary
-            input_partition_rows:
-              runtimeValue:
-                constant: None
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -221,9 +213,6 @@ root:
             cropping_threshold:
               runtimeValue:
                 constant: 0.0
-            input_partition_rows:
-              runtimeValue:
-                constant: None
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",

--- a/tests/example_pipelines/compiled_pipeline/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/kubeflow_pipeline.yml
@@ -33,7 +33,6 @@
                       "description": "The number of rows to load per partition. Set to override the automatic partitioning",
                       "isOptional": True,
                       "parameterType": "STRING",
-                      "defaultValue": "None",
                     },
                   "cache":
                     {
@@ -181,7 +180,6 @@
                   "description": "The number of rows to load per partition. Set to override the automatic partitioning",
                   "isOptional": True,
                   "parameterType": "STRING",
-                  "defaultValue": "None",
                 },
               "cache":
                 {

--- a/tests/example_specs/component_specs/kubeflow_component.yaml
+++ b/tests/example_specs/component_specs/kubeflow_component.yaml
@@ -1,234 +1,99 @@
-{
-    "components":
-        {
-            "comp-example-component":
-                {
-                    "executorLabel": "exec-example-component",
-                    "inputDefinitions":
-                        {
-                            "artifacts":
-                                {
-                                    "input_manifest_path":
-                                        {
-                                            "description": "Path to the input manifest",
-                                            "artifactType":
-                                                {
-                                                    "schemaTitle": "system.Artifact",
-                                                    "schemaVersion": "0.0.1",
-                                                },
-                                            "isOptional": True,
-                                        },
-                                },
-                            "parameters":
-                                {
-                                    "component_spec":
-                                        {
-                                            "description": "The component specification as a dictionary",
-                                            "defaultValue": {},
-                                            "isOptional": True,
-                                            "parameterType": "STRUCT",
-                                        },
-                                    "input_partition_rows":
-                                        {
-                                            "description": "The number of rows to load per partition. Set to override the automatic partitioning",
-                                            "isOptional": True,
-                                            "parameterType": "STRING",
-                                            "defaultValue": "None",
-                                        },
-                                    "cache":
-                                        {
-                                            "parameterType": "BOOLEAN",
-                                            "description": "Set to False to disable caching, True by default.",
-                                            "defaultValue": True,
-                                            "isOptional": True,
-                                        },
-                                    "metadata":
-                                        {
-                                            "description": "Metadata arguments containing the run id and base path",
-                                            "parameterType": "STRING",
-                                        },
-                                    "storage_args":
-                                        {
-                                            "parameterType": "STRING",
-                                            "description": "Storage arguments",
-                                        },
-                                },
-                        },
-                    "outputDefinitions":
-                        {
-                            "artifacts":
-                                {
-                                    "output_manifest_path":
-                                        {
-                                            "artifactType":
-                                                {
-                                                    "schemaTitle": "system.Artifact",
-                                                    "schemaVersion": "0.0.1",
-                                                },
-                                            "description": "Path to the output manifest",
-                                        },
-                                },
-                        },
-                },
-        },
-    "deploymentSpec":
-        {
-            "executors":
-                {
-                    "exec-example-component":
-                        {
-                            "container":
-                                {
-                                    "args":
-                                        [
-                                            "--input_manifest_path",
-                                            "{{$.inputs.artifacts['input_manifest_path'].uri}}",
-                                            "--metadata",
-                                            "{{$.inputs.parameters['metadata']}}",
-                                            "--component_spec",
-                                            "{{$.inputs.parameters['component_spec']}}",
-                                            "--input_partition_rows",
-                                            "{{$.inputs.parameters['input_partition_rows']}}",
-                                            "--cache",
-                                            "{{$.inputs.parameters['cache']}}",
-                                            "--storage_args",
-                                            "{{$.inputs.parameters['storage_args']}}",
-                                            "--output_manifest_path",
-                                            "{{$.outputs.artifacts['output_manifest_path'].uri}}",
-                                        ],
-                                    "command": ["fondant", "execute", "main"],
-                                    "image": "example_component:latest",
-                                },
-                        },
-                },
-        },
-    "pipelineInfo": { "name": "example-component" },
-    "root":
-        {
-            "dag":
-                {
-                    "outputs":
-                        {
-                            "artifacts":
-                                {
-                                    "output_manifest_path":
-                                        {
-                                            "artifactSelectors":
-                                                [
-                                                    {
-                                                        "outputArtifactKey": "output_manifest_path",
-                                                        "producerSubtask": "example-component",
-                                                    },
-                                                ],
-                                        },
-                                },
-                        },
-                    "tasks":
-                        {
-                            "example-component":
-                                {
-                                    "cachingOptions": { "enableCache": True },
-                                    "componentRef":
-                                        { "name": "comp-example-component" },
-                                    "inputs":
-                                        {
-                                            "artifacts":
-                                                {
-                                                    "input_manifest_path":
-                                                        {
-                                                            "componentInputArtifact": "input_manifest_path",
-                                                        },
-                                                },
-                                            "parameters":
-                                                {
-                                                    "component_spec":
-                                                        {
-                                                            "componentInputParameter": "component_spec",
-                                                        },
-                                                    "input_partition_rows":
-                                                        {
-                                                            "componentInputParameter": "input_partition_rows",
-                                                        },
-                                                    "metadata":
-                                                        {
-                                                            "componentInputParameter": "metadata",
-                                                        },
-                                                    "cache":
-                                                        {
-                                                            "componentInputParameter": "cache",
-                                                        },
-                                                },
-                                        },
-                                    "taskInfo": { "name": "example-component" },
-                                },
-                        },
-                },
-            "inputDefinitions":
-                {
-                    "artifacts":
-                        {
-                            "input_manifest_path":
-                                {
-                                    "description": "Path to the input manifest",
-                                    "artifactType":
-                                        {
-                                            "schemaTitle": "system.Artifact",
-                                            "schemaVersion": "0.0.1",
-                                        },
-                                    "isOptional": True,
-                                },
-                        },
-                    "parameters":
-                        {
-                            "component_spec":
-                                {
-                                    "description": "The component specification as a dictionary",
-                                    "defaultValue": {},
-                                    "isOptional": True,
-                                    "parameterType": "STRUCT",
-                                },
-                            "input_partition_rows":
-                                {
-                                    "description": "The number of rows to load per partition. Set to override the automatic partitioning",
-                                    "isOptional": True,
-                                    "parameterType": "STRING",
-                                    "defaultValue": "None",
-                                },
-                            "cache":
-                                {
-                                    "parameterType": "BOOLEAN",
-                                    "description": "Set to False to disable caching, True by default.",
-                                    "defaultValue": True,
-                                    "isOptional": True,
-                                },
-                            "metadata":
-                                {
-                                    "description": "Metadata arguments containing the run id and base path",
-                                    "parameterType": "STRING",
-                                },
-                            "storage_args":
-                                {
-                                    "parameterType": "STRING",
-                                    "description": "Storage arguments",
-                                },
-                        },
-                },
-            "outputDefinitions":
-                {
-                    "artifacts":
-                        {
-                            "output_manifest_path":
-                                {
-                                    "artifactType":
-                                        {
-                                            "schemaTitle": "system.Artifact",
-                                            "schemaVersion": "0.0.1",
-                                        },
-                                    "description": "Path to the output manifest",
-                                },
-                        },
-                },
-        },
-    "schemaVersion": "2.1.0",
-    "sdkVersion": "kfp-2.0.1",
-}
+components:
+  comp-example-component:
+    executorLabel: exec-example-component
+    inputDefinitions: &id001
+      artifacts:
+        input_manifest_path:
+          description: Path to the input manifest
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+          isOptional: true
+      parameters:
+        component_spec:
+          description: The component specification as a dictionary
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
+        input_partition_rows:
+          description: The number of rows to load per partition. Set to override the
+            automatic partitioning
+          isOptional: true
+          parameterType: NUMBER_INTEGER
+        cache:
+          parameterType: BOOLEAN
+          description: Set to False to disable caching, True by default.
+          defaultValue: true
+          isOptional: true
+        metadata:
+          description: Metadata arguments containing the run id and base path
+          parameterType: STRING
+        storage_args:
+          parameterType: STRING
+          description: Storage arguments
+    outputDefinitions: &id002
+      artifacts:
+        output_manifest_path:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+          description: Path to the output manifest
+deploymentSpec:
+  executors:
+    exec-example-component:
+      container:
+        args:
+        - --input_manifest_path
+        - '{{$.inputs.artifacts[''input_manifest_path''].uri}}'
+        - --metadata
+        - '{{$.inputs.parameters[''metadata'']}}'
+        - --component_spec
+        - '{{$.inputs.parameters[''component_spec'']}}'
+        - --input_partition_rows
+        - '{{$.inputs.parameters[''input_partition_rows'']}}'
+        - --cache
+        - '{{$.inputs.parameters[''cache'']}}'
+        - --storage_args
+        - '{{$.inputs.parameters[''storage_args'']}}'
+        - --output_manifest_path
+        - '{{$.outputs.artifacts[''output_manifest_path''].uri}}'
+        command:
+        - fondant
+        - execute
+        - main
+        image: example_component:latest
+pipelineInfo:
+  name: example-component
+root:
+  dag:
+    outputs:
+      artifacts:
+        output_manifest_path:
+          artifactSelectors:
+          - outputArtifactKey: output_manifest_path
+            producerSubtask: example-component
+    tasks:
+      example-component:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-example-component
+        inputs:
+          artifacts:
+            input_manifest_path:
+              componentInputArtifact: input_manifest_path
+          parameters:
+            component_spec:
+              componentInputParameter: component_spec
+            input_partition_rows:
+              componentInputParameter: input_partition_rows
+            metadata:
+              componentInputParameter: metadata
+            cache:
+              componentInputParameter: cache
+        taskInfo:
+          name: example-component
+  inputDefinitions: *id001
+  outputDefinitions: *id002
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.0.1

--- a/tests/example_specs/components/arguments/component.yaml
+++ b/tests/example_specs/components/arguments/component.yaml
@@ -18,19 +18,19 @@ args:
   bool_false_default_arg:
     description: default bool argument
     type: bool
-    default: 'False'
+    default: False
   bool_true_default_arg:
     description: default bool argument
     type: bool
-    default: 'True'
+    default: True
   list_default_arg:
     description: default list argument
     type: list
-    default: '["foo", "bar"]'
+    default: ["foo", "bar"]
   dict_default_arg:
     description: default dict argument
     type: dict
-    default: '{"foo":1, "bar":2}'
+    default: {"foo":1, "bar":2}
   string_default_arg_none:
     description: default string argument
     type: str

--- a/tests/example_specs/components/arguments/component_default_args.yaml
+++ b/tests/example_specs/components/arguments/component_default_args.yaml
@@ -18,19 +18,19 @@ args:
   bool_false_default_arg:
     description: default bool argument
     type: bool
-    default: 'False'
+    default: False
   bool_true_default_arg:
     description: default bool argument
     type: bool
-    default: 'True'
+    default: True
   list_default_arg:
     description: default list argument
     type: list
-    default: '["foo", "bar"]'
+    default: ["foo", "bar"]
   dict_default_arg:
     description: default dict argument
     type: dict
-    default: '{"foo":1, "bar":2}'
+    default: {"foo":1, "bar":2}
   string_default_arg_none:
     description: default string argument
     type: str

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -21,7 +21,7 @@ TEST_PIPELINES = [
                 "component_op": ComponentOp(
                     Path(COMPONENTS_PATH / "example_1" / "first_component"),
                     arguments={"storage_args": "a dummy string arg"},
-                    input_partition_rows="disable",
+                    input_partition_rows=10,
                 ),
                 "cache_key": "1",
             },
@@ -29,7 +29,7 @@ TEST_PIPELINES = [
                 "component_op": ComponentOp(
                     Path(COMPONENTS_PATH / "example_1" / "second_component"),
                     arguments={"storage_args": "a dummy string arg"},
-                    input_partition_rows="10",
+                    input_partition_rows=10,
                 ),
                 "cache_key": "2",
             },

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -123,13 +123,13 @@ def test_component_arguments(metadata):
     assert executor.input_partition_rows == expected_partition_row_arg
     assert executor.cache is True
     assert executor.user_arguments == {
-        "string_default_arg": "foo",
         "integer_default_arg": 0,
         "float_default_arg": 3.14,
         "bool_false_default_arg": False,
         "bool_true_default_arg": True,
         "list_default_arg": ["foo", "bar"],
         "dict_default_arg": {"foo": 1, "bar": 2},
+        "string_default_arg": "foo",
         "string_default_arg_none": None,
         "integer_default_arg_none": None,
         "float_default_arg_none": None,
@@ -285,7 +285,7 @@ def test_dask_transform_component(metadata):
         "--value",
         "1",
         "--input_partition_rows",
-        "disable",
+        "10",
         "--output_manifest_path",
         str(components_path / "output_manifest.json"),
         "--component_spec",
@@ -307,7 +307,8 @@ def test_dask_transform_component(metadata):
 
     executor_factory = ExecutorFactory(MyDaskComponent)
     executor = executor_factory.get_executor()
-    assert executor.input_partition_rows == "disable"
+    expected_input_partition_rows = 10
+    assert executor.input_partition_rows == expected_input_partition_rows
     transform = patch_method_class(MyDaskComponent.transform)
     with mock.patch.object(
         MyDaskComponent,


### PR DESCRIPTION
PR that fixes the v2 default /optional types. KFP v2 has two different optional types: 

- Optional values that default to None -> defined by setting `isOptional` to True and not passing the default value
- Optional values that default to another values  -> defined by setting the value in  `defaultValue` and having `isOptional` False or empty. 

This PR adjusts the componentSpec accordingly. Another nice win is that we do not have to define bools/dicts/lists as strings in the component spec 

Few things no note: 

* Due to strict type. Mixing different data types is not allowed -> we had to change the type of `input_partition_rows` to int. Which means it does not accept the value `disable` anymore. Need to fix this in a seperate PR 
* 'inf` as float is not allowed 
