### PR TITLE
Set dask local scheduler as default

### DIFF
--- a/src/fondant/component_spec.py
+++ b/src/fondant/component_spec.py
@@ -273,7 +273,7 @@ class KubeflowComponentSpec:
                     "name": "cluster_type",
                     "description": "The type of cluster to use for distributed execution",
                     "type": "String",
-                    "default": "local",
+                    "default": "default",
                 },
                 {
                     "name": "client_kwargs",

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -100,9 +100,8 @@ class Executor(t.Generic[Component]):
             raise NotImplementedError(msg)
         else:
             logger.info(
-                f"We currently do not support {cluster_type}. "
-                f"Our supported options are limited to 'local' and 'distributed'. "
-                f"Dask local mode will be used for further executions.",
+                "Dask default local mode will be used for further executions."
+                "Our current supported options are limited to 'local' and 'default'.",
             )
             self.client = None
 

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -65,7 +65,7 @@ class ComponentOp:
         node_pool_name: t.Optional[str] = None,
         cache: t.Optional[bool] = True,
         preemptible: t.Optional[bool] = False,
-        cluster_type: t.Optional[str] = "local",
+        cluster_type: t.Optional[str] = "default",
         client_kwargs: t.Optional[dict] = None,
     ) -> None:
         self.component_dir = Path(component_dir)
@@ -173,7 +173,7 @@ class ComponentOp:
         node_pool_name: t.Optional[str] = None,
         cache: t.Optional[bool] = True,
         preemptible: t.Optional[bool] = False,
-        cluster_type: t.Optional[str] = "local",
+        cluster_type: t.Optional[str] = "default",
         client_kwargs: t.Optional[dict] = None,
     ) -> "ComponentOp":
         """Load a reusable component by its name.

--- a/tests/example_pipelines/compiled_pipeline/example_1/docker-compose.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     - --cache
     - 'True'
     - --cluster_type
-    - local
+    - default
     - --component_spec
     - '{"name": "First component", "description": "This is an example component",
       "image": "example_component:latest", "produces": {"images": {"fields": {"data":
@@ -52,7 +52,7 @@ services:
     - --cache
     - 'True'
     - --cluster_type
-    - local
+    - default
     - --component_spec
     - '{"name": "Second component", "description": "This is an example component",
       "image": "example_component:latest", "consumes": {"images": {"fields": {"data":
@@ -82,7 +82,7 @@ services:
     - --cache
     - 'True'
     - --cluster_type
-    - local
+    - default
     - --component_spec
     - '{"name": "Third component", "description": "This is an example component",
       "image": "example_component:latest", "consumes": {"images": {"fields": {"data":

--- a/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
@@ -50,7 +50,7 @@ spec:
       - --output_manifest_path
       - /tmp/outputs/output_manifest_path/data
       - --cluster_type
-      - local
+      - default
       - --client_kwargs
       - '{}'
       image: example_component:latest
@@ -67,7 +67,7 @@ spec:
     metadata:
       annotations:
         pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "client_kwargs":
-          "{}", "cluster_type": "local", "component_spec": "{\"args\": {\"storage_args\":
+          "{}", "cluster_type": "default", "component_spec": "{\"args\": {\"storage_args\":
           {\"description\": \"Storage arguments\", \"type\": \"str\"}}, \"description\":
           \"This is an example component\", \"image\": \"example_component:latest\",
           \"name\": \"First component\", \"produces\": {\"captions\": {\"fields\":
@@ -76,7 +76,7 @@ spec:
           "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\", \"run_id\":
           \"test_pipeline-20230101000000\", \"component_id\": \"first_component\",
           \"cache_key\": \"1\"}", "storage_args": "a dummy string arg"}'
-        pipelines.kubeflow.org/component_ref: '{"digest": "fa027f119dc037eb255b5a6826e2c6697f6f4ffbac366ab4600ba3a9f94aef17"}'
+        pipelines.kubeflow.org/component_ref: '{"digest": "ba182d1dd6a5f8fdffb3c9e487c84d1d1b9ebbfe4b5a137a4af02be832c0c820"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",
           "main", "--input_manifest_path", {"inputPath": "input_manifest_path"}, "--metadata",
@@ -94,7 +94,7 @@ spec:
           rows to load per partition. Set to override the automatic partitioning",
           "name": "input_partition_rows", "type": "String"}, {"default": "True", "description":
           "Set to False to disable caching, True by default.", "name": "cache", "type":
-          "Boolean"}, {"default": "local", "description": "The type of cluster to
+          "Boolean"}, {"default": "default", "description": "The type of cluster to
           use for distributed execution", "name": "cluster_type", "type": "String"},
           {"default": "{}", "description": "Keyword arguments used to initialise the
           dask client", "name": "client_kwargs", "type": "JsonObject"}, {"description":
@@ -141,7 +141,7 @@ spec:
       - --output_manifest_path
       - /tmp/outputs/output_manifest_path/data
       - --cluster_type
-      - local
+      - default
       - --client_kwargs
       - '{}'
       image: example_component:latest
@@ -153,7 +153,7 @@ spec:
     metadata:
       annotations:
         pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "client_kwargs":
-          "{}", "cluster_type": "local", "component_spec": "{\"args\": {\"storage_args\":
+          "{}", "cluster_type": "default", "component_spec": "{\"args\": {\"storage_args\":
           {\"description\": \"Storage arguments\", \"type\": \"str\"}}, \"consumes\":
           {\"images\": {\"fields\": {\"data\": {\"type\": \"binary\"}}}}, \"description\":
           \"This is an example component\", \"image\": \"example_component:latest\",
@@ -163,7 +163,7 @@ spec:
           \"pipeline_name\": \"test_pipeline\", \"run_id\": \"test_pipeline-20230101000000\",
           \"component_id\": \"second_component\", \"cache_key\": \"2\"}", "storage_args":
           "a dummy string arg"}'
-        pipelines.kubeflow.org/component_ref: '{"digest": "95e51b6417bb05924e4ff864258f462f6cd551362e98882e38e94e9875493898"}'
+        pipelines.kubeflow.org/component_ref: '{"digest": "e8f5a26a42664b1e4774da40117b542baa9676368d9e05262a40e4fd10be0e68"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",
           "main", "--input_manifest_path", {"inputPath": "input_manifest_path"}, "--metadata",
@@ -181,7 +181,7 @@ spec:
           rows to load per partition. Set to override the automatic partitioning",
           "name": "input_partition_rows", "type": "String"}, {"default": "True", "description":
           "Set to False to disable caching, True by default.", "name": "cache", "type":
-          "Boolean"}, {"default": "local", "description": "The type of cluster to
+          "Boolean"}, {"default": "default", "description": "The type of cluster to
           use for distributed execution", "name": "cluster_type", "type": "String"},
           {"default": "{}", "description": "Keyword arguments used to initialise the
           dask client", "name": "client_kwargs", "type": "JsonObject"}, {"description":
@@ -246,7 +246,7 @@ spec:
       - --output_manifest_path
       - /tmp/outputs/output_manifest_path/data
       - --cluster_type
-      - local
+      - default
       - --client_kwargs
       - '{}'
       image: example_component:latest
@@ -258,7 +258,7 @@ spec:
     metadata:
       annotations:
         pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "client_kwargs":
-          "{}", "cluster_type": "local", "component_spec": "{\"args\": {\"storage_args\":
+          "{}", "cluster_type": "default", "component_spec": "{\"args\": {\"storage_args\":
           {\"description\": \"Storage arguments\", \"type\": \"str\"}}, \"consumes\":
           {\"captions\": {\"fields\": {\"data\": {\"type\": \"string\"}}}, \"embeddings\":
           {\"fields\": {\"data\": {\"items\": {\"type\": \"float32\"}, \"type\": \"array\"}}},
@@ -269,7 +269,7 @@ spec:
           "None", "metadata": "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\",
           \"run_id\": \"test_pipeline-20230101000000\", \"component_id\": \"third_component\",
           \"cache_key\": \"3\"}", "storage_args": "a dummy string arg"}'
-        pipelines.kubeflow.org/component_ref: '{"digest": "dd35c317cfb8ae4ebead14a866b7677f889c4dc1bc942212c904e7fb85d33a3c"}'
+        pipelines.kubeflow.org/component_ref: '{"digest": "8d2ae6379592151eea3b644c61fb091a68a431ac15ed24064cb66434cabf6e08"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",
           "main", "--input_manifest_path", {"inputPath": "input_manifest_path"}, "--metadata",
@@ -287,7 +287,7 @@ spec:
           rows to load per partition. Set to override the automatic partitioning",
           "name": "input_partition_rows", "type": "String"}, {"default": "True", "description":
           "Set to False to disable caching, True by default.", "name": "cache", "type":
-          "Boolean"}, {"default": "local", "description": "The type of cluster to
+          "Boolean"}, {"default": "default", "description": "The type of cluster to
           use for distributed execution", "name": "cluster_type", "type": "String"},
           {"default": "{}", "description": "Keyword arguments used to initialise the
           dask client", "name": "client_kwargs", "type": "JsonObject"}, {"description":

--- a/tests/example_pipelines/compiled_pipeline/example_2/docker-compose.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     - --cache
     - 'True'
     - --cluster_type
-    - local
+    - default
     - --component_spec
     - '{"name": "First component", "description": "This is an example component",
       "image": "example_component:latest", "produces": {"images": {"fields": {"data":
@@ -39,7 +39,7 @@ services:
     - --cache
     - 'True'
     - --cluster_type
-    - local
+    - default
     - --component_spec
     - '{"name": "Image cropping", "description": "Component that removes single-colored
       borders around images and crops them appropriately", "image": "ghcr.io/ml6team/image_cropping:dev",

--- a/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
@@ -40,7 +40,7 @@ spec:
       - --output_manifest_path
       - /tmp/outputs/output_manifest_path/data
       - --cluster_type
-      - local
+      - default
       - --client_kwargs
       - '{}'
       image: example_component:latest
@@ -54,7 +54,7 @@ spec:
     metadata:
       annotations:
         pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "client_kwargs":
-          "{}", "cluster_type": "local", "component_spec": "{\"args\": {\"storage_args\":
+          "{}", "cluster_type": "default", "component_spec": "{\"args\": {\"storage_args\":
           {\"description\": \"Storage arguments\", \"type\": \"str\"}}, \"description\":
           \"This is an example component\", \"image\": \"example_component:latest\",
           \"name\": \"First component\", \"produces\": {\"captions\": {\"fields\":
@@ -63,7 +63,7 @@ spec:
           "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\", \"run_id\":
           \"test_pipeline-20230101000000\", \"component_id\": \"first_component\",
           \"cache_key\": \"1\"}", "storage_args": "a dummy string arg"}'
-        pipelines.kubeflow.org/component_ref: '{"digest": "fa027f119dc037eb255b5a6826e2c6697f6f4ffbac366ab4600ba3a9f94aef17"}'
+        pipelines.kubeflow.org/component_ref: '{"digest": "ba182d1dd6a5f8fdffb3c9e487c84d1d1b9ebbfe4b5a137a4af02be832c0c820"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",
           "main", "--input_manifest_path", {"inputPath": "input_manifest_path"}, "--metadata",
@@ -81,7 +81,7 @@ spec:
           rows to load per partition. Set to override the automatic partitioning",
           "name": "input_partition_rows", "type": "String"}, {"default": "True", "description":
           "Set to False to disable caching, True by default.", "name": "cache", "type":
-          "Boolean"}, {"default": "local", "description": "The type of cluster to
+          "Boolean"}, {"default": "default", "description": "The type of cluster to
           use for distributed execution", "name": "cluster_type", "type": "String"},
           {"default": "{}", "description": "Keyword arguments used to initialise the
           dask client", "name": "client_kwargs", "type": "JsonObject"}, {"description":
@@ -130,7 +130,7 @@ spec:
       - --output_manifest_path
       - /tmp/outputs/output_manifest_path/data
       - --cluster_type
-      - local
+      - default
       - --client_kwargs
       - '{}'
       image: ghcr.io/ml6team/image_cropping:dev
@@ -142,7 +142,7 @@ spec:
     metadata:
       annotations:
         pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "client_kwargs":
-          "{}", "cluster_type": "local", "component_spec": "{\"args\": {\"cropping_threshold\":
+          "{}", "cluster_type": "default", "component_spec": "{\"args\": {\"cropping_threshold\":
           {\"default\": -30, \"description\": \"Threshold parameter used for detecting
           borders. A lower (negative) parameter results in a more performant border
           detection, but can cause overcropping. Default is -30\", \"type\": \"int\"},
@@ -157,7 +157,7 @@ spec:
           "metadata": "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\",
           \"run_id\": \"test_pipeline-20230101000000\", \"component_id\": \"image_cropping\",
           \"cache_key\": \"2\"}", "padding": "0"}'
-        pipelines.kubeflow.org/component_ref: '{"digest": "957fdd80bb26d6a78c7d20ca6116bed681443f982c9cbc7ee640017c2cbddbb2"}'
+        pipelines.kubeflow.org/component_ref: '{"digest": "d31e5d546956a42a470f033e2be84f229d3e926dfa7a7a1703c94ff47a1cb992"}'
         pipelines.kubeflow.org/component_spec: '{"description": "Component that removes
           single-colored borders around images and crops them appropriately", "implementation":
           {"container": {"command": ["fondant", "execute", "main", "--input_manifest_path",
@@ -176,7 +176,7 @@ spec:
           rows to load per partition. Set to override the automatic partitioning",
           "name": "input_partition_rows", "type": "String"}, {"default": "True", "description":
           "Set to False to disable caching, True by default.", "name": "cache", "type":
-          "Boolean"}, {"default": "local", "description": "The type of cluster to
+          "Boolean"}, {"default": "default", "description": "The type of cluster to
           use for distributed execution", "name": "cluster_type", "type": "String"},
           {"default": "{}", "description": "Keyword arguments used to initialise the
           dask client", "name": "client_kwargs", "type": "JsonObject"}, {"default":

--- a/tests/example_pipelines/compiled_pipeline/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/kubeflow_pipeline.yml
@@ -25,7 +25,7 @@ spec:
       - /tmp/inputs/input_manifest_path/data
       - --metadata
       - '{"base_path": "/foo/bar", "pipeline_name": "test_pipeline", "run_id": "test_pipeline-20230101000000",
-        "component_id": "first_component", "cache_key": "d02d8db2a8c7283abec87def979197f8"}'
+        "component_id": "first_component", "cache_key": "1ba5e93659a51abe43ddd64b31bc1c59"}'
       - --component_spec
       - '{"args": {"storage_args": {"description": "Storage arguments", "type": "str"}},
         "description": "This is an example component", "image": "example_component:latest",
@@ -40,7 +40,7 @@ spec:
       - --output_manifest_path
       - /tmp/outputs/output_manifest_path/data
       - --cluster_type
-      - local
+      - default
       - --client_kwargs
       - '{}'
       image: example_component:latest
@@ -57,7 +57,7 @@ spec:
     metadata:
       annotations:
         pipelines.kubeflow.org/arguments.parameters: '{"cache": "True", "client_kwargs":
-          "{}", "cluster_type": "local", "component_spec": "{\"args\": {\"storage_args\":
+          "{}", "cluster_type": "default", "component_spec": "{\"args\": {\"storage_args\":
           {\"description\": \"Storage arguments\", \"type\": \"str\"}}, \"description\":
           \"This is an example component\", \"image\": \"example_component:latest\",
           \"name\": \"First component\", \"produces\": {\"captions\": {\"fields\":
@@ -65,9 +65,9 @@ spec:
           {\"type\": \"binary\"}}}}}", "input_partition_rows": "None", "metadata":
           "{\"base_path\": \"/foo/bar\", \"pipeline_name\": \"test_pipeline\", \"run_id\":
           \"test_pipeline-20230101000000\", \"component_id\": \"first_component\",
-          \"cache_key\": \"d02d8db2a8c7283abec87def979197f8\"}", "storage_args": "a
+          \"cache_key\": \"1ba5e93659a51abe43ddd64b31bc1c59\"}", "storage_args": "a
           dummy string arg"}'
-        pipelines.kubeflow.org/component_ref: '{"digest": "fa027f119dc037eb255b5a6826e2c6697f6f4ffbac366ab4600ba3a9f94aef17"}'
+        pipelines.kubeflow.org/component_ref: '{"digest": "ba182d1dd6a5f8fdffb3c9e487c84d1d1b9ebbfe4b5a137a4af02be832c0c820"}'
         pipelines.kubeflow.org/component_spec: '{"description": "This is an example
           component", "implementation": {"container": {"command": ["fondant", "execute",
           "main", "--input_manifest_path", {"inputPath": "input_manifest_path"}, "--metadata",
@@ -85,7 +85,7 @@ spec:
           rows to load per partition. Set to override the automatic partitioning",
           "name": "input_partition_rows", "type": "String"}, {"default": "True", "description":
           "Set to False to disable caching, True by default.", "name": "cache", "type":
-          "Boolean"}, {"default": "local", "description": "The type of cluster to
+          "Boolean"}, {"default": "default", "description": "The type of cluster to
           use for distributed execution", "name": "cluster_type", "type": "String"},
           {"default": "{}", "description": "Keyword arguments used to initialise the
           dask client", "name": "client_kwargs", "type": "JsonObject"}, {"description":

--- a/tests/example_specs/component_specs/kubeflow_component.yaml
+++ b/tests/example_specs/component_specs/kubeflow_component.yaml
@@ -23,7 +23,7 @@ inputs:
 -   name: cluster_type
     description: The type of cluster to use for distributed execution
     type: String
-    default: local
+    default: default
 -   name: client_kwargs
     description: Keyword arguments used to initialise the dask client
     type: JsonObject


### PR DESCRIPTION
Still, there might be some issues with the usage of the dask client and local cluster. To make it more intuitive, we should revert to using the old way as the default. This PR sets the old way as the default option, and the client usage will now need to be set explicitly.