### PR TITLE
Use auto_mkdir in fs_open calls

### DIFF
--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -273,7 +273,12 @@ class Executor(t.Generic[Component]):
         )
 
         try:
-            with fs_open(manifest_reference_path, mode="rt", encoding="utf-8") as file_:
+            with fs_open(
+                manifest_reference_path,
+                mode="rt",
+                encoding="utf-8",
+                auto_mkdir=True,
+            ) as file_:
                 cached_manifest_path = file_.read()
                 manifest = Manifest.from_file(cached_manifest_path)
                 logger.info(
@@ -379,7 +384,12 @@ class Executor(t.Generic[Component]):
 
         logger.info(f"Writing cache key to {manifest_reference_path}")
 
-        with fs_open(manifest_reference_path, mode="wt", encoding="utf-8") as file_:
+        with fs_open(
+            manifest_reference_path,
+            mode="wt",
+            encoding="utf-8",
+            auto_mkdir=True,
+        ) as file_:
             file_.write(str(manifest_save_path))
 
     def upload_manifest(self, manifest: Manifest, save_path: t.Union[str, Path]):

--- a/src/fondant/manifest.py
+++ b/src/fondant/manifest.py
@@ -179,13 +179,13 @@ class Manifest:
     @classmethod
     def from_file(cls, path: t.Union[str, Path]) -> "Manifest":
         """Load the manifest from the file specified by the provided path."""
-        with fs_open(path, encoding="utf-8") as file_:
+        with fs_open(path, encoding="utf-8", auto_mkdir=True) as file_:
             specification = json.load(file_)
             return cls(specification)
 
     def to_file(self, path: t.Union[str, Path]) -> None:
         """Dump the manifest to the file specified by the provided path."""
-        with fs_open(path, "w", encoding="utf-8") as file_:
+        with fs_open(path, "w", encoding="utf-8", auto_mkdir=True) as file_:
             json.dump(self._specification, file_)
 
     def copy(self) -> "Manifest":


### PR DESCRIPTION
There was a change of the default behaviour in the recent fsspec release (2023.9.1)
Use the `auto_mkdir` in fs_open to utilize automatic directory creation. 

Solves #440 