### PR TITLE
Enable defining additional Vertex Resources

### DIFF
--- a/src/fondant/compiler.py
+++ b/src/fondant/compiler.py
@@ -463,6 +463,8 @@ class VertexCompiler(Compiler):
         # Unpack optional specifications
         number_of_accelerators = fondant_component_operation.number_of_accelerators
         accelerator_name = fondant_component_operation.accelerator_name
+        cpu_request = fondant_component_operation.cpu_request
+        memory_request = fondant_component_operation.memory_request
 
         # Assign optional specification
         if number_of_accelerators is not None:
@@ -475,5 +477,11 @@ class VertexCompiler(Compiler):
                 raise InvalidPipelineDefinition(msg)
 
             task.set_accelerator_type(accelerator_name)
+
+        if memory_request is not None:
+            task.set_memory_limit(memory_request)
+
+        if cpu_request is not None:
+            task.set_cpu_limit(str(cpu_request))
 
         return task

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -61,7 +61,13 @@ class ComponentOp:
           accelerators here https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec.
         node_pool_label: The label of the node pool to which the operation will be assigned.
         node_pool_name: The name of the node pool to which the operation will be assigned.
-        cache: Set to False to disable caching, True by default.
+        cache: Set to False in order to disable caching, True by default.
+        cpu_request: The CPU cores to request. This string value can be a number
+         (integer value for number of CPUs), or a number followed by "m", which means 1/1000.
+         You can specify at most 96 CPUs.
+        memory_request: The RAM memory to request. This string value can be a number,
+        or a number followed by "K" (kilobyte), "M" (megabyte), or "G" (gigabyte). At most 624GB
+        is supported.
 
     Note:
         - A Fondant Component operation is created by defining a Fondant Component and its input
@@ -86,6 +92,8 @@ class ComponentOp:
         node_pool_label: t.Optional[str] = None,
         node_pool_name: t.Optional[str] = None,
         cache: t.Optional[bool] = True,
+        cpu_request: t.Optional[int] = None,
+        memory_request: t.Optional[t.Union[str, int]] = None,
     ) -> None:
         self.component_dir = Path(component_dir)
         self.input_partition_rows = input_partition_rows
@@ -108,6 +116,8 @@ class ComponentOp:
             number_of_accelerators,
             accelerator_name,
         )
+        self.cpu_request = cpu_request
+        self.memory_request = memory_request
 
     def _configure_caching_from_image_tag(
         self,
@@ -204,6 +214,8 @@ class ComponentOp:
         node_pool_label: t.Optional[str] = None,
         node_pool_name: t.Optional[str] = None,
         cache: t.Optional[bool] = True,
+        cpu_request: t.Optional[int] = None,
+        memory_request: t.Optional[t.Union[str, int]] = None,
     ) -> "ComponentOp":
         """Load a reusable component by its name.
 
@@ -221,6 +233,13 @@ class ComponentOp:
             node_pool_label: The label of the node pool to which the operation will be assigned.
             node_pool_name: The name of the node pool to which the operation will be assigned.
             cache: Set to False to disable caching, True by default.
+            machine_type: the machine type to run the component on (currently only valid for Vertex)
+            cpu_request: The CPU cores to request. This string value can be a number
+             (integer value for number of CPUs), or a number followed by "m", which means 1/1000.
+             You can specify at most 96 CPUs.
+            memory_request: The RAM memory to request. This string value can be a number,
+                or a number followed by "K" (kilobyte), "M" (megabyte), or "G" (gigabyte).
+                At most 624GB is supported.
         """
         components_dir: Path = t.cast(Path, files("fondant") / f"components/{name}")
 
@@ -237,6 +256,8 @@ class ComponentOp:
             node_pool_label=node_pool_label,
             node_pool_name=node_pool_name,
             cache=cache,
+            cpu_request=cpu_request,
+            memory_request=memory_request,
         )
 
     def get_component_cache_key(self) -> str:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -399,6 +399,8 @@ def test_vertex_configuration(tmp_path_factory):
         arguments={"storage_args": "a dummy string arg"},
         number_of_accelerators=1,
         accelerator_name="NVIDIA_TESLA_K80",
+        cpu_request=16,
+        memory_request="32G",
     )
     pipeline.add_op(component_1)
     compiler = VertexCompiler()
@@ -414,6 +416,8 @@ def test_vertex_configuration(tmp_path_factory):
         ]["container"]["resources"]
         assert component_resources["accelerator"]["count"] == "1"
         assert component_resources["accelerator"]["type"] == "NVIDIA_TESLA_K80"
+        assert component_resources["cpuLimit"] == 16.0  # noqa: PLR2004
+        assert component_resources["memoryLimit"] == 32.0  # noqa: PLR2004
 
 
 @pytest.mark.usefixtures("_freeze_time")


### PR DESCRIPTION
PR that enables assigning additional resources to Vertex (CPU/RAM)

https://cloud.google.com/vertex-ai/docs/pipelines/machine-types

1) Setting name of the compute instance directly using a custom job as specified [here](https://cloud.google.com/vertex-ai/docs/pipelines/request-gcp-machine-resources). This does not work well because it ended up changing the structure of the compiled spec entirely and uses a custom docker image by default. I also ran into a bug that forced me to specify it outside of the compilation decorartor https://github.com/kubeflow/pipelines/issues/9320 which can be a bit ugly (Required looping through the components twice) 

2) Specifying the requested resources as mentioned [here](https://cloud.google.com/vertex-ai/docs/pipelines/machine-types) This seems like a better solution overall and worked quite nicely, the name was initially misleading (`set_cpu_limit`) but in fact the limit is the actual requested compute. Vertex then tries to find a machine that matches that description. 

Note: Right now the componentOp seems to have many configs that don't necessarily apply to all the runners which can be confusing, we need to think of a way to split those or maybe add warnings if they are specified for the wrong runner. 


