### PR TITLE
Small fixes explorer

### DIFF
--- a/src/fondant/explorer.py
+++ b/src/fondant/explorer.py
@@ -22,6 +22,8 @@ def run_explorer_app(  # type: ignore
     cmd = [
         "docker",
         "run",
+        "--pull",
+        "always",
         "--name",
         "fondant-explorer",
         "--rm",
@@ -58,7 +60,7 @@ def run_explorer_app(  # type: ignore
 
         # Mount the local base path to the container
         cmd.extend(
-            ["-v", f"{shlex.quote(host_machine_path)}:{shlex.quote(container_path)}"],
+            ["-v", f"/{shlex.quote(host_machine_path)}:/{shlex.quote(container_path)}"],
         )
 
         # add the image name

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -46,6 +46,8 @@ def test_run_data_explorer_local_base_path(host_path, container_path, credential
             [
                 "docker",
                 "run",
+                "--pull",
+                "always",
                 "--name",
                 "fondant-explorer",
                 "--rm",
@@ -54,7 +56,7 @@ def test_run_data_explorer_local_base_path(host_path, container_path, credential
                 "-v",
                 f"{credentials}:ro",
                 "-v",
-                f"{Path(host_path).resolve()}:{container_path}",
+                f"/{Path(host_path).resolve()}:/{container_path}",
                 f"{DEFAULT_CONTAINER}:{DEFAULT_TAG}",
                 "--base_path",
                 f"{container_path}",
@@ -78,6 +80,8 @@ def test_run_data_explorer_remote_base_path(remote_path, credentials):
             [
                 "docker",
                 "run",
+                "--pull",
+                "always",
                 "--name",
                 "fondant-explorer",
                 "--rm",


### PR DESCRIPTION
Small PR that: 

- Add pull always policy to the data explore. @Hakimovich99 ran into some issues where the latest image was not pulled (False positive in caching since we're using the `latest` tag)
- Fixes issue that @janvanlooy ran into that's related to the volume mounting. Related to Windows (still to be tested if fix actually resolves the issue). 

https://stackoverflow.com/questions/50540721/docker-toolbox-error-response-from-daemon-invalid-mode-root-docker