### PR TITLE
Improve download images logs

### DIFF
--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -72,6 +72,10 @@ class DownloadImagesComponent(PandasTransformComponent):
             except Exception as e:
                 print("e")
                 print(e)
+                print("repr")
+                print(repr(e))
+                print("type")
+                print(type(e))
                 print("string")
                 print(str(e))
                 logger.warning(f"Skipping {url}: {e}")

--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -70,6 +70,10 @@ class DownloadImagesComponent(PandasTransformComponent):
                                             headers={"User-Agent": user_agent_string})
                 image_stream = response.content
             except Exception as e:
+                print("e")
+                print(e)
+                print("string")
+                print(str(e))
                 logger.warning(f"Skipping {url}: {e}")
                 image_stream = None
 

--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -70,15 +70,7 @@ class DownloadImagesComponent(PandasTransformComponent):
                                             headers={"User-Agent": user_agent_string})
                 image_stream = response.content
             except Exception as e:
-                print("e")
-                print(e)
-                print("repr")
-                print(repr(e))
-                print("type")
-                print(type(e))
-                print("string")
-                print(str(e))
-                logger.warning(f"Skipping {url}: {e}")
+                logger.warning(f"Skipping {url}: {repr(e)}")
                 image_stream = None
 
         return image_stream


### PR DESCRIPTION
Some of the exception caught by the download images component returned an empty string since the exception object does not always have a **string representation** .

Example:

```python
except Exception as e:
    logger.warning(f"Skipping {url}: {e)")
```

returns: 

```bash
Skipping https://2.gravatar.com/avatar/2d7699b189a0d1e40a506aa3b8cad2dc?s=48&d=identicon&r=G: 
```

This makes it difficult to trace back why a url was skipped. Changing to `repr(e)` seems to fix it since most exeception objects seem to have a **printable representational string** (at least the httpx ones)