### PR TITLE
Disable caching in the image retrieval sample pipeline

### DIFF
--- a/examples/pipelines/filter-cc-25m/pipeline.py
+++ b/examples/pipelines/filter-cc-25m/pipeline.py
@@ -40,18 +40,12 @@ load_from_hf_hub = ComponentOp(
         "column_name_mapping": load_component_column_mapping,
         "n_rows_to_load": 10000,  # Here you can modify the number of images you want to download.
     },
-    # If you run the pipeline several times with the cache set to the default settings,
-    # cached pipeline steps will be skipped.
-    cache=False,
 )
 
 # Download images component
 download_images = ComponentOp.from_registry(
     name="download_images",
     arguments={"input_partition_rows": 1000, "resize_mode": "no"},
-    # If you run the pipeline several times with the cache set to the default settings,
-    # cached pipeline steps will be skipped.
-    cache=False,
 )
 
 # Add components to the pipeline


### PR DESCRIPTION
Disable caching in the example pipeline.