### PR TITLE
Improve hit rate of download images component

### DIFF
--- a/components/download_images/fondant_component.yaml
+++ b/components/download_images/fondant_component.yaml
@@ -28,6 +28,10 @@ args:
     description: Number of times to retry downloading an image if it fails.
     type: int
     default: 0
+  n_connections:
+    description: Number of concurrent connections opened per process. Decrease this number if you are running into timeout errors.
+    type: int
+    default: 1000
   image_size:
     description: Size of the images after resizing.
     type: int

--- a/components/download_images/fondant_component.yaml
+++ b/components/download_images/fondant_component.yaml
@@ -29,9 +29,9 @@ args:
     type: int
     default: 0
   n_connections:
-    description: Number of concurrent connections opened per process. Decrease this number if you are running into timeout errors.
+    description: Number of concurrent connections opened per process. Decrease this number if you are running into timeout errors. A lower number of connections can increase the success rate but lower the throughput.
     type: int
-    default: 1000
+    default: 100
   image_size:
     description: Size of the images after resizing.
     type: int

--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -64,7 +64,7 @@ class DownloadImagesComponent(PandasTransformComponent):
         user_agent_string += " (compatible; +https://github.com/ml6team/fondant)"
 
         transport = httpx.AsyncHTTPTransport(retries=self.retries)
-        async with httpx.AsyncClient(transport=transport) as client:
+        async with httpx.AsyncClient(transport=transport, follow_redirects=True) as client:
             try:
                 async with semaphore:
                     response = await client.get(url, timeout=self.timeout,

--- a/components/download_images/src/main.py
+++ b/components/download_images/src/main.py
@@ -38,7 +38,8 @@ class DownloadImagesComponent(PandasTransformComponent):
             timeout: Maximum time (in seconds) to wait when trying to download an image.
             retries: Number of times to retry downloading an image if it fails.
             n_connections: Number of concurrent connections opened per process. Decrease this
-                number if you are running into timeout errors.
+                number if you are running into timeout errors. A lower number of connections can
+                increase the success rate but lower the throughput.
             image_size: Size of the images after resizing.
             resize_mode: Resize mode to use. One of "no", "keep_ratio", "center_crop", "border".
             resize_only_if_bigger: If True, resize only if image is bigger than image_size.


### PR DESCRIPTION
This PR contains two changes to improve the hit rate of the download images component:

- Introduce a Semaphore to limit the amount of concurrent requests. This should help with the timeout errors. If this slows down the speed too much, we can increase the number. If the changes in this PR work, we probably want to make this an argument to the component.
- Configure httpx to follow redirects, [which it doesn't do by default](https://www.python-httpx.org/compatibility/#redirects), but requests / urllib3 does.