### PR TITLE
Bugfix partitioning

### DIFF
--- a/src/fondant/data_io.py
+++ b/src/fondant/data_io.py
@@ -36,27 +36,60 @@ class DaskDataLoader(DataIO):
         Returns:
             The partitioned dataframe.
         """
+        n_workers: int = os.cpu_count()  # type: ignore
+        original_n_partitions = dataframe.npartitions
+
         if self.input_partition_rows != "disable":
             if isinstance(self.input_partition_rows, int):
                 # Only load the index column to trigger a faster compute of the rows
                 total_rows = len(dataframe.index)
                 # +1 to handle any remainder rows
-                n_partitions = (total_rows // self.input_partition_rows) + 1
-                dataframe = dataframe.repartition(npartitions=n_partitions)
+                n_partitions_from_row = (total_rows // self.input_partition_rows) + 1
                 logger.info(
-                    f"Total number of rows is {total_rows}.\n"
-                    f"Repartitioning the data from {dataframe.partitions} partitions to have"
-                    f" {n_partitions} such that the number of partitions per row is approximately"
+                    f"Number of specified rows per partition is "
                     f"{self.input_partition_rows}",
                 )
 
-            elif self.input_partition_rows is None:
-                n_partitions = dataframe.npartitions
-                n_workers = os.cpu_count()
-                if n_partitions < n_workers:  # type: ignore
+                if original_n_partitions > n_partitions_from_row:
                     logger.info(
-                        f"The number of partitions of the input dataframe is {n_partitions}. The "
-                        f"available number of workers is {n_workers}.",
+                        f"The number of partitions required"
+                        f"to get `{self.input_partition_rows}` per row is lower than the "
+                        f"original number of partitions of the dataset "
+                        f"({original_n_partitions}.",
+                    )
+                    n_partitions = original_n_partitions
+
+                else:
+                    logger.info(
+                        f"The number of partitions required"
+                        f"to get `{self.input_partition_rows}` per row is higher than the "
+                        f"original number of partitions of the dataset "
+                        f"({original_n_partitions}.",
+                    )
+                    n_partitions = n_partitions_from_row
+
+                if n_partitions < n_workers:
+                    logger.info(
+                        f"The number of workers is larger than than {n_partitions} partitions."
+                        f" Setting the number of partitions equal to the"
+                        f" amount of workers {n_workers}",
+                    )
+                    dataframe = dataframe.repartition(npartitions=n_workers)
+                else:
+                    logger.info(
+                        f"Total number of rows is {total_rows}.\n"
+                        f"Repartitioning the data from {dataframe.npartitions} partitions to have"
+                        f" {n_partitions} such that the number of partitions per row is"
+                        f" approximately {self.input_partition_rows}",
+                    )
+                dataframe = dataframe.repartition(npartitions=n_partitions)
+
+            elif self.input_partition_rows is None:
+                if original_n_partitions < n_workers:  # type: ignore
+                    logger.info(
+                        f"The number of partitions of the input dataframe is"
+                        f" {original_n_partitions}. The available number of workers is {n_workers}"
+                        f".",
                     )
                     dataframe = dataframe.repartition(npartitions=n_workers)
                     logger.info(

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -77,15 +77,17 @@ def test_load_dataframe_default(manifest, component_spec):
     assert dataframe.npartitions in list(range(number_workers - 1, number_workers + 2))
 
 
-def test_load_dataframe_rows(manifest, component_spec):
+def test_load_dataframe_rows(manifest, component_spec, monkeypatch):
     """Test merging of subsets in a dataframe based on a component_spec."""
+    # Set cpu count to low to partition based on the input partition rows
+    monkeypatch.setattr(os, "cpu_count", lambda: 1)
     dl = DaskDataLoader(
         manifest=manifest,
         component_spec=component_spec,
-        input_partition_rows=100,
+        input_partition_rows=10,
     )
     dataframe = dl.load_dataframe()
-    expected_partitions = 2  # dataset with 151 rows
+    expected_partitions = 16  # dataset with 151 rows
     assert dataframe.npartitions == expected_partitions
 
 

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -77,17 +77,15 @@ def test_load_dataframe_default(manifest, component_spec):
     assert dataframe.npartitions in list(range(number_workers - 1, number_workers + 2))
 
 
-def test_load_dataframe_rows(manifest, component_spec, monkeypatch):
+def test_load_dataframe_rows(manifest, component_spec):
     """Test merging of subsets in a dataframe based on a component_spec."""
-    # Set cpu count to low to partition based on the input partition rows
-    monkeypatch.setattr(os, "cpu_count", lambda: 1)
     dl = DaskDataLoader(
         manifest=manifest,
         component_spec=component_spec,
-        input_partition_rows=10,
+        input_partition_rows=100,
     )
     dataframe = dl.load_dataframe()
-    expected_partitions = 16  # dataset with 151 rows
+    expected_partitions = 2  # dataset with 151 rows
     assert dataframe.npartitions == expected_partitions
 
 


### PR DESCRIPTION
The number of partitions set based on the number of specified rows per partition (optional argument) did not take into account the number of available cpu cores which can be suboptimal if the # cores is larger than the inferred number of estimated partitions. 

This PR addresses this bug by taking into account the number of cores before repartitioning 