### PR TITLE
Add caching dependency

### DIFF
--- a/src/fondant/compiler.py
+++ b/src/fondant/compiler.py
@@ -104,7 +104,7 @@ class DockerCompiler(Compiler):
             path = base_path
         return path, volume
 
-    def _generate_spec(  # noqa: PLR0912
+    def _generate_spec(
         self,
         pipeline: Pipeline,
         *,
@@ -126,12 +126,9 @@ class DockerCompiler(Compiler):
         for component_name, component in pipeline._graph.items():
             component_op = component["fondant_component_op"]
 
-            if component_cache_key is None:
-                component_cache_key = component_op.get_component_cache_key()
-            else:
-                component_cache_key = component_op.get_component_cache_key(
-                    previous_component_cache=component_cache_key,
-                )
+            component_cache_key = component_op.get_component_cache_key(
+                previous_component_cache=component_cache_key,
+            )
 
             metadata = Metadata(
                 pipeline_name=pipeline.name,
@@ -272,13 +269,9 @@ class KubeFlowCompiler(Compiler):
             for component_name, component in pipeline._graph.items():
                 component_op = component["fondant_component_op"]
 
-                if component_cache_key is None:
-                    component_cache_key = component_op.get_component_cache_key()
-                else:
-                    component_cache_key = component_op.get_component_cache_key(
-                        previous_component_cache=component_cache_key,
-                    )
-
+                component_cache_key = component_op.get_component_cache_key(
+                    previous_component_cache=component_cache_key,
+                )
                 metadata = Metadata(
                     pipeline_name=pipeline.name,
                     run_id=run_id,

--- a/src/fondant/compiler.py
+++ b/src/fondant/compiler.py
@@ -104,7 +104,7 @@ class DockerCompiler(Compiler):
             path = base_path
         return path, volume
 
-    def _generate_spec(
+    def _generate_spec(  # noqa: PLR0912
         self,
         pipeline: Pipeline,
         *,
@@ -121,15 +121,24 @@ class DockerCompiler(Compiler):
 
         pipeline.validate(run_id=run_id)
 
+        component_cache_key = None
+
         for component_name, component in pipeline._graph.items():
             component_op = component["fondant_component_op"]
+
+            if component_cache_key is None:
+                component_cache_key = component_op.get_component_cache_key()
+            else:
+                component_cache_key = component_op.get_component_cache_key(
+                    previous_component_cache=component_cache_key,
+                )
 
             metadata = Metadata(
                 pipeline_name=pipeline.name,
                 run_id=run_id,
                 base_path=path,
                 component_id=component_name,
-                cache_key=component_op.get_component_cache_key(),
+                cache_key=component_cache_key,
             )
 
             logger.info(f"Compiling service for {component_name}")
@@ -258,16 +267,24 @@ class KubeFlowCompiler(Compiler):
         def kfp_pipeline():
             previous_component_task = None
             manifest_path = ""
+            component_cache_key = None
 
             for component_name, component in pipeline._graph.items():
                 component_op = component["fondant_component_op"]
+
+                if component_cache_key is None:
+                    component_cache_key = component_op.get_component_cache_key()
+                else:
+                    component_cache_key = component_op.get_component_cache_key(
+                        previous_component_cache=component_cache_key,
+                    )
 
                 metadata = Metadata(
                     pipeline_name=pipeline.name,
                     run_id=run_id,
                     base_path=pipeline.base_path,
                     component_id=component_name,
-                    cache_key=component_op.get_component_cache_key(),
+                    cache_key=component_cache_key,
                 )
 
                 logger.info(f"Compiling service for {component_name}")

--- a/src/fondant/pipeline.py
+++ b/src/fondant/pipeline.py
@@ -214,7 +214,10 @@ class ComponentOp:
             client_kwargs=client_kwargs,
         )
 
-    def get_component_cache_key(self) -> str:
+    def get_component_cache_key(
+        self,
+        previous_component_cache: t.Optional[str] = None,
+    ) -> str:
         """Calculate a cache key representing the unique identity of this ComponentOp.
 
         The cache key is computed based on the component specification, image hash, arguments, and
@@ -250,6 +253,9 @@ class ComponentOp:
             "number_of_gpus": self.number_of_gpus,
             "node_pool_name": self.node_pool_name,
         }
+
+        if previous_component_cache is not None:
+            component_op_uid_dict["previous_component_cache"] = previous_component_cache
 
         return get_nested_dict_hash(component_op_uid_dict)
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import sys
 from pathlib import Path
 from unittest import mock
@@ -99,7 +100,7 @@ def setup_pipeline(request, tmp_path, monkeypatch):
         monkeypatch.setattr(
             component,
             "get_component_cache_key",
-            lambda cache_key=cache_key: cache_key,
+            lambda cache_key=cache_key, previous_component_cache=None: cache_key,
         )
         pipeline.add_op(component, dependencies=prev_comp)
         prev_comp = component
@@ -266,3 +267,92 @@ def test_kfp_import():
         sys.modules["kfp"] = None
         with pytest.raises(ImportError):
             _ = KubeFlowCompiler()
+
+
+def test_caching_dependency_docker(tmp_path_factory):
+    """Test that the component cache key changes when a depending component cache key change for
+    the docker compiler.
+    """
+    arg_list = ["dummy_arg_1", "dummy_arg_2"]
+    second_component_cache_key_dict = {}
+
+    for arg in arg_list:
+        pipeline = Pipeline(
+            pipeline_name="test_pipeline",
+            pipeline_description="description of the test pipeline",
+            base_path="/foo/bar",
+        )
+        compiler = DockerCompiler()
+
+        component_1 = ComponentOp(
+            Path(COMPONENTS_PATH / "example_1" / "first_component"),
+            arguments={"storage_args": f"{arg}"},
+        )
+        component_2 = ComponentOp(
+            Path(COMPONENTS_PATH / "example_1" / "second_component"),
+            arguments={"storage_args": "a dummy string arg"},
+        )
+
+        pipeline.add_op(component_1)
+        pipeline.add_op(component_2, dependencies=component_1)
+
+        with tmp_path_factory.mktemp("temp") as fn:
+            output_path = str(fn / "docker-compose.yml")
+            compiler.compile(pipeline=pipeline, output_path=output_path, build_args=[])
+            with open(output_path) as src:
+                spec = yaml.safe_load(src)
+                command = spec["services"]["second_component"]["command"]
+                cache_key = json.loads(command[command.index("--metadata") + 1])[
+                    "cache_key"
+                ]
+
+            second_component_cache_key_dict[arg] = cache_key
+
+    assert (
+        second_component_cache_key_dict[arg_list[0]]
+        != second_component_cache_key_dict[arg_list[1]]
+    )
+
+
+def test_caching_dependency_kfp(tmp_path_factory):
+    """Test that the component cache key changes when a depending component cache key change for
+    the kubeflow compiler.
+    """
+    arg_list = ["dummy_arg_1", "dummy_arg_2"]
+    second_component_cache_key_dict = {}
+
+    for arg in arg_list:
+        pipeline = Pipeline(
+            pipeline_name="test_pipeline",
+            pipeline_description="description of the test pipeline",
+            base_path="/foo/bar",
+        )
+        compiler = KubeFlowCompiler()
+
+        component_1 = ComponentOp(
+            Path(COMPONENTS_PATH / "example_1" / "first_component"),
+            arguments={"storage_args": f"{arg}"},
+        )
+        component_2 = ComponentOp(
+            Path(COMPONENTS_PATH / "example_1" / "second_component"),
+            arguments={"storage_args": "a dummy string arg"},
+        )
+
+        pipeline.add_op(component_1)
+        pipeline.add_op(component_2, dependencies=component_1)
+
+        with tmp_path_factory.mktemp("temp") as fn:
+            output_path = str(fn / "kubeflow_pipeline.yml")
+            compiler.compile(pipeline=pipeline, output_path=output_path)
+            with open(output_path) as src:
+                spec = yaml.safe_load(src)
+                commands = spec["spec"]["templates"][1]["container"]["command"]
+                cache_key = json.loads(commands[commands.index("--metadata") + 1])[
+                    "cache_key"
+                ]
+            second_component_cache_key_dict[arg] = cache_key
+
+    assert (
+        second_component_cache_key_dict[arg_list[0]]
+        != second_component_cache_key_dict[arg_list[1]]
+    )


### PR DESCRIPTION
Current implemented caching does not take into account the previous component cache key when estimating the cache key. This can be an issue in some scenarios, for example: 

 **1st run:** load_from_hub (input_dataset=x) -> download_images
 **2nd run:** load_from_hub (input_dataset=y) -> download_images
 
 In the second run, the download images component won't execute and will be cached since it might have the same input arguments as the first run. However, both runs start from different input datasets and thus the second run would actually end up loading in the dataset cached from the 1st run. 

This PR addresses this by including the hash key of the dependent component in the component cache key estimation. 