### PR TITLE
explorer small fix

### DIFF
--- a/src/fondant/explorer.py
+++ b/src/fondant/explorer.py
@@ -60,7 +60,7 @@ def run_explorer_app(  # type: ignore
 
         # Mount the local base path to the container
         cmd.extend(
-            ["-v", f"/{shlex.quote(host_machine_path)}:/{shlex.quote(container_path)}"],
+            ["-v", f"{shlex.quote(host_machine_path)}:{shlex.quote(container_path)}"],
         )
 
         # add the image name

--- a/src/fondant/explorer.py
+++ b/src/fondant/explorer.py
@@ -55,7 +55,7 @@ def run_explorer_app(  # type: ignore
                 "from a cloud provider, mount the credentials file with the --credentials flag.",
             )
         data_directory_path = Path(base_path).resolve()
-        host_machine_path = str(data_directory_path)
+        host_machine_path = data_directory_path.as_posix()
         container_path = os.path.join("/", data_directory_path.name)
 
         # Mount the local base path to the container

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -56,7 +56,7 @@ def test_run_data_explorer_local_base_path(host_path, container_path, credential
                 "-v",
                 f"{credentials}:ro",
                 "-v",
-                f"/{Path(host_path).resolve()}:/{container_path}",
+                f"{Path(host_path).resolve()}:{container_path}",
                 f"{DEFAULT_CONTAINER}:{DEFAULT_TAG}",
                 "--base_path",
                 f"{container_path}",


### PR DESCRIPTION
use as_posix to return the absolute path. Avoids denied mounting issue when calling the explorer.