### PR TITLE
Cast id to string laion

### DIFF
--- a/components/embedding_based_laion_retrieval/src/main.py
+++ b/components/embedding_based_laion_retrieval/src/main.py
@@ -64,6 +64,9 @@ class LAIONRetrievalComponent(PandasTransformComponent):
 
         results_df = pd.DataFrame(results)[["id", "url"]]
         results_df = results_df.set_index("id")
+
+        # Cast the index to string
+        results_df.index = results_df.index.astype(str)
         results_df.columns = [["images"], ["url"]]
 
         return results_df

--- a/components/prompt_based_laion_retrieval/src/main.py
+++ b/components/prompt_based_laion_retrieval/src/main.py
@@ -65,6 +65,9 @@ class LAIONRetrievalComponent(PandasTransformComponent):
 
         results_df = pd.DataFrame(results)[["id", "url"]]
         results_df = results_df.set_index("id")
+
+        # Cast the index to string
+        results_df.index = results_df.index.astype(str)
         results_df.columns = [["images"], ["url"]]
 
         return results_df

--- a/examples/pipelines/controlnet-interior-design/components/generate_prompts/fondant_component.yaml
+++ b/examples/pipelines/controlnet-interior-design/components/generate_prompts/fondant_component.yaml
@@ -1,6 +1,6 @@
 name: Generate prompts
 description: Component that generates a set of seed prompts
-image: ghcr.io/ml6team/generate_prompts:latest
+image: ghcr.io/ml6team/generate_prompts:dev
 
 produces:
   prompts:


### PR DESCRIPTION
PR that cast id to string in the laion component. 

Not really sure why Dask expects a string as an ID? Seem to be the default behavior. We don't define the type of index explicitly in the schema since it can be either a string or an integer depending on the what the user or Fondant sets as an index. 

More on this: 
https://github.com/ml6team/fondant/pull/391#discussion_r1308294201


```
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:52,375 | fondant.cli | INFO] Component `LAIONRetrievalComponent` found in module main
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:52,377 | fondant.executor | INFO] Dask default local mode will be used for further executions.Our current supported options are limited to 'local' and 'default'.
controlnet-pipeline-laion_retrieval-1   | /usr/local/lib/python3.8/site-packages/google/auth/_default.py:76: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. 
controlnet-pipeline-laion_retrieval-1   |   warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:52,468 | google.auth._default | WARNING] No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:52,740 | fondant.executor | INFO] Previous component `generate_prompts` is not cached. Invalidating cache for current and subsequent components
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:52,741 | fondant.executor | INFO] Caching disabled for the component
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:52,741 | root | INFO] Executing component
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:53,206 | fondant.data_io | INFO] Loading subset prompts with fields ['text']...
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:53,669 | fondant.data_io | INFO] The number of partitions of the input dataframe is 1. The available number of workers is 8.
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:53,670 | fondant.data_io | INFO] Repartitioning the data to 8 partitions before processing to maximize worker usage
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:53,670 | root | INFO] Columns of dataframe: ['prompts_text']
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:53,679 | root | INFO] Creating write task for: gs://soy-audio-379412_kfp-artifacts/custom_artifact/controlnet-pipeline/controlnet-pipeline-20231004152247/laion_retrieval/index
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:53,685 | root | INFO] Creating write task for: gs://soy-audio-379412_kfp-artifacts/custom_artifact/controlnet-pipeline/controlnet-pipeline-20231004152247/laion_retrieval/images
controlnet-pipeline-laion_retrieval-1   | [2023-10-04 13:22:53,685 | root | INFO] Writing data...
[###################                     ] | 48% Completed | 1.81 s ms
controlnet-pipeline-laion_retrieval-1   | Traceback (most recent call last):
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/bin/fondant", line 8, in <module>
controlnet-pipeline-laion_retrieval-1   |     sys.exit(entrypoint())
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/fondant/cli.py", line 80, in entrypoint
controlnet-pipeline-laion_retrieval-1   |     args.func(args)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/fondant/cli.py", line 382, in execute
controlnet-pipeline-laion_retrieval-1   |     executor.execute(component)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/fondant/executor.py", line 363, in execute
controlnet-pipeline-laion_retrieval-1   |     output_manifest = self._run_execution(component_cls, input_manifest)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/fondant/executor.py", line 341, in _run_execution
controlnet-pipeline-laion_retrieval-1   |     self._write_data(dataframe=output_df, manifest=output_manifest)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/fondant/executor.py", line 258, in _write_data
controlnet-pipeline-laion_retrieval-1   |     data_writer.write_dataframe(dataframe, self.client)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/fondant/data_io.py", line 195, in write_dataframe
controlnet-pipeline-laion_retrieval-1   |     dd.compute(*write_tasks, scheduler=dask_client)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/base.py", line 599, in compute
controlnet-pipeline-laion_retrieval-1   |     results = schedule(dsk, keys, **kwargs)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/threaded.py", line 89, in get
controlnet-pipeline-laion_retrieval-1   |     results = get_async(
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/local.py", line 511, in get_async
controlnet-pipeline-laion_retrieval-1   |     raise_exception(exc, tb)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/local.py", line 319, in reraise
controlnet-pipeline-laion_retrieval-1   |     raise exc
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/local.py", line 224, in execute_task
controlnet-pipeline-laion_retrieval-1   |     result = _execute_task(task, data)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/core.py", line 119, in _execute_task
controlnet-pipeline-laion_retrieval-1   |     return func(*(_execute_task(a, cache) for a in args))
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/optimization.py", line 990, in __call__
controlnet-pipeline-laion_retrieval-1   |     return core.get(self.dsk, self.outkey, dict(zip(self.inkeys, args)))
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/core.py", line 149, in get
controlnet-pipeline-laion_retrieval-1   |     result = _execute_task(task, cache)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/core.py", line 119, in _execute_task
controlnet-pipeline-laion_retrieval-1   |     return func(*(_execute_task(a, cache) for a in args))
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/dataframe/io/parquet/core.py", line 170, in __call__
controlnet-pipeline-laion_retrieval-1   |     return self.engine.write_partition(
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/dataframe/io/parquet/arrow.py", line 880, in write_partition
controlnet-pipeline-laion_retrieval-1   |     t = cls._pandas_to_arrow_table(df, preserve_index=preserve_index, schema=schema)
controlnet-pipeline-laion_retrieval-1   |   File "/usr/local/lib/python3.8/site-packages/dask/dataframe/io/parquet/arrow.py", line 841, in _pandas_to_arrow_table
controlnet-pipeline-laion_retrieval-1   |     raise ValueError(
controlnet-pipeline-laion_retrieval-1   | ValueError: Failed to convert partition to expected pyarrow schema:
controlnet-pipeline-laion_retrieval-1   |     `ArrowTypeError('Expected a string or bytes dtype, got int64', 'Conversion failed for column id with type int64')`
controlnet-pipeline-laion_retrieval-1   | 
controlnet-pipeline-laion_retrieval-1   | Expected partition schema:
controlnet-pipeline-laion_retrieval-1   |     id: string
controlnet-pipeline-laion_retrieval-1   | 
controlnet-pipeline-laion_retrieval-1   | Received partition schema:
controlnet-pipeline-laion_retrieval-1   |     id: int64
controlnet-pipeline-laion_retrieval-1   | 
controlnet-pipeline-laion_retrieval-1   | This error *may* be resolved by passing in schema information for
controlnet-pipeline-laion_retrieval-1   | the mismatched column(s) using the `schema` keyword in `to_parquet`.
```