### PR TITLE
Load parquet from hub

### DIFF
--- a/components/load_from_hf_hub/src/main.py
+++ b/components/load_from_hf_hub/src/main.py
@@ -46,7 +46,7 @@ class LoadFromHubComponent(DaskLoadComponent):
     def load(self) -> dd.DataFrame:
         # 1) Load data, read as Dask dataframe
         logger.info("Loading dataset from the hub...")
-        dask_df = dd.read_parquet(f"hf://datasets/{self.dataset_name}")
+        dask_df = dd.read_parquet(f"hf://datasets/{self.dataset_name}@~parquet")
 
         # 2) Make sure images are bytes instead of dicts
         if self.image_column_names is not None:


### PR DESCRIPTION
Datasets on HF hub can either be parquet or json formatted. However, the data seems to always be automatically converted to a parquet format when loaded in the hub. This is often times located on a different branch

https://huggingface.co/datasets/jamescalam/llama-2-arxiv-papers-chunked/tree/main
![image](https://github.com/ml6team/fondant/assets/47530815/f207f239-9e2e-4c6f-8103-68e8ef7f64f9)

In order to ensure that any dataset can be loaded, we can specify to always read from parquet as suggested [here](https://github.com/huggingface/huggingface_hub/issues/1707#issuecomment-1748692200)
