### PR TITLE
Use s3 client instead of http to access common crawl

### DIFF
--- a/examples/pipelines/commoncrawl/components/extract_images_from_warc/requirements.txt
+++ b/examples/pipelines/commoncrawl/components/extract_images_from_warc/requirements.txt
@@ -2,3 +2,4 @@ trafilatura==1.6.1
 beautifulsoup4==4.12.2
 fastwarc==0.14.5
 distributed==2023.8.1
+boto3==1.28.61

--- a/examples/pipelines/commoncrawl/components/extract_images_from_warc/src/main.py
+++ b/examples/pipelines/commoncrawl/components/extract_images_from_warc/src/main.py
@@ -1,7 +1,7 @@
 """A component that downloads common crawl files."""
 import logging
 import typing as t
-
+import gzip
 import dask
 import dask.dataframe as dd
 import pandas as pd
@@ -105,7 +105,8 @@ class CommonCrawlDownloadComponent(DaskTransformComponent):
 
         try:
             response = download_warc_file(warc_file)
-            return self.extract_images(response.raw)
+            with gzip.GzipFile(fileobj=response, mode="rb") as file:
+                return self.extract_images(file)
         except BaseException as e:
             logging.warning(e)
             return []

--- a/examples/pipelines/commoncrawl/components/extract_images_from_warc/src/utils/download_utils.py
+++ b/examples/pipelines/commoncrawl/components/extract_images_from_warc/src/utils/download_utils.py
@@ -4,7 +4,8 @@ import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
-
+import boto3
+import botocore
 
 logger = logging.getLogger(__name__)
 
@@ -12,27 +13,14 @@ COMMONCRAWL_BASE_URL = "https://data.commoncrawl.org/"
 
 
 def download_warc_file(
-    warc_file: str, retries: int = 10, backoff_factor: int = 5
-) -> requests.Response:
-    """Downloads a WARC file using http requests.
-    Args:
-        warc_file: The path to the WARC file.
-    Returns:
-        The WARC file as a bytes object.
-    """
-    session = Session()
-    retry_strategy = Retry(
-        total=retries,
-        backoff_factor=backoff_factor,
-        status_forcelist=[502, 503, 504],
-        allowed_methods={"POST", "GET"},
+    warc_file: str,
+    retries: int = 10,
+):
+    retry_config = botocore.config.Config(
+        retries={"max_attempts": retries, "mode": "standard"}
     )
-    session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
 
-    try:
-        response = session.get(COMMONCRAWL_BASE_URL + warc_file, stream=True)
-        response.raise_for_status()
-        return response
-    except Exception as e:
-        logger.error(f"Error downloading WARC file: {e}")
-        raise
+    s3_client = boto3.client("s3", config=retry_config)
+    bucket_name = "commoncrawl"
+    response = s3_client.get_object(Bucket=bucket_name, Key=warc_file)
+    return response["Body"]

--- a/examples/pipelines/commoncrawl/pipeline.py
+++ b/examples/pipelines/commoncrawl/pipeline.py
@@ -22,6 +22,7 @@ extract_images_op = ComponentOp(
     component_dir="components/extract_images_from_warc",
     node_pool_label="node_pool",
     node_pool_name="n2-standard-128-pool-3",
+    cluster_type="local",
 )
 
 pipeline = Pipeline(pipeline_name=pipeline_name, base_path=PipelineConfigs.BASE_PATH)


### PR DESCRIPTION
Update the Common Crawl download and image extraction component to utilise S3 instead of HTTP requests.

Solving #497 