### PR TITLE
Bugfix input partition rows

### DIFF
--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -64,7 +64,7 @@ class Executor(t.Generic[Component]):
         output_manifest_path: t.Union[str, Path],
         metadata: t.Dict[str, t.Any],
         user_arguments: t.Dict[str, t.Any],
-        input_partition_rows: int,
+        input_partition_rows: int = -1,
         cluster_type: t.Optional[str] = None,
         client_kwargs: t.Optional[dict] = None,
     ) -> None:

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -139,7 +139,7 @@ class Executor(t.Generic[Component]):
         component_spec: ComponentSpec,
         *,
         cache: bool,
-        input_partition_rows: int,
+        input_partition_rows: int = -1,
         cluster_type: t.Optional[str],
         client_kwargs: t.Optional[dict],
     ) -> "Executor":


### PR DESCRIPTION
Currently, pipeline executions without defined input partition rows will fail. Due to the migration to KfP v2, the default value of `input_partition_rows` wasn't correctly overwritten. We need to set the default to -1 in the executor as well.