### PR TITLE
Revert fsspec changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ importlib-resources = { version = ">= 1.3", python = "<3.9" }
 jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 
-fsspec = { version = ">= 2023.4.0", optional = true}
+fsspec = { version = ">= 2023.4.0, !=2023.9.1", optional = true}
 gcsfs = { version = ">= 2023.4.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }
 adlfs = { version = ">= 2023.4.0", optional = true }

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -281,7 +281,6 @@ class Executor(t.Generic[Component]):
                 manifest_reference_path,
                 mode="rt",
                 encoding="utf-8",
-                auto_mkdir=True,
             ) as file_:
                 cached_manifest_path = file_.read()
                 manifest = Manifest.from_file(cached_manifest_path)
@@ -395,7 +394,6 @@ class Executor(t.Generic[Component]):
             manifest_reference_path,
             mode="wt",
             encoding="utf-8",
-            auto_mkdir=True,
         ) as file_:
             file_.write(str(manifest_save_path))
 

--- a/src/fondant/manifest.py
+++ b/src/fondant/manifest.py
@@ -179,13 +179,13 @@ class Manifest:
     @classmethod
     def from_file(cls, path: t.Union[str, Path]) -> "Manifest":
         """Load the manifest from the file specified by the provided path."""
-        with fs_open(path, encoding="utf-8", auto_mkdir=True) as file_:
+        with fs_open(path, encoding="utf-8") as file_:
             specification = json.load(file_)
             return cls(specification)
 
     def to_file(self, path: t.Union[str, Path]) -> None:
         """Dump the manifest to the file specified by the provided path."""
-        with fs_open(path, "w", encoding="utf-8", auto_mkdir=True) as file_:
+        with fs_open(path, "w", encoding="utf-8") as file_:
             json.dump(self._specification, file_)
 
     def copy(self) -> "Manifest":


### PR DESCRIPTION
Due to a bug in fsspec, we added `auto_mkdir=True` to the fsspec calls. This is no longer necessary. This PR reverts the changes and avoids using the version with the bug.