### PR TITLE
Propagate `client_kwargs` argument and lower extract_images python version

### DIFF
--- a/examples/pipelines/commoncrawl/components/extract_images_from_warc/Dockerfile
+++ b/examples/pipelines/commoncrawl/components/extract_images_from_warc/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.11-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/component_spec.py
+++ b/src/fondant/component_spec.py
@@ -244,6 +244,12 @@ class ComponentSpec:
                 type="str",
                 default="default",
             ),
+            "client_kwargs": Argument(
+                name="client_kwargs",
+                description="Keyword arguments to pass to the Dask client",
+                type="dict",
+                default={},
+            ),
             "metadata": Argument(
                 name="metadata",
                 description="Metadata arguments containing the run id and base path",

--- a/src/fondant/executor.py
+++ b/src/fondant/executor.py
@@ -77,12 +77,11 @@ class Executor(t.Generic[Component]):
         self.input_partition_rows = input_partition_rows
 
         if cluster_type == "local":
-            if client_kwargs is None:
-                client_kwargs = {
-                    "processes": True,
-                    "n_workers": os.cpu_count(),
-                    "threads_per_worker": 1,
-                }
+            client_kwargs = client_kwargs or {
+                "processes": True,
+                "n_workers": os.cpu_count(),
+                "threads_per_worker": 1,
+            }
 
             logger.info(f"Initialize local dask cluster with arguments {client_kwargs}")
 

--- a/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/kubeflow_pipeline.yml
@@ -11,6 +11,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -21,7 +25,7 @@ components:
           isOptional: true
           parameterType: STRING
         input_partition_rows:
-          defaultValue: -1
+          defaultValue: -1.0
           isOptional: true
           parameterType: NUMBER_INTEGER
         metadata:
@@ -38,6 +42,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -48,7 +56,7 @@ components:
           isOptional: true
           parameterType: STRING
         input_partition_rows:
-          defaultValue: -1
+          defaultValue: -1.0
           isOptional: true
           parameterType: NUMBER_INTEGER
         metadata:
@@ -65,6 +73,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -75,7 +87,7 @@ components:
           isOptional: true
           parameterType: STRING
         input_partition_rows:
-          defaultValue: -1
+          defaultValue: -1.0
           isOptional: true
           parameterType: NUMBER_INTEGER
         metadata:
@@ -89,26 +101,28 @@ deploymentSpec:
     exec-first-component:
       container:
         args:
-        - "--input_manifest_path"
-        - "{{$.inputs.parameters['input_manifest_path']}}"
-        - "--component_spec"
-        - "{{$.inputs.parameters['component_spec']}}"
-        - "--input_partition_rows"
-        - "{{$.inputs.parameters['input_partition_rows']}}"
-        - "--cache"
-        - "{{$.inputs.parameters['cache']}}"
-        - "--cluster_type"
-        - "{{$.inputs.parameters['cluster_type']}}"
-        - "--metadata"
-        - "{{$.inputs.parameters['metadata']}}"
-        - "--output_manifest_path"
-        - "{{$.inputs.parameters['output_manifest_path']}}"
-        - "--storage_args"
-        - "{{$.inputs.parameters['storage_args']}}"
+          - "--input_manifest_path"
+          - "{{$.inputs.parameters['input_manifest_path']}}"
+          - "--component_spec"
+          - "{{$.inputs.parameters['component_spec']}}"
+          - "--input_partition_rows"
+          - "{{$.inputs.parameters['input_partition_rows']}}"
+          - "--cache"
+          - "{{$.inputs.parameters['cache']}}"
+          - "--cluster_type"
+          - "{{$.inputs.parameters['cluster_type']}}"
+          - "--client_kwargs"
+          - "{{$.inputs.parameters['client_kwargs']}}"
+          - "--metadata"
+          - "{{$.inputs.parameters['metadata']}}"
+          - "--output_manifest_path"
+          - "{{$.inputs.parameters['output_manifest_path']}}"
+          - "--storage_args"
+          - "{{$.inputs.parameters['storage_args']}}"
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: example_component:latest
         resources:
           memoryLimit: 0.512
@@ -116,50 +130,54 @@ deploymentSpec:
     exec-second-component:
       container:
         args:
-        - "--input_manifest_path"
-        - "{{$.inputs.parameters['input_manifest_path']}}"
-        - "--component_spec"
-        - "{{$.inputs.parameters['component_spec']}}"
-        - "--input_partition_rows"
-        - "{{$.inputs.parameters['input_partition_rows']}}"
-        - "--cache"
-        - "{{$.inputs.parameters['cache']}}"
-        - "--cluster_type"
-        - "{{$.inputs.parameters['cluster_type']}}"
-        - "--metadata"
-        - "{{$.inputs.parameters['metadata']}}"
-        - "--output_manifest_path"
-        - "{{$.inputs.parameters['output_manifest_path']}}"
-        - "--storage_args"
-        - "{{$.inputs.parameters['storage_args']}}"
+          - "--input_manifest_path"
+          - "{{$.inputs.parameters['input_manifest_path']}}"
+          - "--component_spec"
+          - "{{$.inputs.parameters['component_spec']}}"
+          - "--input_partition_rows"
+          - "{{$.inputs.parameters['input_partition_rows']}}"
+          - "--cache"
+          - "{{$.inputs.parameters['cache']}}"
+          - "--cluster_type"
+          - "{{$.inputs.parameters['cluster_type']}}"
+          - "--client_kwargs"
+          - "{{$.inputs.parameters['client_kwargs']}}"
+          - "--metadata"
+          - "{{$.inputs.parameters['metadata']}}"
+          - "--output_manifest_path"
+          - "{{$.inputs.parameters['output_manifest_path']}}"
+          - "--storage_args"
+          - "{{$.inputs.parameters['storage_args']}}"
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: example_component:latest
     exec-third-component:
       container:
         args:
-        - "--input_manifest_path"
-        - "{{$.inputs.parameters['input_manifest_path']}}"
-        - "--component_spec"
-        - "{{$.inputs.parameters['component_spec']}}"
-        - "--input_partition_rows"
-        - "{{$.inputs.parameters['input_partition_rows']}}"
-        - "--cache"
-        - "{{$.inputs.parameters['cache']}}"
-        - "--cluster_type"
-        - "{{$.inputs.parameters['cluster_type']}}"
-        - "--metadata"
-        - "{{$.inputs.parameters['metadata']}}"
-        - "--output_manifest_path"
-        - "{{$.inputs.parameters['output_manifest_path']}}"
-        - "--storage_args"
-        - "{{$.inputs.parameters['storage_args']}}"
+          - "--input_manifest_path"
+          - "{{$.inputs.parameters['input_manifest_path']}}"
+          - "--component_spec"
+          - "{{$.inputs.parameters['component_spec']}}"
+          - "--input_partition_rows"
+          - "{{$.inputs.parameters['input_partition_rows']}}"
+          - "--cache"
+          - "{{$.inputs.parameters['cache']}}"
+          - "--cluster_type"
+          - "{{$.inputs.parameters['cluster_type']}}"
+          - "--client_kwargs"
+          - "{{$.inputs.parameters['client_kwargs']}}"
+          - "--metadata"
+          - "{{$.inputs.parameters['metadata']}}"
+          - "--output_manifest_path"
+          - "{{$.inputs.parameters['output_manifest_path']}}"
+          - "--storage_args"
+          - "{{$.inputs.parameters['storage_args']}}"
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: example_component:latest
 pipelineInfo:
   description: description of the test pipeline
@@ -200,7 +218,7 @@ root:
                           type: binary
             input_partition_rows:
               runtimeValue:
-                constant: 10
+                constant: 10.0
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -219,7 +237,7 @@ root:
         componentRef:
           name: comp-second-component
         dependentTasks:
-        - first-component
+          - first-component
         inputs:
           parameters:
             cache:
@@ -255,7 +273,7 @@ root:
                 constant: "/foo/bar/testpipeline/testpipeline-20230101000000/first_component/manifest.json"
             input_partition_rows:
               runtimeValue:
-                constant: 10
+                constant: 10.0
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -274,7 +292,7 @@ root:
         componentRef:
           name: comp-third-component
         dependentTasks:
-        - second-component
+          - second-component
         inputs:
           parameters:
             cache:

--- a/tests/example_pipelines/compiled_pipeline/example_1/vertex_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_1/vertex_pipeline.yml
@@ -1,6 +1,7 @@
 # PIPELINE DEFINITION
 # Name: testpipeline
 # Description: description of the test pipeline
+---
 components:
   comp-first-component:
     executorLabel: exec-first-component
@@ -10,6 +11,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -37,6 +42,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -64,6 +73,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -88,74 +101,80 @@ deploymentSpec:
     exec-first-component:
       container:
         args:
-        - "--input_manifest_path"
-        - "{{$.inputs.parameters['input_manifest_path']}}"
-        - "--component_spec"
-        - "{{$.inputs.parameters['component_spec']}}"
-        - "--input_partition_rows"
-        - "{{$.inputs.parameters['input_partition_rows']}}"
-        - "--cache"
-        - "{{$.inputs.parameters['cache']}}"
-        - "--cluster_type"
-        - "{{$.inputs.parameters['cluster_type']}}"
-        - "--metadata"
-        - "{{$.inputs.parameters['metadata']}}"
-        - "--output_manifest_path"
-        - "{{$.inputs.parameters['output_manifest_path']}}"
-        - "--storage_args"
-        - "{{$.inputs.parameters['storage_args']}}"
+          - "--input_manifest_path"
+          - "{{$.inputs.parameters['input_manifest_path']}}"
+          - "--component_spec"
+          - "{{$.inputs.parameters['component_spec']}}"
+          - "--input_partition_rows"
+          - "{{$.inputs.parameters['input_partition_rows']}}"
+          - "--cache"
+          - "{{$.inputs.parameters['cache']}}"
+          - "--cluster_type"
+          - "{{$.inputs.parameters['cluster_type']}}"
+          - "--client_kwargs"
+          - "{{$.inputs.parameters['client_kwargs']}}"
+          - "--metadata"
+          - "{{$.inputs.parameters['metadata']}}"
+          - "--output_manifest_path"
+          - "{{$.inputs.parameters['output_manifest_path']}}"
+          - "--storage_args"
+          - "{{$.inputs.parameters['storage_args']}}"
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: example_component:latest
     exec-second-component:
       container:
         args:
-        - "--input_manifest_path"
-        - "{{$.inputs.parameters['input_manifest_path']}}"
-        - "--component_spec"
-        - "{{$.inputs.parameters['component_spec']}}"
-        - "--input_partition_rows"
-        - "{{$.inputs.parameters['input_partition_rows']}}"
-        - "--cache"
-        - "{{$.inputs.parameters['cache']}}"
-        - "--cluster_type"
-        - "{{$.inputs.parameters['cluster_type']}}"
-        - "--metadata"
-        - "{{$.inputs.parameters['metadata']}}"
-        - "--output_manifest_path"
-        - "{{$.inputs.parameters['output_manifest_path']}}"
-        - "--storage_args"
-        - "{{$.inputs.parameters['storage_args']}}"
+          - "--input_manifest_path"
+          - "{{$.inputs.parameters['input_manifest_path']}}"
+          - "--component_spec"
+          - "{{$.inputs.parameters['component_spec']}}"
+          - "--input_partition_rows"
+          - "{{$.inputs.parameters['input_partition_rows']}}"
+          - "--cache"
+          - "{{$.inputs.parameters['cache']}}"
+          - "--cluster_type"
+          - "{{$.inputs.parameters['cluster_type']}}"
+          - "--client_kwargs"
+          - "{{$.inputs.parameters['client_kwargs']}}"
+          - "--metadata"
+          - "{{$.inputs.parameters['metadata']}}"
+          - "--output_manifest_path"
+          - "{{$.inputs.parameters['output_manifest_path']}}"
+          - "--storage_args"
+          - "{{$.inputs.parameters['storage_args']}}"
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: example_component:latest
     exec-third-component:
       container:
         args:
-        - "--input_manifest_path"
-        - "{{$.inputs.parameters['input_manifest_path']}}"
-        - "--component_spec"
-        - "{{$.inputs.parameters['component_spec']}}"
-        - "--input_partition_rows"
-        - "{{$.inputs.parameters['input_partition_rows']}}"
-        - "--cache"
-        - "{{$.inputs.parameters['cache']}}"
-        - "--cluster_type"
-        - "{{$.inputs.parameters['cluster_type']}}"
-        - "--metadata"
-        - "{{$.inputs.parameters['metadata']}}"
-        - "--output_manifest_path"
-        - "{{$.inputs.parameters['output_manifest_path']}}"
-        - "--storage_args"
-        - "{{$.inputs.parameters['storage_args']}}"
+          - "--input_manifest_path"
+          - "{{$.inputs.parameters['input_manifest_path']}}"
+          - "--component_spec"
+          - "{{$.inputs.parameters['component_spec']}}"
+          - "--input_partition_rows"
+          - "{{$.inputs.parameters['input_partition_rows']}}"
+          - "--cache"
+          - "{{$.inputs.parameters['cache']}}"
+          - "--cluster_type"
+          - "{{$.inputs.parameters['cluster_type']}}"
+          - "--client_kwargs"
+          - "{{$.inputs.parameters['client_kwargs']}}"
+          - "--metadata"
+          - "{{$.inputs.parameters['metadata']}}"
+          - "--output_manifest_path"
+          - "{{$.inputs.parameters['output_manifest_path']}}"
+          - "--storage_args"
+          - "{{$.inputs.parameters['storage_args']}}"
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: example_component:latest
 pipelineInfo:
   description: description of the test pipeline
@@ -196,7 +215,7 @@ root:
                           type: binary
             input_partition_rows:
               runtimeValue:
-                constant: 10.0
+                constant: 10
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -215,7 +234,7 @@ root:
         componentRef:
           name: comp-second-component
         dependentTasks:
-        - first-component
+          - first-component
         inputs:
           parameters:
             cache:
@@ -251,7 +270,7 @@ root:
                 constant: "/foo/bar/testpipeline/testpipeline-20230101000000/first_component/manifest.json"
             input_partition_rows:
               runtimeValue:
-                constant: 10.0
+                constant: 10
             metadata:
               runtimeValue:
                 constant: '{"base_path": "/foo/bar", "pipeline_name": "testpipeline",
@@ -270,7 +289,7 @@ root:
         componentRef:
           name: comp-third-component
         dependentTasks:
-        - second-component
+          - second-component
         inputs:
           parameters:
             cache:

--- a/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/kubeflow_pipeline.yml
@@ -11,6 +11,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -21,7 +25,7 @@ components:
           isOptional: true
           parameterType: STRING
         input_partition_rows:
-          defaultValue: -1.0
+          defaultValue: -1
           isOptional: true
           parameterType: NUMBER_INTEGER
         metadata:
@@ -38,6 +42,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -45,14 +53,14 @@ components:
         component_spec:
           parameterType: STRUCT
         cropping_threshold:
-          defaultValue: -30.0
+          defaultValue: -30
           isOptional: true
           parameterType: NUMBER_INTEGER
         input_manifest_path:
           isOptional: true
           parameterType: STRING
         input_partition_rows:
-          defaultValue: -1.0
+          defaultValue: -1
           isOptional: true
           parameterType: NUMBER_INTEGER
         metadata:
@@ -60,7 +68,7 @@ components:
         output_manifest_path:
           parameterType: STRING
         padding:
-          defaultValue: 10.0
+          defaultValue: 10
           isOptional: true
           parameterType: NUMBER_INTEGER
 deploymentSpec:
@@ -78,6 +86,8 @@ deploymentSpec:
         - "{{$.inputs.parameters['cache']}}"
         - "--cluster_type"
         - "{{$.inputs.parameters['cluster_type']}}"
+        - "--client_kwargs"
+        - "{{$.inputs.parameters['client_kwargs']}}"
         - "--metadata"
         - "{{$.inputs.parameters['metadata']}}"
         - "--output_manifest_path"
@@ -102,6 +112,8 @@ deploymentSpec:
         - "{{$.inputs.parameters['cache']}}"
         - "--cluster_type"
         - "{{$.inputs.parameters['cluster_type']}}"
+        - "--client_kwargs"
+        - "{{$.inputs.parameters['client_kwargs']}}"
         - "--metadata"
         - "{{$.inputs.parameters['metadata']}}"
         - "--output_manifest_path"
@@ -184,13 +196,13 @@ root:
                 constant:
                   args:
                     cropping_threshold:
-                      default: -30.0
+                      default: -30
                       description: Threshold parameter used for detecting borders.
                         A lower (negative) parameter results in a more performant
                         border detection, but can cause overcropping. Default is -30
                       type: int
                     padding:
-                      default: 10.0
+                      default: 10
                       description: Padding for the image cropping. The padding is
                         added to all borders of the image.
                       type: int
@@ -227,7 +239,7 @@ root:
                           type: int32
             cropping_threshold:
               runtimeValue:
-                constant: 0.0
+                constant: 0
             input_manifest_path:
               runtimeValue:
                 constant: "/foo/bar/testpipeline/testpipeline-20230101000000/first_component/manifest.json"
@@ -241,7 +253,7 @@ root:
                 constant: "/foo/bar/testpipeline/testpipeline-20230101000000/image_cropping/manifest.json"
             padding:
               runtimeValue:
-                constant: 0.0
+                constant: 0
         taskInfo:
           name: image-cropping
 schemaVersion: 2.1.0

--- a/tests/example_pipelines/compiled_pipeline/example_2/vertex_pipeline.yml
+++ b/tests/example_pipelines/compiled_pipeline/example_2/vertex_pipeline.yml
@@ -11,6 +11,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -38,6 +42,10 @@ components:
           defaultValue: true
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           isOptional: true
@@ -45,14 +53,14 @@ components:
         component_spec:
           parameterType: STRUCT
         cropping_threshold:
-          defaultValue: -30.0
+          defaultValue: -30
           isOptional: true
           parameterType: NUMBER_INTEGER
         input_manifest_path:
           isOptional: true
           parameterType: STRING
         input_partition_rows:
-          defaultValue: -1.0
+          defaultValue: -1
           isOptional: true
           parameterType: NUMBER_INTEGER
         metadata:
@@ -60,7 +68,7 @@ components:
         output_manifest_path:
           parameterType: STRING
         padding:
-          defaultValue: 10.0
+          defaultValue: 10
           isOptional: true
           parameterType: NUMBER_INTEGER
 deploymentSpec:
@@ -68,52 +76,56 @@ deploymentSpec:
     exec-first-component:
       container:
         args:
-        - "--input_manifest_path"
-        - "{{$.inputs.parameters['input_manifest_path']}}"
-        - "--component_spec"
-        - "{{$.inputs.parameters['component_spec']}}"
-        - "--input_partition_rows"
-        - "{{$.inputs.parameters['input_partition_rows']}}"
-        - "--cache"
-        - "{{$.inputs.parameters['cache']}}"
-        - "--cluster_type"
-        - "{{$.inputs.parameters['cluster_type']}}"
-        - "--metadata"
-        - "{{$.inputs.parameters['metadata']}}"
-        - "--output_manifest_path"
-        - "{{$.inputs.parameters['output_manifest_path']}}"
-        - "--storage_args"
-        - "{{$.inputs.parameters['storage_args']}}"
+          - "--input_manifest_path"
+          - "{{$.inputs.parameters['input_manifest_path']}}"
+          - "--component_spec"
+          - "{{$.inputs.parameters['component_spec']}}"
+          - "--input_partition_rows"
+          - "{{$.inputs.parameters['input_partition_rows']}}"
+          - "--cache"
+          - "{{$.inputs.parameters['cache']}}"
+          - "--cluster_type"
+          - "{{$.inputs.parameters['cluster_type']}}"
+          - "--client_kwargs"
+          - "{{$.inputs.parameters['client_kwargs']}}"
+          - "--metadata"
+          - "{{$.inputs.parameters['metadata']}}"
+          - "--output_manifest_path"
+          - "{{$.inputs.parameters['output_manifest_path']}}"
+          - "--storage_args"
+          - "{{$.inputs.parameters['storage_args']}}"
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: example_component:latest
     exec-image-cropping:
       container:
         args:
-        - "--input_manifest_path"
-        - "{{$.inputs.parameters['input_manifest_path']}}"
-        - "--component_spec"
-        - "{{$.inputs.parameters['component_spec']}}"
-        - "--input_partition_rows"
-        - "{{$.inputs.parameters['input_partition_rows']}}"
-        - "--cache"
-        - "{{$.inputs.parameters['cache']}}"
-        - "--cluster_type"
-        - "{{$.inputs.parameters['cluster_type']}}"
-        - "--metadata"
-        - "{{$.inputs.parameters['metadata']}}"
-        - "--output_manifest_path"
-        - "{{$.inputs.parameters['output_manifest_path']}}"
-        - "--cropping_threshold"
-        - "{{$.inputs.parameters['cropping_threshold']}}"
-        - "--padding"
-        - "{{$.inputs.parameters['padding']}}"
+          - "--input_manifest_path"
+          - "{{$.inputs.parameters['input_manifest_path']}}"
+          - "--component_spec"
+          - "{{$.inputs.parameters['component_spec']}}"
+          - "--input_partition_rows"
+          - "{{$.inputs.parameters['input_partition_rows']}}"
+          - "--cache"
+          - "{{$.inputs.parameters['cache']}}"
+          - "--cluster_type"
+          - "{{$.inputs.parameters['cluster_type']}}"
+          - "--client_kwargs"
+          - "{{$.inputs.parameters['client_kwargs']}}"
+          - "--metadata"
+          - "{{$.inputs.parameters['metadata']}}"
+          - "--output_manifest_path"
+          - "{{$.inputs.parameters['output_manifest_path']}}"
+          - "--cropping_threshold"
+          - "{{$.inputs.parameters['cropping_threshold']}}"
+          - "--padding"
+          - "{{$.inputs.parameters['padding']}}"
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: fndnt/image_cropping:dev
 pipelineInfo:
   description: description of the test pipeline
@@ -170,7 +182,7 @@ root:
         componentRef:
           name: comp-image-cropping
         dependentTasks:
-        - first-component
+          - first-component
         inputs:
           parameters:
             cache:
@@ -184,13 +196,13 @@ root:
                 constant:
                   args:
                     cropping_threshold:
-                      default: -30.0
+                      default: -30
                       description: Threshold parameter used for detecting borders.
                         A lower (negative) parameter results in a more performant
                         border detection, but can cause overcropping. Default is -30
                       type: int
                     padding:
-                      default: 10.0
+                      default: 10
                       description: Padding for the image cropping. The padding is
                         added to all borders of the image.
                       type: int
@@ -227,7 +239,7 @@ root:
                           type: int32
             cropping_threshold:
               runtimeValue:
-                constant: 0.0
+                constant: 0
             input_manifest_path:
               runtimeValue:
                 constant: "/foo/bar/testpipeline/testpipeline-20230101000000/first_component/manifest.json"
@@ -241,7 +253,7 @@ root:
                 constant: "/foo/bar/testpipeline/testpipeline-20230101000000/image_cropping/manifest.json"
             padding:
               runtimeValue:
-                constant: 0.0
+                constant: 0
         taskInfo:
           name: image-cropping
 schemaVersion: 2.1.0

--- a/tests/example_specs/component_specs/kubeflow_component.yaml
+++ b/tests/example_specs/component_specs/kubeflow_component.yaml
@@ -8,6 +8,11 @@ components:
           description: Set to False to disable caching, True by default.
           isOptional: true
           parameterType: BOOLEAN
+        client_kwargs:
+          defaultValue: {}
+          description: Keyword arguments to pass to the Dask client
+          isOptional: true
+          parameterType: STRUCT
         cluster_type:
           defaultValue: default
           description: The cluster type to use for the execution
@@ -40,26 +45,28 @@ deploymentSpec:
     exec-example-component:
       container:
         args:
-        - --input_manifest_path
-        - '{{$.inputs.parameters[''input_manifest_path'']}}'
-        - --component_spec
-        - '{{$.inputs.parameters[''component_spec'']}}'
-        - --input_partition_rows
-        - '{{$.inputs.parameters[''input_partition_rows'']}}'
-        - --cache
-        - '{{$.inputs.parameters[''cache'']}}'
-        - --cluster_type
-        - '{{$.inputs.parameters[''cluster_type'']}}'
-        - --metadata
-        - '{{$.inputs.parameters[''metadata'']}}'
-        - --output_manifest_path
-        - '{{$.inputs.parameters[''output_manifest_path'']}}'
-        - --storage_args
-        - '{{$.inputs.parameters[''storage_args'']}}'
+          - --input_manifest_path
+          - '{{$.inputs.parameters[''input_manifest_path'']}}'
+          - --component_spec
+          - '{{$.inputs.parameters[''component_spec'']}}'
+          - --input_partition_rows
+          - '{{$.inputs.parameters[''input_partition_rows'']}}'
+          - --cache
+          - '{{$.inputs.parameters[''cache'']}}'
+          - --cluster_type
+          - '{{$.inputs.parameters[''cluster_type'']}}'
+          - --client_kwargs
+          - '{{$.inputs.parameters[''client_kwargs'']}}'
+          - --metadata
+          - '{{$.inputs.parameters[''metadata'']}}'
+          - --output_manifest_path
+          - '{{$.inputs.parameters[''output_manifest_path'']}}'
+          - --storage_args
+          - '{{$.inputs.parameters[''storage_args'']}}'
         command:
-        - fondant
-        - execute
-        - main
+          - fondant
+          - execute
+          - main
         image: example_component:latest
 pipelineInfo:
   name: example-component
@@ -75,6 +82,8 @@ root:
           parameters:
             cache:
               componentInputParameter: cache
+            client_kwargs:
+              componentInputParameter: client_kwargs
             cluster_type:
               componentInputParameter: cluster_type
             component_spec:


### PR DESCRIPTION
This PR addresses 2 issues:
- The `client_kwargs` argument was not propagated properly and couldn't be used
- Python 3.11 leads to very long dependency resolution times with KfP and aiplatform dependencies