### PR TITLE
Fix explorer build script for DockerHub

### DIFF
--- a/scripts/build_explorer.sh
+++ b/scripts/build_explorer.sh
@@ -23,8 +23,8 @@ if [ -z "${tag}" ]; then
 fi
 
 # Set github repo information
-namespace="ml6team"
-repo="fondant"
+namespace="fndnt"
+repo="ml6team/fondant"
 
 # Get the explorer directory
 scripts_dir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )

--- a/scripts/tag_components.sh
+++ b/scripts/tag_components.sh
@@ -25,7 +25,7 @@ if [ -z "${old_tag}" ] || [ -z "${new_tag}" ]; then
 fi
 
 # Set github repo information
-namespace="ml6team"
+namespace="fndnt"
 
 # Get the component directory
 scripts_dir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )

--- a/scripts/tag_explorer.sh
+++ b/scripts/tag_explorer.sh
@@ -25,7 +25,7 @@ if [ -z "${old_tag}" ] || [ -z "${new_tag}" ]; then
 fi
 
 # Set github repo information
-namespace="ml6team"
+namespace="fndnt"
 
 # Get the explorer directory
 scripts_dir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )


### PR DESCRIPTION
The release pipeline fails on building the explorer script. It was not properly updated for our switch to DockerHub.

Works now: https://hub.docker.com/r/fndnt/data_explorer