### PR TITLE
Add network argument to vertex runner

### DIFF
--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -194,7 +194,8 @@ def register_build(parent_parser):
         type=str,
         help="Tag to add to built container. If the tag contains a `:`, it will be used as the "
         "full name for the image. If it does not contain a `:`, the image base name will be "
-        "read from the `fondant_component.yaml` and combined into `base_name:tag`.",
+        "read from the `fondant_component.yaml` and combined into `base_name:tag`. If no tag is "
+        "provided, the tag from the `fondant_component.yaml` is used directly.",
     )
     parser.add_argument(
         "--build-arg",
@@ -463,6 +464,13 @@ def register_run(parent_parser):
         default=None,
     )
 
+    vertex_parser.add_argument(
+        "--network",
+        help="Network for the job to connect to, useful when peering with Vertex AI. Format "
+        "should be 'projects/${project_number}/global/networks/${network}'",
+        default=None,
+    )
+
     vertex_parser.set_defaults(func=run_vertex)
 
 
@@ -524,6 +532,7 @@ def run_vertex(args):
             project_id=args.project_id,
             region=args.region,
             service_account=args.service_account,
+            network=args.network,
         )
         runner.run(input_spec=spec_ref)
 

--- a/src/fondant/runner.py
+++ b/src/fondant/runner.py
@@ -99,6 +99,7 @@ class VertexRunner(Runner):
         project_id: str,
         region: str,
         service_account: t.Optional[str] = None,
+        network: t.Optional[str] = None,
     ):
         self.__resolve_imports()
 
@@ -107,6 +108,7 @@ class VertexRunner(Runner):
             location=region,
         )
         self.service_account = service_account
+        self.network = network
 
     def run(self, input_spec: str, *args, **kwargs):
         job = self.aip.PipelineJob(
@@ -114,7 +116,10 @@ class VertexRunner(Runner):
             template_path=input_spec,
             enable_caching=False,
         )
-        job.submit(service_account=self.service_account)
+        job.submit(
+            service_account=self.service_account,
+            network=self.network,
+        )
 
     def get_name_from_spec(self, input_spec: str):
         """Get the name of the pipeline from the spec."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,6 +279,7 @@ def test_vertex_run(tmp_path_factory):
             region="europe-west-1",
             project_id="project-123",
             service_account=None,
+            network=None,
             ref="some/path",
         )
         run_vertex(args)
@@ -286,6 +287,7 @@ def test_vertex_run(tmp_path_factory):
             project_id="project-123",
             region="europe-west-1",
             service_account=None,
+            network=None,
         )
 
     with patch("fondant.cli.VertexRunner") as mock_runner, patch(
@@ -303,10 +305,12 @@ def test_vertex_run(tmp_path_factory):
             region="europe-west-1",
             project_id="project-123",
             service_account=None,
+            network=None,
         )
         run_vertex(args)
         mock_runner.assert_called_once_with(
             project_id="project-123",
             region="europe-west-1",
             service_account=None,
+            network=None,
         )


### PR DESCRIPTION
This is needed to access private IPs from Vertex pipelines (eg. a private Weaviate endpoint).