### PR TITLE
Fix cli error propagation

### DIFF
--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -492,7 +492,10 @@ def run_local(args):
             build_args=args.build_arg,
         )
     finally:
-        DockerRunner().run(spec_ref)
+        try:
+            DockerRunner().run(spec_ref)
+        except UnboundLocalError as e:
+            raise e
 
 
 def run_kfp(args):
@@ -511,8 +514,11 @@ def run_kfp(args):
         compiler = KubeFlowCompiler()
         compiler.compile(pipeline=pipeline, output_path=spec_ref)
     finally:
-        runner = KubeflowRunner(host=args.host)
-        runner.run(input_spec=spec_ref)
+        try:
+            runner = KubeflowRunner(host=args.host)
+            runner.run(input_spec=spec_ref)
+        except UnboundLocalError as e:
+            raise e
 
 
 def run_vertex(args):
@@ -528,13 +534,16 @@ def run_vertex(args):
         compiler = VertexCompiler()
         compiler.compile(pipeline=pipeline, output_path=spec_ref)
     finally:
-        runner = VertexRunner(
-            project_id=args.project_id,
-            region=args.region,
-            service_account=args.service_account,
-            network=args.network,
-        )
-        runner.run(input_spec=spec_ref)
+        try:
+            runner = VertexRunner(
+                project_id=args.project_id,
+                region=args.region,
+                service_account=args.service_account,
+                network=args.network,
+            )
+            runner.run(input_spec=spec_ref)
+        except UnboundLocalError as e:
+            raise e
 
 
 def register_execute(parent_parser):


### PR DESCRIPTION
Fixes error with wrong error being propagated when using any of the runners with the CLI: 

before:

```bash
❯ fondant run local pipeline.py --extra-volumes "$HOME/.config/gcloud/application_default_credentials.json:/root/.config/gcloud/application_default_credentials.json:ro"
Traceback (most recent call last):
  File "/home/philippe/Scripts/express/src/fondant/cli.py", line 479, in run_local
    pipeline = pipeline_from_module(args.ref)
  File "/home/philippe/Scripts/express/src/fondant/cli.py", line 605, in pipeline_from_module
    module = get_module(module_str)
  File "/home/philippe/Scripts/express/src/fondant/cli.py", line 595, in get_module
    module = importlib.import_module(module_str)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/philippe/Scripts/express/examples/pipelines/finetune_stable_diffusion/./pipeline.py", line 24, in <module>
    load_from_hub_op = ComponentOp(
  File "/home/philippe/Scripts/express/src/fondant/pipeline.py", line 114, in __init__
    self.component_spec = ComponentSpec.from_file(
  File "/home/philippe/Scripts/express/src/fondant/component_spec.py", line 141, in from_file
    with open(path, encoding="utf-8") as file_:
FileNotFoundError: [Errno 2] No such file or directory: 'components/load_from_hf_hub/fondant_component.yaml'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/philippe/Scripts/express/venv/bin/fondant", line 6, in <module>
    sys.exit(entrypoint())
  File "/home/philippe/Scripts/express/src/fondant/cli.py", line 83, in entrypoint
    args.func(args)
  File "/home/philippe/Scripts/express/src/fondant/cli.py", line 496, in run_local
    DockerRunner().run(spec_ref)
UnboundLocalError: local variable 'spec_ref' referenced before assignment
```

After this fix:

```bash
❯ fondant run local pipeline.py --extra-volumes "$HOME/.config/gcloud/application_default_credentials.json:/root/.config/gcloud/application_default_credentials.json:ro"
Traceback (most recent call last):
  File "/home/philippe/Scripts/express/src/fondant/cli.py", line 479, in run_local
    pipeline = pipeline_from_module(args.ref)
  File "/home/philippe/Scripts/express/src/fondant/cli.py", line 605, in pipeline_from_module
    module = get_module(module_str)
  File "/home/philippe/Scripts/express/src/fondant/cli.py", line 595, in get_module
    module = importlib.import_module(module_str)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/philippe/Scripts/express/examples/pipelines/finetune_stable_diffusion/./pipeline.py", line 24, in <module>
    load_from_hub_op = ComponentOp(
  File "/home/philippe/Scripts/express/src/fondant/pipeline.py", line 114, in __init__
    self.component_spec = ComponentSpec.from_file(
  File "/home/philippe/Scripts/express/src/fondant/component_spec.py", line 141, in from_file
    with open(path, encoding="utf-8") as file_:
FileNotFoundError: [Errno 2] No such file or directory: 'components/load_from_hf_hub/fondant_component.yaml'
```