### PR TITLE
Set mkdocs site_url to fix 404 page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Fondant
+site_url: https://fondant.ai/en/latest
 repo_url: https://github.com/ml6team/fondant
 repo_name: ml6team/fondant
 theme:


### PR DESCRIPTION
I believe this will fix the 404 pages on the deployed website.

It's unfortunately not possible to test this with mkdocs serve / PR builds since the canonical base url is different. However, if you inspect the requests used to load the assets, you can see it now uses `/en/latest/<asset>` instead of `/<asset>`, which should work when deployed on the main site.

[Relevant ReadTheDocs docs](https://docs.readthedocs.io/en/stable/reference/404-not-found.html)