### PR TITLE
Expand docker installation guide

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -61,8 +61,6 @@ have [Docker compose](https://docs.docker.com/compose/install/) and Python >=3.8
 installed on your system. We only support Docker compose V2 and above. If you have an older version of
 Docker compose, please upgrade to the latest version as described in the [Docker compose migration doc](https://docs.docker.com/compose/migrate/).
 
-#### TODO: Modify/extend considerations for Docker-compose/desktop
-
 !!! note "IMPORTANT"
     For **Apple M1/M2 ship users**: <br>
     

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -58,12 +58,25 @@ Check out the [guide](../components/publishing_components.md) on publishing comp
 
 To execute pipelines locally, you must
 have [Docker compose](https://docs.docker.com/compose/install/) and Python >=3.8
-installed on your system.
+installed on your system. We only support Docker compose V2 and above. If you have an older version of
+Docker compose, please upgrade to the latest version as described in the [Docker compose migration doc](https://docs.docker.com/compose/migrate/).
 
 #### TODO: Modify/extend considerations for Docker-compose/desktop
 
-For Apple M1/M2 ship users: <br>
+!!! note "IMPORTANT"
+    For **Apple M1/M2 ship users**: <br>
+    
+    - Make sure that Docker uses linux/amd64 platform and not arm64. <br>
 
-- Make sure that Docker uses linux/amd64 platform and not arm64. <br>
-- In Docker Dashboards’ Settings<Features in development, make sure to
-  uncheck `Use containerid for pulling and storing images`.
+        ```bash
+        export DOCKER_DEFAULT_PLATFORM=linux/amd64
+        ```
+
+    - In Docker Desktop Dashboards’ `Settings -> Features in development`, make sure to
+      uncheck `Use containerid for pulling and storing images`.
+
+!!! note "IMPORTANT"
+    For **Windows** users: <br>
+    
+    - We recommend installing and running docker on [WSL](https://learn.microsoft.com/en-us/windows/wsl/about). 
+    Check out this [guide](https://docs.docker.com/desktop/wsl/) for more info on the installation. <br>.


### PR DESCRIPTION
Addresses #599 
I think referencing the docker installation docs rather than pasting few snippets is better in our case since we don't require anything custom compared to airflow