### PR TITLE
Add label argument to fondant build

### DIFF
--- a/src/fondant/build.py
+++ b/src/fondant/build.py
@@ -17,6 +17,7 @@ def build_component(  # ruff: noqa: PLR0912, PLR0915
     *,
     tag: t.Optional[str],
     build_args: t.List[str],
+    labels: t.List[str],
     nocache: bool = False,
     pull: bool = False,
     target: t.Optional[str] = None,
@@ -57,11 +58,18 @@ def build_component(  # ruff: noqa: PLR0912, PLR0915
     logger.info(f"Assuming full image name: {full_image_name}")
 
     logger.info("Building image...")
+
     # Convert build args from ["key=value", ...] to {"key": "value", ...}
     build_kwargs = {}
     for arg in build_args:
         k, v = arg.split("=", 1)
         build_kwargs[k] = v
+
+    # Convert label args from ["key=value", ...] to {"key": "value", ...}
+    label_kwargs = {}
+    for arg in labels:
+        k, v = arg.split("=", 1)
+        label_kwargs[k] = v
 
     try:
         docker_client = docker.from_env()
@@ -89,6 +97,7 @@ def build_component(  # ruff: noqa: PLR0912, PLR0915
         pull=pull,
         target=target,
         decode=True,
+        labels=label_kwargs,
     )
 
     for chunk in logs:

--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -255,7 +255,7 @@ def register_build(parent_parser):
     parser.add_argument(
         "--label",
         action="append",
-        help="Label pass to `docker build` and assign to the container. Format {key}={value}, can be repeated.",
+        help="Label passed to `docker build` and assigned to the container. Format {key}={value}, can be repeated.",
         default=[],
     )
 

--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -252,6 +252,13 @@ def register_build(parent_parser):
         help="Name of the build-stage to build in a multi-stage Dockerfile.",
     )
 
+    parser.add_argument(
+        "--label",
+        action="append",
+        help="Label pass to `docker build` and assign to the container. Format {key}={value}, can be repeated.",
+        default=[],
+    )
+
     parser.set_defaults(func=build)
 
 
@@ -265,6 +272,7 @@ def build(args):
         nocache=args.nocache,
         pull=args.pull,
         target=args.target,
+        labels=args.label,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -355,6 +355,7 @@ def test_component_build(mock_build, mock_push):
         nocache=True,
         pull=True,
         target="base",
+        labels=["label_0_key=label_0_value", "label_1_key=label_1_value"],
     )
 
     # Set up the return values for the mocked methods
@@ -373,6 +374,7 @@ def test_component_build(mock_build, mock_push):
         pull=True,
         target="base",
         decode=True,
+        labels={"label_0_key": "label_0_value", "label_1_key": "label_1_value"},
     )
 
     mock_push.assert_called_with("image", tag="test", stream=True, decode=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -355,7 +355,7 @@ def test_component_build(mock_build, mock_push):
         nocache=True,
         pull=True,
         target="base",
-        labels=["label_0_key=label_0_value", "label_1_key=label_1_value"],
+        label=["label_0_key=label_0_value", "label_1_key=label_1_value"],
     )
 
     # Set up the return values for the mocked methods


### PR DESCRIPTION
We could use `fondant build` in the cicd pipeline for building the component images. Add a parameter to enable the cli adding the label. 

Needed for [#5](https://github.com/ml6team/fondant-usecase-RAG/pull/5/files)