### PR TITLE
Add authentification arg to run command

### DIFF
--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -448,6 +448,8 @@ def register_run(parent_parser):
     runner_subparser = parser.add_subparsers()
 
     local_parser = runner_subparser.add_parser(name="local", help="Local runner")
+    auth_group_local_parser = local_parser.add_mutually_exclusive_group()
+
     kubeflow_parser = runner_subparser.add_parser(
         name="kubeflow",
         help="Kubeflow runner",
@@ -483,7 +485,6 @@ def register_run(parent_parser):
         action="append",
         help="Build arguments for `docker build`",
     )
-    local_parser.set_defaults(func=run_local)
 
     # kubeflow runner parser
     kubeflow_parser.add_argument(
@@ -504,8 +505,26 @@ def register_run(parent_parser):
         help="KubeFlow pipeline host url",
         required=True,
     )
+    auth_group_local_parser.add_argument(
+        "--auth-gcp",
+        action="store_true",
+        help=f"Flag to authenticate with GCP. Uses the following mount command"
+        f" `{CloudCredentialsMount.GCP.value}`",
+    )
 
-    kubeflow_parser.set_defaults(func=run_kfp)
+    auth_group_local_parser.add_argument(
+        "--auth-azure",
+        action="store_true",
+        help="Flag to authenticate with Azure. Uses the following mount command"
+        f" `{CloudCredentialsMount.AZURE.value}`",
+    )
+
+    auth_group_local_parser.add_argument(
+        "--auth-aws",
+        action="store_true",
+        help="Flag to authenticate with AWS. Uses the following mount command"
+        f" `{CloudCredentialsMount.AWS.value}`",
+    )
 
     # Vertex runner parser
     vertex_parser.add_argument(
@@ -544,12 +563,23 @@ def register_run(parent_parser):
         default=None,
     )
 
+    local_parser.set_defaults(func=run_local)
+    kubeflow_parser.set_defaults(func=run_kfp)
     vertex_parser.set_defaults(func=run_vertex)
 
 
 def run_local(args):
     from fondant.pipeline.compiler import DockerCompiler
     from fondant.pipeline.runner import DockerRunner
+
+    extra_volumes = []
+    cloud_cred = get_cloud_credentials(args)
+
+    if args.extra_volumes:
+        extra_volumes.extend(args.extra_volumes)
+
+    if cloud_cred:
+        extra_volumes.append(cloud_cred)
 
     try:
         pipeline = pipeline_from_module(args.ref)
@@ -563,7 +593,7 @@ def run_local(args):
         compiler = DockerCompiler()
         compiler.compile(
             pipeline=pipeline,
-            extra_volumes=args.extra_volumes,
+            extra_volumes=extra_volumes,
             output_path=spec_ref,
             build_args=args.build_arg,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,6 @@ from fondant.cli import (
     PipelineImportError,
     build,
     compile_kfp,
-    compile_local,
     compile_vertex,
     component_from_module,
     execute,
@@ -133,8 +132,8 @@ def test_execute_logic(monkeypatch):
     execute(args)
 
 
-def test_local_logic(tmp_path_factory):
-    """Test that the compile command works with arguments."""
+def test_cloud_credentials_argument_logic(tmp_path_factory):
+    """Test that the run command works with arguments."""
     namespace_creds_kwargs = [
         {"auth_gcp": True, "auth_azure": False, "auth_aws": False},
         {"auth_gcp": False, "auth_azure": True, "auth_aws": False},
@@ -156,7 +155,7 @@ def test_local_logic(tmp_path_factory):
                 **namespace_cred_kwargs,
                 credentials=None,
             )
-            compile_local(args)
+            run_local(args)
 
             if namespace_cred_kwargs["auth_gcp"] is True:
                 extra_volumes = [CloudCredentialsMount.GCP.value]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -210,7 +210,16 @@ def test_vertex_compile(tmp_path_factory):
 
 def test_local_run(tmp_path_factory):
     """Test that the run command works with different arguments."""
-    args = argparse.Namespace(local=True, ref="some/path", output_path=None)
+    args = argparse.Namespace(
+        local=True,
+        ref="some/path",
+        output_path=None,
+        auth_gcp=False,
+        auth_azure=False,
+        auth_aws=False,
+        credentials=None,
+        extra_volumes=[],
+    )
     with patch("subprocess.call") as mock_call:
         run_local(args)
         mock_call.assert_called_once_with(
@@ -236,6 +245,10 @@ def test_local_run(tmp_path_factory):
             output_path=str(fn / "docker-compose.yml"),
             extra_volumes=[],
             build_arg=[],
+            auth_gcp=False,
+            auth_azure=False,
+            auth_aws=False,
+            credentials=None,
         )
         run_local(args1)
         mock_call.assert_called_once_with(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from fondant.cli import (
     PipelineImportError,
     build,
     compile_kfp,
+    compile_local,
     compile_vertex,
     component_from_module,
     execute,
@@ -132,8 +133,8 @@ def test_execute_logic(monkeypatch):
     execute(args)
 
 
-def test_cloud_credentials_argument_logic(tmp_path_factory):
-    """Test that the run command works with arguments."""
+def test_local_compile(tmp_path_factory):
+    """Test that the compile command works with arguments."""
     namespace_creds_kwargs = [
         {"auth_gcp": True, "auth_azure": False, "auth_aws": False},
         {"auth_gcp": False, "auth_azure": True, "auth_aws": False},
@@ -155,7 +156,7 @@ def test_cloud_credentials_argument_logic(tmp_path_factory):
                 **namespace_cred_kwargs,
                 credentials=None,
             )
-            run_local(args)
+            compile_local(args)
 
             if namespace_cred_kwargs["auth_gcp"] is True:
                 extra_volumes = [CloudCredentialsMount.GCP.value]
@@ -264,6 +265,61 @@ def test_local_run(tmp_path_factory):
                 "--remove-orphans",
             ],
         )
+
+
+def test_local_run_cloud_credentials(tmp_path_factory):
+    namespace_creds_kwargs = [
+        {"auth_gcp": True, "auth_azure": False, "auth_aws": False},
+        {"auth_gcp": False, "auth_azure": True, "auth_aws": False},
+        {"auth_gcp": False, "auth_azure": False, "auth_aws": True},
+    ]
+
+    for namespace_cred_kwargs in namespace_creds_kwargs:
+        with tmp_path_factory.mktemp("temp") as fn, patch(
+            "fondant.pipeline.compiler.DockerCompiler.compile",
+        ) as mock_compiler, patch(
+            "subprocess.call",
+        ) as mock_runner:
+            args = argparse.Namespace(
+                local=True,
+                vertex=False,
+                kubeflow=False,
+                ref=__name__,
+                output_path=str(fn / "docker-compose.yml"),
+                **namespace_cred_kwargs,
+                credentials=None,
+                extra_volumes=[],
+                build_arg=[],
+            )
+            run_local(args)
+
+            if namespace_cred_kwargs["auth_gcp"] is True:
+                extra_volumes = [CloudCredentialsMount.GCP.value]
+            if namespace_cred_kwargs["auth_aws"] is True:
+                extra_volumes = [CloudCredentialsMount.AWS.value]
+            if namespace_cred_kwargs["auth_azure"] is True:
+                extra_volumes = [CloudCredentialsMount.AZURE.value]
+
+            mock_compiler.assert_called_once_with(
+                pipeline=TEST_PIPELINE,
+                extra_volumes=extra_volumes,
+                output_path=str(fn / "docker-compose.yml"),
+                build_args=[],
+            )
+
+            mock_runner.assert_called_once_with(
+                [
+                    "docker",
+                    "compose",
+                    "-f",
+                    str(fn / "docker-compose.yml"),
+                    "up",
+                    "--build",
+                    "--pull",
+                    "always",
+                    "--remove-orphans",
+                ],
+            )
 
 
 def test_kfp_run(tmp_path_factory):


### PR DESCRIPTION
The cloud credential arguments were only present to the `compile` command and not the `run` one. This PR fixes this issue, @Hakimovich99 