### PR TITLE
Update fondant_component.yaml

### DIFF
--- a/components/load_from_parquet/fondant_component.yaml
+++ b/components/load_from_parquet/fondant_component.yaml
@@ -21,6 +21,7 @@ args:
   n_rows_to_load:
     description: Optional argument that defines the number of rows to load. Useful for testing pipeline runs on a small scale
     type: int
+    default: None
   index_column:
     description: Column to set index to in the load component, if not specified a default globally unique index will be set
     type: str


### PR DESCRIPTION
minor detail: set n_rows_to_load default value to None to be able to easily load the whole parquet file