### PR TITLE
Update tag pattern in prep-release pipeline to match dev versions

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -2,7 +2,7 @@ name: Build Python 🐍 distributions 📦 and publish to TestPyPI
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+*'
+      - '[0-9]+.[0-9]+.*[0-9]+*'
 jobs:
   build-n-publish:
     name: Build Python 🐍 distributions 📦 and publish to TestPyPI


### PR DESCRIPTION
The pipeline was not triggered by my `0.8.dev0` tag, which is the [recommended format](https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases) for development releases.