### PR TITLE
Feature/build 2 ecr

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,12 +7,11 @@ on:
   workflow_dispatch:
 
 env:
-  
   AWS_REGION : us-east-1
 
 permissions:
-      id-token: write
-      contents: read
+  id-token: write
+  contents: read
 
 jobs:
   docker:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   
-  AWS_REGION : <"us-east-1">
+  AWS_REGION : us-east-1
 
 permissions:
       id-token: write   # This is required for requesting the JWT
@@ -45,7 +45,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::904708148714:role/fondant-github-actions
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: ${{env.AWS_DEFAULT_REGION}}
+          aws-region: ${{env.AWS_REGION}}
 
       - name: Login to Amazon ECR Public
         id: login-ecr-public

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,14 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  
+  AWS_REGION : <"us-east-1">
+
+permissions:
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -30,6 +38,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::904708148714:role/fondant-github-actions
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{env.AWS_DEFAULT_REGION}}
+
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Build components
         run: ./scripts/build_components.sh --cache -t $GITHUB_SHA -t dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::904708148714:oidc-provider/token.actions.githubusercontent.com
+          role-to-assume: arn:aws:iam::904708148714:role/fondant-github-actions
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{env.AWS_REGION}}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,8 +11,8 @@ env:
   AWS_REGION : us-east-1
 
 permissions:
-      id-token: write   # This is required for requesting the JWT
-      contents: read    # This is required for actions/checkout
+      id-token: write
+      contents: read
 
 jobs:
   docker:
@@ -43,7 +43,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::904708148714:role/fondant-github-actions
+          role-to-assume: arn:aws:iam::904708148714:oidc-provider/token.actions.githubusercontent.com
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{env.AWS_REGION}}
 

--- a/scripts/build_components.sh
+++ b/scripts/build_components.sh
@@ -74,7 +74,6 @@ for dir in "${components_to_build[@]}"; do
     fi
     echo "$full_image_name"
     full_image_names+=("$full_image_name")
-    aws_full_image_names+=("$aws_full_image_name")
   done
 
   echo "Updating the image version in the fondant_component.yaml with:"
@@ -83,7 +82,7 @@ for dir in "${components_to_build[@]}"; do
 
   # create repo if not exists
   aws ecr-public describe-repositories --region us-east-1 --repository-names ${BASENAME} || aws ecr-public create-repository --region us-east-1 --repository-name ${BASENAME}
-  full_image_names+=("public.ecr.aws/m4f5a0g0/${BASENAME}:${tag}")
+  full_image_names+=("public.ecr.aws/fndnt/${BASENAME}:${tag}")
 
   args=()
 


### PR DESCRIPTION
I :
- created a public repo called `fndnt` ont the correct AWS account (the name reservation is pending)
- altered the `build_components.sh` script. So now It will create repo's if they do not exist yet and add a tag with the public ECR uri. (if you want to run it locally you will need to be logged in in Docker with AWS credentials)
- I ran the script locally for one component and without building to docker hub (only ECR) succesfully
- setup OIDC on the Public AWS account for github actions (using [1](https://www.automat-it.com/post/using-github-actions-with-aws-iam-roles)  [2](https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/))
- updated the github actions to include fetching credentials via OIDC and authenticating to the public ecr. (every AWS account can only have 1 public ECR so all aws commands using `aws ecr-public ...` will be ran against it.

I still need to test everything together in github itself.