### PR TITLE
Build to AWS ECR on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,12 +32,11 @@ jobs:
           sudo chmod +x /usr/libexec/docker/cli-plugins/docker-pushrm
           docker pushrm --help
 
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -3,6 +3,14 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.*[0-9]+*'
+
+env:
+  AWS_REGION : us-east-1
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-n-publish:
     name: Build Python 🐍 distributions 📦 and publish to TestPyPI
@@ -29,11 +37,24 @@ jobs:
           sudo wget https://github.com/christian-korneck/docker-pushrm/releases/download/v1.9.0/docker-pushrm_linux_amd64 -O /usr/libexec/docker/cli-plugins/docker-pushrm
           sudo chmod +x /usr/libexec/docker/cli-plugins/docker-pushrm
 
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::904708148714:role/fondant-github-actions
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{env.AWS_REGION}}
+
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Build components
         run: ./scripts/build_components.sh -t $GITHUB_REF_NAME

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         sudo wget https://github.com/christian-korneck/docker-pushrm/releases/download/v1.9.0/docker-pushrm_linux_amd64 -O /usr/libexec/docker/cli-plugins/docker-pushrm
         sudo chmod +x /usr/libexec/docker/cli-plugins/docker-pushrm
 
-    - name: Login to GitHub Container Registry
+    - name: Login to DockerHub
       uses: docker/login-action@v2
       with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/scripts/tag_components.sh
+++ b/scripts/tag_components.sh
@@ -24,7 +24,7 @@ if [ -z "${old_tag}" ] || [ -z "${new_tag}" ]; then
   exit 1
 fi
 
-# Set github repo information
+# Set DockerHub namespace information
 namespace="fndnt"
 
 # Get the component directory


### PR DESCRIPTION
The [prep-release pipeline failed](https://github.com/ml6team/fondant/actions/runs/7086335306) since it uses the `build_component.sh` script but doesn't login to AWS.

This PR fixes that.

I did not update the release pipeline. It uses the `tag_components.sh` script, which adds a `latest` tag to the version being released. We would need to update the script to enable updating the ECR tag as well. But
- I don't think we're actually using the `latest` tag anywhere
- The `latest` tag would raise additional issues with the pull-through cache, since it's cached
So I propose to leave it as is for now.