### PR TITLE
Support pipeline factory functions as CLI reference

### DIFF
--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -659,13 +659,13 @@ def run_local(args):
         ref = pipeline_from_module(args.ref)
     except ModuleNotFoundError:
         ref = args.ref
-    finally:
-        runner = DockerRunner()
-        runner.run(
-            input=ref,
-            extra_volumes=extra_volumes,
-            build_args=args.build_arg,
-        )
+
+    runner = DockerRunner()
+    runner.run(
+        input=ref,
+        extra_volumes=extra_volumes,
+        build_args=args.build_arg,
+    )
 
 
 def run_kfp(args):
@@ -686,12 +686,9 @@ def run_kfp(args):
         )
         compiler = KubeFlowCompiler()
         compiler.compile(pipeline=pipeline, output_path=spec_ref)
-    finally:
-        try:
-            runner = KubeflowRunner(host=args.host)
-            runner.run(input_spec=spec_ref)
-        except UnboundLocalError as e:
-            raise e
+
+    runner = KubeflowRunner(host=args.host)
+    runner.run(input_spec=spec_ref)
 
 
 def run_vertex(args):
@@ -709,17 +706,14 @@ def run_vertex(args):
         )
         compiler = VertexCompiler()
         compiler.compile(pipeline=pipeline, output_path=spec_ref)
-    finally:
-        try:
-            runner = VertexRunner(
-                project_id=args.project_id,
-                region=args.region,
-                service_account=args.service_account,
-                network=args.network,
-            )
-            runner.run(input_spec=spec_ref)
-        except UnboundLocalError as e:
-            raise e
+
+    runner = VertexRunner(
+        project_id=args.project_id,
+        region=args.region,
+        service_account=args.service_account,
+        network=args.network,
+    )
+    runner.run(input_spec=spec_ref)
 
 
 def run_sagemaker(args):
@@ -729,14 +723,14 @@ def run_sagemaker(args):
         ref = pipeline_from_module(args.ref)
     except ModuleNotFoundError:
         ref = args.ref
-    finally:
-        runner = SagemakerRunner()
-        runner.run(
-            input=ref,
-            pipeline_name=args.pipeline_name,
-            role_arn=args.role_arn,
-            instance_type=args.instance_type,
-        )
+
+    runner = SagemakerRunner()
+    runner.run(
+        input=ref,
+        pipeline_name=args.pipeline_name,
+        role_arn=args.role_arn,
+        instance_type=args.instance_type,
+    )
 
 
 def register_execute(parent_parser):

--- a/tests/examples/example_modules/pipeline.py
+++ b/tests/examples/example_modules/pipeline.py
@@ -1,3 +1,12 @@
 from fondant.pipeline import Pipeline
 
-pipeline = Pipeline(pipeline_name="test_pipeline", base_path="some/path")
+
+def create_pipeline_with_args(name):
+    return Pipeline(pipeline_name=name, base_path="some/path")
+
+
+def create_pipeline():
+    return Pipeline(pipeline_name="test_pipeline", base_path="some/path")
+
+
+pipeline = create_pipeline()

--- a/tests/examples/example_modules/pipeline.py
+++ b/tests/examples/example_modules/pipeline.py
@@ -9,4 +9,11 @@ def create_pipeline():
     return Pipeline(pipeline_name="test_pipeline", base_path="some/path")
 
 
+def not_implemented():
+    raise NotImplementedError
+
+
 pipeline = create_pipeline()
+
+
+number = 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,12 +132,28 @@ def test_pipeline_from_module(module_str):
         "examples.example_modules.pipeline:create_pipeline('test_pipeline')",
         # Factory does not expect an argument
         "examples.example_modules.pipeline:create_pipeline(name='test_pipeline')",
+        # Invalid argument
+        "examples.example_modules.pipeline:create_pipeline(name)",
+        # Not a variable or function
+        "examples.example_modules.pipeline:[]",
+        # Attribute doesn't exist
+        "examples.example_modules.pipeline:no_pipeline",
+        # Attribute is not a valid python name
+        "examples.example_modules.pipeline:pipe;line",
+        # Not a Pipeline
+        "examples.example_modules.pipeline:number",
     ],
 )
 def test_pipeline_from_module_error(module_str):
     """Test different error cases for pipeline_from_string."""
     with pytest.raises(PipelineImportError):
         pipeline_from_string(module_str)
+
+
+def test_factory_error_propagated():
+    """Test that an error in the factory method is correctly propagated."""
+    with pytest.raises(NotImplementedError):
+        pipeline_from_string("examples.example_modules.pipeline:not_implemented")
 
 
 def test_execute_logic(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from fondant.cli import (
     component_from_module,
     execute,
     get_module,
-    pipeline_from_module,
+    pipeline_from_string,
     run_kfp,
     run_local,
     run_vertex,
@@ -107,11 +107,15 @@ def test_component_from_module_error(module_str):
     [
         __name__,
         "examples.example_modules.pipeline",
+        "examples.example_modules.pipeline:pipeline",
+        "examples.example_modules.pipeline:create_pipeline",
+        "examples.example_modules.pipeline:create_pipeline_with_args('test_pipeline')",
+        "examples.example_modules.pipeline:create_pipeline_with_args(name='test_pipeline')",
     ],
 )
 def test_pipeline_from_module(module_str):
     """Test that pipeline_from_string works."""
-    pipeline = pipeline_from_module(module_str)
+    pipeline = pipeline_from_string(module_str)
     assert pipeline.name == "test_pipeline"
 
 
@@ -122,12 +126,18 @@ def test_pipeline_from_module(module_str):
         "examples.example_modules.component",
         # module contains many pipeline instances
         "examples.example_modules.invalid_double_pipeline",
+        # Factory expects an argument
+        "examples.example_modules.pipeline:create_pipeline_with_args",
+        # Factory does not expect an argument
+        "examples.example_modules.pipeline:create_pipeline('test_pipeline')",
+        # Factory does not expect an argument
+        "examples.example_modules.pipeline:create_pipeline(name='test_pipeline')",
     ],
 )
 def test_pipeline_from_module_error(module_str):
     """Test different error cases for pipeline_from_string."""
     with pytest.raises(PipelineImportError):
-        pipeline_from_module(module_str)
+        pipeline_from_string(module_str)
 
 
 def test_execute_logic(monkeypatch):


### PR DESCRIPTION
In our RAG use case, [we want to start using a pipeline factory function](https://github.com/ml6team/fondant-usecase-RAG/pull/34#discussion_r1414114415), but this is currently not supported by the CLI.

This PR fixes that.

I also included a change (the first commit) which removes the `finally` blocks. We were using this as follows:
```python
try:
    ref = ...
except SpecificError:
    ref = ...
finally:
    run(ref)
```

But apparently the `finally` block is also entered if any non-`SpecificError` exception is raised in the `try` block. This lead to all non-handled errors to become an `UnboundLocal` error. This is now no longer the case, and the original error is not caught.