### PR TITLE
Add support for resources with Sagemaker

### DIFF
--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -407,13 +407,6 @@ def register_compile(parent_parser):
         default=".fondant/sagemaker_pipeline.json",
     )
     sagemaker_parser.add_argument(
-        "--instance-type",
-        help="""the instance type to use for the processing steps
-        (see: https://aws.amazon.com/ec2/instance-types/ for options).""",
-        default="ml.m5.large",
-    )
-
-    sagemaker_parser.add_argument(
         "--role-arn",
         help="""the Amazon Resource Name role to use for the processing steps""",
         default=None,
@@ -471,7 +464,6 @@ def compile_sagemaker(args):
     compiler.compile(
         pipeline=pipeline,
         output_path=args.output_path,
-        instance_type=args.instance_type,
         role_arn=args.role_arn,
     )
 
@@ -631,12 +623,6 @@ def register_run(parent_parser):
         help="""the Amazon Resource Name role to use for the processing steps""",
         default=None,
     )
-    sagemaker_parser.add_argument(
-        "--instance-type",
-        help="""the instance type to use for the processing steps
-        (see: https://aws.amazon.com/ec2/instance-types/ for options).""",
-        default="ml.m5.large",
-    )
 
     local_parser.set_defaults(func=run_local)
     kubeflow_parser.set_defaults(func=run_kfp)
@@ -714,7 +700,6 @@ def run_sagemaker(args):
         input=ref,
         pipeline_name=args.pipeline_name,
         role_arn=args.role_arn,
-        instance_type=args.instance_type,
     )
 
 

--- a/src/fondant/pipeline/pipeline.py
+++ b/src/fondant/pipeline/pipeline.py
@@ -56,6 +56,7 @@ class Resources:
     memory_limit: t.Optional[str] = None
     node_pool_label: t.Optional[str] = None
     node_pool_name: t.Optional[str] = None
+    instance_type: t.Optional[str] = None
 
     """
     Class representing the resources to assign to a Fondant Component operation in a Fondant
@@ -81,6 +82,7 @@ class Resources:
              number followed by one of “E”, “P”, “T”, “G”, “M”, “K”.
            memory_limit: the maximum memory that can be used by the component. The value  can be a
             number or a number followed by one of “E”, “P”, “T”, “G”, “M”, “K”.
+           instancy_type: the instancy type of the component.
        """
 
     def __post_init__(self):

--- a/src/fondant/pipeline/runner.py
+++ b/src/fondant/pipeline/runner.py
@@ -243,8 +243,6 @@ class SagemakerRunner(Runner):
         input: t.Union[Pipeline, str],
         pipeline_name: str,
         role_arn: str,
-        *,
-        instance_type: str = "ml.m5.xlarge",
     ):
         """Run a pipeline, either from a compiled sagemaker spec or from a fondant pipeline.
 
@@ -266,7 +264,6 @@ class SagemakerRunner(Runner):
             compiler.compile(
                 input,
                 output_path=output_path,
-                instance_type=instance_type,
                 role_arn=role_arn,
             )
             self._run(output_path, pipeline_name=pipeline_name, role_arn=role_arn)

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -236,7 +236,6 @@ class MockSagemakerCompiler:
         pipeline,
         output_path,
         *,
-        instance_type,
         role_arn,
     ) -> None:
         with open(output_path, "w") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,13 +252,11 @@ def test_sagemaker_compile(tmp_path_factory):
             sagemaker=True,
             output_path=str(fn / "sagemaker_pipeline.json"),
             role_arn="some_role",
-            instance_type="some_instance_type",
         )
         compile_sagemaker(args)
         mock_compiler.assert_called_once_with(
             pipeline=TEST_PIPELINE,
             output_path=str(fn / "sagemaker_pipeline.json"),
-            instance_type="some_instance_type",
             role_arn="some_role",
         )
 


### PR DESCRIPTION
You can now define resources on a component level for SageMaker:

```
images = raw_data.apply(
    "download_images",
    arguments={
        "input_partition_rows": 100,
        "resize_mode": "no",
    },
    resources=Resources(instance_type="ml.t3.xlarge"),
)
```

Only the instance_type is supported for SageMaker (for now)