### PR TITLE
Reactivate readme generation pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,11 +62,11 @@ repos:
           - types-retry
         pass_filenames: false
 
-#  - repo: local
-#    hooks:
-#      - id: generate_component_readmes
-#        name: Generate component READMEs
-#        language: python
-#        entry: python scripts/component_readme/generate_readme.py
-#        files: ^components/.*/fondant_component.yaml
-#        additional_dependencies: ["fondant@git+https://github.com/ml6team/fondant@main", "Jinja2==3.1.2"]
+  - repo: local
+    hooks:
+      - id: generate_component_readmes
+        name: Generate component READMEs
+        language: python
+        entry: python scripts/component_readme/generate_readme.py
+        files: ^components/.*/fondant_component.yaml
+        additional_dependencies: ["fondant@git+https://github.com/ml6team/fondant@main", "Jinja2==3.1.2"]

--- a/components/write_to_hf_hub/README.md
+++ b/components/write_to_hf_hub/README.md
@@ -5,9 +5,7 @@ Component that writes a dataset to the hub
 
 ### Inputs / outputs
 
-**This component consumes:**
-
-- dummy_variable: binary
+**This component consumes no data.**
 
 **This component produces no data.**
 

--- a/components/write_to_hf_hub/fondant_component.yaml
+++ b/components/write_to_hf_hub/fondant_component.yaml
@@ -5,7 +5,7 @@ tags:
   - Data writing
 
 consumes:
-  additional_properties: true
+  additionalProperties: true
 
 args:
   hf_token:

--- a/scripts/component_readme/generate_readme.py
+++ b/scripts/component_readme/generate_readme.py
@@ -52,4 +52,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     for spec in args.component_specs:
+        print(f"Generating readme for {spec}")
         main(spec)


### PR DESCRIPTION
This was temporarily deactivated since the specification on the main branch was out of sync. We still need to update the generic components to generate a more useful README, but that's for a separate PR.

Devs will need to reset their local pre-commit environments for this to work.