### PR TITLE
Fix environment variable setting in embed_text component

### DIFF
--- a/components/embed_text/src/main.py
+++ b/components/embed_text/src/main.py
@@ -32,13 +32,13 @@ class EmbedTextComponent(PandasTransformComponent):
         auth_kwargs: dict,
         **kwargs,
     ):
+        to_env_vars(api_keys)
+        
         self.embedding_model = self.get_embedding_model(
             model_provider,
             model,
             auth_kwargs,
         )
-
-        to_env_vars(api_keys)
 
     @staticmethod
     def get_embedding_model(

--- a/components/embed_text/src/main.py
+++ b/components/embed_text/src/main.py
@@ -33,7 +33,7 @@ class EmbedTextComponent(PandasTransformComponent):
         **kwargs,
     ):
         to_env_vars(api_keys)
-        
+
         self.embedding_model = self.get_embedding_model(
             model_provider,
             model,


### PR DESCRIPTION
Set the environment key before calling the embedding model to avoid "no api key found" error.