### PR TITLE
Reduce pulling logs

### DIFF
--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -526,6 +526,12 @@ def register_run(parent_parser):
         action="append",
         help="Build arguments for `docker build`",
     )
+    local_parser.add_argument(
+        "--quiet-pull",
+        action="store_true",
+        help="Flag to suppress the output of the docker pull command",
+        default=True,
+    )
 
     # kubeflow runner parser
     kubeflow_parser.add_argument(
@@ -652,6 +658,7 @@ def run_local(args):
         input=ref,
         extra_volumes=extra_volumes,
         build_args=args.build_arg,
+        quiet_pull=args.quiet_pull,
     )
 
 

--- a/src/fondant/pipeline/runner.py
+++ b/src/fondant/pipeline/runner.py
@@ -26,7 +26,7 @@ class Runner(ABC):
 
 
 class DockerRunner(Runner):
-    def _run(self, input_spec: str, *args, **kwargs):
+    def _run(self, input_spec: str, quiet_pull: bool, *args, **kwargs):
         """Run a docker-compose spec."""
         cmd = [
             "docker",
@@ -40,6 +40,9 @@ class DockerRunner(Runner):
             "--remove-orphans",
         ]
 
+        if quiet_pull:
+            cmd.append("--quiet-pull")
+
         print("Starting pipeline run...")
         subprocess.call(cmd)  # nosec
         print("Finished pipeline run.")
@@ -50,16 +53,18 @@ class DockerRunner(Runner):
         *,
         extra_volumes: t.Union[t.Optional[list], t.Optional[str]] = None,
         build_args: t.Optional[t.List[str]] = None,
+        quiet_pull: bool = True,
     ) -> None:
         """Run a pipeline, either from a compiled docker-compose spec or from a fondant pipeline.
 
         Args:
             input: the pipeline to compile or a path to a already compiled docker-compose spec
-            output_path: the path where to save the docker-compose spec
             extra_volumes: a list of extra volumes (using the Short syntax:
-            https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5)
+             https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5)
             to mount in the docker-compose spec.
             build_args: List of build arguments to pass to docker
+            quiet_pull: Whether to use the --quiet-pull flag when running docker-compose to
+            suppress the output of the docker pull command.
         """
         if isinstance(input, Pipeline):
             os.makedirs(".fondant", exist_ok=True)
@@ -74,9 +79,9 @@ class DockerRunner(Runner):
                 extra_volumes=extra_volumes,
                 build_args=build_args,
             )
-            self._run(output_path)
+            self._run(output_path, quiet_pull)
         else:
-            self._run(input)
+            self._run(input, quiet_pull)
 
 
 class KubeflowRunner(Runner):

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -36,6 +36,7 @@ def test_docker_runner():
                 "--pull",
                 "always",
                 "--remove-orphans",
+                "--quiet-pull",
             ],
         )
 
@@ -54,6 +55,7 @@ def test_docker_runner_from_pipeline():
                 "--pull",
                 "always",
                 "--remove-orphans",
+                "--quiet-pull",
             ],
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -273,6 +273,7 @@ def test_local_run():
         credentials=None,
         extra_volumes=[],
         build_arg=[],
+        quiet_pull=True,
     )
     with patch("subprocess.call") as mock_call:
         run_local(args)
@@ -287,6 +288,7 @@ def test_local_run():
                 "--pull",
                 "always",
                 "--remove-orphans",
+                "--quiet-pull",
             ],
         )
 
@@ -302,6 +304,7 @@ def test_local_run():
             auth_azure=False,
             auth_aws=False,
             credentials=None,
+            quiet_pull=False,
         )
         run_local(args1)
         mock_call.assert_called_once_with(
@@ -341,6 +344,7 @@ def test_local_run_cloud_credentials():
                 credentials=None,
                 extra_volumes=[],
                 build_arg=[],
+                quiet_pull=False,
             )
             run_local(args)
 


### PR DESCRIPTION
PR to reduce pulling logs when running docker compose since they can clutter the notebooks where there are many images to pull