### PR TITLE
Fix illegal memory access embedding

### DIFF
--- a/components/embed_text/src/main.py
+++ b/components/embed_text/src/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+import dask
 import google.cloud.aiplatform as aip
 import pandas as pd
 from fondant.component import PandasTransformComponent
@@ -15,6 +16,8 @@ from langchain.schema.embeddings import Embeddings
 from retry import retry
 
 logger = logging.getLogger(__name__)
+
+dask.config.set(scheduler="processes")
 
 
 def to_env_vars(api_keys: dict):


### PR DESCRIPTION
PR that fixes issue that arises with error 139 when running embedding component with large number of rows (~100k). The issue seems to stem from multiple processes trying to access the GPU at the same time. 

This should be a temporary fix until [#566](https://github.com/ml6team/fondant/issues/566) is addressed 

more info [here](https://docs.google.com/document/d/1ugiMhf2zeLQtS9Psd4m4SIlwDl4uCWba5vW-hsSO1yo/edit)