### PR TITLE
Unify operation and component spec

### DIFF
--- a/components/load_from_csv/src/main.py
+++ b/components/load_from_csv/src/main.py
@@ -23,7 +23,6 @@ class CSVReader(DaskLoadComponent):
     ) -> None:
         """
         Args:
-            spec: the component spec
             produces: The schema the component should produce
             dataset_uri: The remote path to the csv file/folder containing the dataset
             column_separator: Separator to use when parsing csv

--- a/components/load_with_llamahub/src/main.py
+++ b/components/load_with_llamahub/src/main.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import dask.dataframe as dd
 import pandas as pd
 from fondant.component import DaskLoadComponent
-from fondant.core.component_spec import ComponentSpec
+from fondant.core.component_spec import OperationSpec
 from llama_index import download_loader
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class LlamaHubReader(DaskLoadComponent):
     def __init__(
         self,
-        spec: ComponentSpec,
+        spec: OperationSpec,
         *,
         loader_class: str,
         loader_kwargs: dict,
@@ -73,7 +73,7 @@ class LlamaHubReader(DaskLoadComponent):
 
             def _get_meta_df() -> pd.DataFrame:
                 meta_dict = {"id": pd.Series(dtype="object")}
-                for field_name, field in self.spec.produces.items():
+                for field_name, field in self.spec.inner_produces.items():
                     meta_dict[field_name] = pd.Series(
                         dtype=pd.ArrowDtype(field.type.value),
                     )
@@ -95,7 +95,7 @@ class LlamaHubReader(DaskLoadComponent):
 
         doc_dict = defaultdict(list)
         for d, document in enumerate(documents):
-            for column in self.spec.produces:
+            for column in self.spec.inner_produces:
                 if column == "text":
                     doc_dict["text"].append(document.text)
                 else:

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -199,7 +199,7 @@ class DaskDataWriter(DataIO):
         """Create dataframe writing task."""
         location = (
             f"{self.manifest.base_path}/{self.manifest.pipeline_name}/"
-            f"{self.manifest.run_id}/{self.operation_spec.specification.component_folder_name}"
+            f"{self.manifest.run_id}/{self.operation_spec.component_spec.component_folder_name}"
         )
 
         schema = {

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -199,7 +199,7 @@ class DaskDataWriter(DataIO):
         """Create dataframe writing task."""
         location = (
             f"{self.manifest.base_path}/{self.manifest.pipeline_name}/"
-            f"{self.manifest.run_id}/{self.operation_spec.component_spec.component_folder_name}"
+            f"{self.manifest.run_id}/{self.operation_spec.component_folder_name}"
         )
 
         schema = {

--- a/src/fondant/component/executor.py
+++ b/src/fondant/component/executor.py
@@ -27,7 +27,7 @@ from fondant.component import (
     PandasTransformComponent,
 )
 from fondant.component.data_io import DaskDataLoader, DaskDataWriter
-from fondant.core.component_spec import Argument, ComponentSpec, OperationSpec
+from fondant.core.component_spec import Argument, OperationSpec
 from fondant.core.manifest import Manifest, Metadata
 
 dask.config.set({"dataframe.convert-string": False})
@@ -143,7 +143,7 @@ class Executor(t.Generic[Component]):
         client_kwargs: t.Optional[dict],
     ) -> "Executor":
         """Create an executor from a component spec."""
-        args_dict = vars(cls._add_and_parse_args(operation_spec.component_spec))
+        args_dict = vars(cls._add_and_parse_args(operation_spec))
 
         for argument in [
             "operation_spec",
@@ -171,13 +171,13 @@ class Executor(t.Generic[Component]):
             input_partition_rows=input_partition_rows,
             cluster_type=cluster_type,
             client_kwargs=client_kwargs,
-            previous_index=operation_spec.component_spec.previous_index,
+            previous_index=operation_spec.previous_index,
         )
 
     @classmethod
-    def _add_and_parse_args(cls, spec: ComponentSpec):
+    def _add_and_parse_args(cls, operation_spec: OperationSpec):
         parser = argparse.ArgumentParser()
-        component_arguments = cls._get_component_arguments(spec)
+        component_arguments = cls._get_component_arguments(operation_spec)
 
         for arg in component_arguments.values():
             if arg.name in cls.optional_fondant_arguments():
@@ -213,17 +213,19 @@ class Executor(t.Generic[Component]):
         return []
 
     @staticmethod
-    def _get_component_arguments(spec: ComponentSpec) -> t.Dict[str, Argument]:
+    def _get_component_arguments(
+        operation_spec: OperationSpec,
+    ) -> t.Dict[str, Argument]:
         """
         Get the component arguments as a dictionary representation containing both input and output
             arguments of a component
         Args:
-            spec: the component spec
+            operation_spec: the operation spec
         Returns:
             Input and output arguments of the component.
         """
         component_arguments: t.Dict[str, Argument] = {}
-        component_arguments.update(spec.args)
+        component_arguments.update(operation_spec.args)
         return component_arguments
 
     @abstractmethod

--- a/src/fondant/component/executor.py
+++ b/src/fondant/component/executor.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import dask
 import dask.dataframe as dd
 import pandas as pd
-import pyarrow as pa
 from dask.distributed import Client, LocalCluster
 from fsspec import open as fs_open
 
@@ -30,7 +29,6 @@ from fondant.component import (
 from fondant.component.data_io import DaskDataLoader, DaskDataWriter
 from fondant.core.component_spec import Argument, ComponentSpec, OperationSpec
 from fondant.core.manifest import Manifest, Metadata
-from fondant.core.schema import Type
 
 dask.config.set({"dataframe.convert-string": False})
 logger = logging.getLogger(__name__)
@@ -41,7 +39,7 @@ class Executor(t.Generic[Component]):
     An executor executes a Component.
 
     Args:
-        spec: The specification of the Component to be executed.
+        operation_spec: The operation spec of the component to be executed.
         cache: Flag indicating whether to use caching for intermediate results.
         input_manifest_path: The path to the input manifest file.
         output_manifest_path: The path to the output manifest file.
@@ -55,11 +53,13 @@ class Executor(t.Generic[Component]):
         (default is "local").
         client_kwargs: Additional keyword arguments dict which will be used to
         initialise the dask client, allowing for advanced configuration.
+        previous_index: The name of the index column of the previous component.
+            Used to remove all previous fields if the component changes the index
     """
 
     def __init__(
         self,
-        spec: ComponentSpec,
+        operation_spec: OperationSpec,
         *,
         cache: bool,
         input_manifest_path: t.Union[str, Path],
@@ -69,18 +69,16 @@ class Executor(t.Generic[Component]):
         input_partition_rows: int,
         cluster_type: t.Optional[str] = None,
         client_kwargs: t.Optional[dict] = None,
-        consumes: t.Optional[t.Dict[str, t.Union[str, pa.DataType]]] = None,
-        produces: t.Optional[t.Dict[str, t.Union[str, pa.DataType]]] = None,
+        previous_index: t.Optional[str] = None,
     ) -> None:
-        self.spec = spec
+        self.operation_spec = operation_spec
         self.cache = cache
         self.input_manifest_path = input_manifest_path
         self.output_manifest_path = output_manifest_path
         self.metadata = Metadata.from_dict(metadata)
         self.user_arguments = user_arguments
         self.input_partition_rows = input_partition_rows
-
-        self.operation_spec = OperationSpec(spec, consumes=consumes, produces=produces)
+        self.previous_index = previous_index
 
         if cluster_type == "local":
             client_kwargs = client_kwargs or {
@@ -113,48 +111,42 @@ class Executor(t.Generic[Component]):
     def from_args(cls) -> "Executor":
         """Create an executor from a passed argument containing the specification as a dict."""
         parser = argparse.ArgumentParser()
-        parser.add_argument("--component_spec", type=json.loads)
+        parser.add_argument("--operation_spec", type=json.loads)
         parser.add_argument("--cache", type=lambda x: bool(strtobool(x)))
         parser.add_argument("--input_partition_rows", type=int)
         parser.add_argument("--cluster_type", type=str)
         parser.add_argument("--client_kwargs", type=json.loads)
-        parser.add_argument("--consumes", type=cls._parse_mapping)
-        parser.add_argument("--produces", type=cls._parse_mapping)
         args, _ = parser.parse_known_args()
 
-        if "component_spec" not in args:
-            msg = "Error: The --component_spec argument is required."
+        if "operation_spec" not in args:
+            msg = "Error: The --operation_spec argument is required."
             raise ValueError(msg)
 
-        component_spec = ComponentSpec(args.component_spec)
+        operation_spec = OperationSpec.from_dict(args.operation_spec)
 
         return cls.from_spec(
-            component_spec,
+            operation_spec,
             cache=args.cache,
             input_partition_rows=args.input_partition_rows,
             cluster_type=args.cluster_type,
             client_kwargs=args.client_kwargs,
-            consumes=args.consumes,
-            produces=args.produces,
         )
 
     @classmethod
     def from_spec(
         cls,
-        component_spec: ComponentSpec,
+        operation_spec: OperationSpec,
         *,
         cache: bool,
         input_partition_rows: int,
         cluster_type: t.Optional[str],
         client_kwargs: t.Optional[dict],
-        consumes: t.Optional[t.Dict[str, t.Union[str, pa.DataType]]] = None,
-        produces: t.Optional[t.Dict[str, t.Union[str, pa.DataType]]] = None,
     ) -> "Executor":
         """Create an executor from a component spec."""
-        args_dict = vars(cls._add_and_parse_args(component_spec))
+        args_dict = vars(cls._add_and_parse_args(operation_spec.component_spec))
 
         for argument in [
-            "component_spec",
+            "operation_spec",
             "input_partition_rows",
             "cache",
             "cluster_type",
@@ -170,7 +162,7 @@ class Executor(t.Generic[Component]):
         metadata = json.loads(metadata) if metadata else {}
 
         return cls(
-            component_spec,
+            operation_spec,
             input_manifest_path=input_manifest_path,
             output_manifest_path=output_manifest_path,
             cache=cache,
@@ -179,19 +171,8 @@ class Executor(t.Generic[Component]):
             input_partition_rows=input_partition_rows,
             cluster_type=cluster_type,
             client_kwargs=client_kwargs,
-            consumes=consumes,
-            produces=produces,
+            previous_index=operation_spec.component_spec.previous_index,
         )
-
-    @staticmethod
-    def _parse_mapping(json_mapping: str) -> t.Mapping:
-        """Parse a json mapping to a Python mapping with Fondant types."""
-        mapping = json.loads(json_mapping)
-
-        for key, value in mapping.items():
-            if isinstance(value, dict):
-                mapping[key] = Type.from_json(value).value
-        return mapping
 
     @classmethod
     def _add_and_parse_args(cls, spec: ComponentSpec):
@@ -580,7 +561,7 @@ class PandasTransformExecutor(TransformExecutor[PandasTransformComponent]):
         )
 
         # Clear divisions if component spec indicates that the index is changed
-        if self.spec.previous_index is not None:
+        if self.previous_index is not None:
             dataframe.clear_divisions()
 
         return dataframe

--- a/src/fondant/core/component_spec.py
+++ b/src/fondant/core/component_spec.py
@@ -299,7 +299,7 @@ class OperationSpec:
         consumes: t.Optional[t.Dict[str, t.Union[str, pa.DataType]]] = None,
         produces: t.Optional[t.Dict[str, t.Union[str, pa.DataType]]] = None,
     ) -> None:
-        self.component_spec = component_spec
+        self._component_spec = component_spec
 
         self._mappings = {
             "consumes": consumes,
@@ -326,7 +326,7 @@ class OperationSpec:
             return serialized_mapping
 
         specification_dict = {
-            "specification": self.component_spec.specification,
+            "specification": self._component_spec.specification,
             "consumes": _dump_mapping(self._mappings["consumes"]),
             "produces": _dump_mapping(self._mappings["produces"]),
         }
@@ -373,7 +373,7 @@ class OperationSpec:
         Args:
             name: "consumes" or "produces"
         """
-        spec_mapping = getattr(self.component_spec, name)
+        spec_mapping = getattr(self._component_spec, name)
         args_mapping = self._mappings[name]
 
         if not args_mapping:
@@ -385,9 +385,9 @@ class OperationSpec:
             if not isinstance(value, pa.DataType):
                 continue
 
-            if not self.component_spec.is_generic(name):
+            if not self._component_spec.is_generic(name):
                 msg = (
-                    f"Component {self.component_spec.name} does not allow specifying additional "
+                    f"Component {self._component_spec.name} does not allow specifying additional "
                     f"fields but received {key}."
                 )
                 raise InvalidPipelineDefinition(msg)
@@ -478,12 +478,27 @@ class OperationSpec:
 
         return self._outer_produces
 
+    @property
+    def component_folder_name(self) -> str:
+        """Cleans and converts a name to a proper folder name."""
+        return self._component_spec.component_folder_name
+
+    @property
+    def previous_index(self) -> t.Optional[str]:
+        """The name of the index column of the previous component."""
+        return self._component_spec.previous_index
+
+    @property
+    def args(self) -> t.Mapping[str, Argument]:
+        """The component arguments."""
+        return self._component_spec.args
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, OperationSpec):
             return False
 
         # Compare component_spec attribute
-        if self.component_spec != other.component_spec:
+        if self._component_spec != other._component_spec:
             return False
 
         # Compare mappings attribute

--- a/src/fondant/core/component_spec.py
+++ b/src/fondant/core/component_spec.py
@@ -234,7 +234,7 @@ class ComponentSpec:
             "operation_spec": Argument(
                 name="operation_spec",
                 description="The operation specification as a dictionary",
-                type="dict",
+                type="str",
             ),
             "input_partition_rows": Argument(
                 name="input_partition_rows",
@@ -273,6 +273,7 @@ class ComponentSpec:
             ),
         }
 
+    @property
     def kubeflow_specification(self) -> "KubeflowComponentSpec":
         return KubeflowComponentSpec.from_fondant_component_spec(self)
 

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -256,7 +256,7 @@ class Manifest:
         evolved_manifest = self.copy()
 
         # Update `run_id` and `component_id` in the metadata
-        component_id = operation_spec.component_spec.component_folder_name
+        component_id = operation_spec.component_folder_name
         evolved_manifest.update_metadata(key="component_id", value=component_id)
         evolved_manifest.update_metadata(key="run_id", value=run_id)
 
@@ -266,7 +266,7 @@ class Manifest:
         )
 
         # Remove all previous fields if the component changes the index
-        if operation_spec.component_spec.previous_index:
+        if operation_spec.previous_index:
             for field_name in evolved_manifest.fields:
                 evolved_manifest.remove_field(field_name)
 

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -256,7 +256,7 @@ class Manifest:
         evolved_manifest = self.copy()
 
         # Update `run_id` and `component_id` in the metadata
-        component_id = operation_spec.specification.component_folder_name
+        component_id = operation_spec.component_spec.component_folder_name
         evolved_manifest.update_metadata(key="component_id", value=component_id)
         evolved_manifest.update_metadata(key="run_id", value=run_id)
 
@@ -266,7 +266,7 @@ class Manifest:
         )
 
         # Remove all previous fields if the component changes the index
-        if operation_spec.specification.previous_index:
+        if operation_spec.component_spec.previous_index:
             for field_name in evolved_manifest.fields:
                 evolved_manifest.remove_field(field_name)
 

--- a/src/fondant/pipeline/pipeline.py
+++ b/src/fondant/pipeline/pipeline.py
@@ -171,14 +171,13 @@ class ComponentOp:
                     "cache": self.cache,
                     "cluster_type": cluster_type,
                     "client_kwargs": client_kwargs,
-                    "consumes": self._dump_mapping(consumes),
-                    "produces": self._dump_mapping(produces),
+                    "operation_spec": self.operation_spec.to_json(),
                 }.items()
                 if value is not None
             },
         )
 
-        self.arguments.setdefault("component_spec", self.component_spec.specification)
+        self.arguments.setdefault("operation_spec", self.operation_spec.to_json())
 
         self.resources = resources or Resources()
 

--- a/src/fondant/pipeline/pipeline.py
+++ b/src/fondant/pipeline/pipeline.py
@@ -19,7 +19,6 @@ import pyarrow as pa
 from fondant.core.component_spec import ComponentSpec, OperationSpec
 from fondant.core.exceptions import InvalidPipelineDefinition
 from fondant.core.manifest import Manifest
-from fondant.core.schema import Type
 
 logger = logging.getLogger(__name__)
 
@@ -180,19 +179,6 @@ class ComponentOp:
         self.arguments.setdefault("operation_spec", self.operation_spec.to_json())
 
         self.resources = resources or Resources()
-
-    @staticmethod
-    def _dump_mapping(
-        mapping: t.Optional[t.Dict[str, t.Union[str, pa.DataType]]],
-    ) -> dict:
-        if mapping is None:
-            return {}
-
-        serialized_mapping: t.Dict[str, t.Any] = mapping.copy()
-        for key, value in mapping.items():
-            if isinstance(value, pa.DataType):
-                serialized_mapping[key] = Type(value).to_json()
-        return serialized_mapping
 
     def _configure_caching_from_image_tag(
         self,

--- a/tests/component/test_component.py
+++ b/tests/component/test_component.py
@@ -23,7 +23,6 @@ from fondant.component.executor import (
 )
 from fondant.core.component_spec import ComponentSpec, OperationSpec
 from fondant.core.manifest import Manifest, Metadata
-from fondant.pipeline import ComponentOp
 
 components_path = Path("examples/component_specs")
 base_path = Path("examples/mock_base_path")
@@ -94,7 +93,11 @@ def test_component_arguments(metadata):
         "embedding": pa.list_(pa.int32()),
         "data": "array",
     }
-    serialized_produces = json.dumps(ComponentOp._dump_mapping(user_produces))
+
+    operation_spec = OperationSpec(
+        ComponentSpec.from_file(components_path / "arguments/component.yaml"),
+        produces=user_produces,
+    )
 
     sys.argv = [
         "",
@@ -104,8 +107,8 @@ def test_component_arguments(metadata):
         metadata.to_json(),
         "--output_manifest_path",
         str(components_path / "arguments/output_manifest.json"),
-        "--component_spec",
-        yaml_file_to_json_string(components_path / "arguments/component.yaml"),
+        "--operation_spec",
+        operation_spec.to_json(),
         "--cache",
         "True",
         "--input_partition_rows",
@@ -116,10 +119,6 @@ def test_component_arguments(metadata):
         "3.14",
         "--override_default_arg_with_none",
         "None",
-        "--produces",
-        serialized_produces,
-        "--consumes",
-        "{}",
     ]
 
     class MyExecutor(Executor):
@@ -157,6 +156,11 @@ def test_component_arguments(metadata):
 
 def test_run_with_cache(metadata, monkeypatch):
     input_manifest_path = str(components_path / "arguments/input_manifest.json")
+
+    operation_spec = OperationSpec(
+        ComponentSpec.from_file(components_path / "arguments/component.yaml"),
+    )
+
     # Mock CLI arguments
     sys.argv = [
         "",
@@ -166,8 +170,8 @@ def test_run_with_cache(metadata, monkeypatch):
         metadata.to_json(),
         "--output_manifest_path",
         str(components_path / "arguments/output_manifest.json"),
-        "--component_spec",
-        yaml_file_to_json_string(components_path / "arguments/component.yaml"),
+        "--operation_spec",
+        operation_spec.to_json(),
         "--cache",
         "True",
         "--input_partition_rows",
@@ -201,6 +205,10 @@ def test_run_with_cache(metadata, monkeypatch):
 def test_run_with_no_cache(metadata):
     input_manifest_path = str(components_path / "arguments/input_manifest.json")
 
+    operation_spec = OperationSpec(
+        ComponentSpec.from_file(components_path / "arguments/component.yaml"),
+    )
+
     # Change metadata to a new cache key that's not cached
     metadata.cache_key = "123"
     # Mock CLI arguments
@@ -212,8 +220,8 @@ def test_run_with_no_cache(metadata):
         metadata.to_json(),
         "--output_manifest_path",
         str(components_path / "arguments/output_manifest.json"),
-        "--component_spec",
-        yaml_file_to_json_string(components_path / "arguments/component.yaml"),
+        "--operation_spec",
+        operation_spec.to_json(),
         "--cache",
         "True",
         "--input_partition_rows",
@@ -244,6 +252,9 @@ def test_run_with_no_cache(metadata):
 @pytest.mark.usefixtures("_patched_data_writing")
 def test_load_component(metadata):
     # Mock CLI arguments load
+    operation_spec = OperationSpec(
+        ComponentSpec.from_file(components_path / "component.yaml"),
+    )
 
     sys.argv = [
         "",
@@ -255,8 +266,8 @@ def test_load_component(metadata):
         "1",
         "--output_manifest_path",
         str(components_path / "output_manifest.json"),
-        "--component_spec",
-        yaml_file_to_json_string(components_path / "component.yaml"),
+        "--operation_spec",
+        operation_spec.to_json(),
         "--cache",
         "False",
         "--produces",
@@ -289,6 +300,10 @@ def test_load_component(metadata):
 
 @pytest.mark.usefixtures("_patched_data_loading", "_patched_data_writing")
 def test_dask_transform_component(metadata):
+    operation_spec = OperationSpec(
+        ComponentSpec.from_file(components_path / "component.yaml"),
+    )
+
     # Mock CLI arguments
     sys.argv = [
         "",
@@ -304,8 +319,8 @@ def test_dask_transform_component(metadata):
         "10",
         "--output_manifest_path",
         str(components_path / "output_manifest.json"),
-        "--component_spec",
-        yaml_file_to_json_string(components_path / "component.yaml"),
+        "--operation_spec",
+        operation_spec.to_json(),
         "--cache",
         "False",
     ]
@@ -337,6 +352,10 @@ def test_dask_transform_component(metadata):
 
 @pytest.mark.usefixtures("_patched_data_loading", "_patched_data_writing")
 def test_pandas_transform_component(metadata):
+    operation_spec = OperationSpec(
+        ComponentSpec.from_file(components_path / "component.yaml"),
+    )
+
     # Mock CLI arguments
     sys.argv = [
         "",
@@ -350,8 +369,8 @@ def test_pandas_transform_component(metadata):
         "1",
         "--output_manifest_path",
         str(components_path / "output_manifest.json"),
-        "--component_spec",
-        yaml_file_to_json_string(components_path / "component.yaml"),
+        "--operation_spec",
+        operation_spec.to_json(),
         "--cache",
         "False",
     ]
@@ -448,6 +467,9 @@ def test_wrap_transform():
 
 @pytest.mark.usefixtures("_patched_data_loading")
 def test_write_component(metadata):
+    operation_spec = OperationSpec(
+        ComponentSpec.from_file(components_path / "component.yaml"),
+    )
     # Mock CLI arguments
     sys.argv = [
         "",
@@ -459,8 +481,8 @@ def test_write_component(metadata):
         "success",
         "--value",
         "1",
-        "--component_spec",
-        yaml_file_to_json_string(components_path / "component.yaml"),
+        "--operation_spec",
+        operation_spec.to_json(),
         "--cache",
         "False",
     ]

--- a/tests/core/examples/component_specs/generic_consumes_produces.yaml
+++ b/tests/core/examples/component_specs/generic_consumes_produces.yaml
@@ -1,0 +1,23 @@
+name: Example component
+description: This is an example component
+image: example_component:latest
+
+consumes:
+  images_data:
+    type: array
+    items:
+      type: float32
+  additionalProperties: true
+
+produces:
+  audio_data:
+    type: binary
+  additionalProperties: true
+
+args:
+  flag:
+    description: user argument
+    type: str
+  value:
+    description: integer value
+    type: int

--- a/tests/core/examples/component_specs/kubeflow_component.yaml
+++ b/tests/core/examples/component_specs/kubeflow_component.yaml
@@ -8,7 +8,7 @@ components:
           description: Path to the input manifest
           isOptional: true
         operation_spec:
-          parameterType: STRUCT
+          parameterType: STRING
           description: The operation specification as a dictionary
         input_partition_rows:
           parameterType: NUMBER_INTEGER

--- a/tests/core/examples/component_specs/kubeflow_component.yaml
+++ b/tests/core/examples/component_specs/kubeflow_component.yaml
@@ -1,16 +1,15 @@
----
 components:
   comp-example-component:
     executorLabel: exec-example-component
-    inputDefinitions:
+    inputDefinitions: &id001
       parameters:
         input_manifest_path:
           parameterType: STRING
           description: Path to the input manifest
           isOptional: true
-        component_spec:
+        operation_spec:
           parameterType: STRUCT
-          description: The component specification as a dictionary
+          description: The operation specification as a dictionary
         input_partition_rows:
           parameterType: NUMBER_INTEGER
           description: The number of rows to load per partition.                         Set
@@ -34,20 +33,6 @@ components:
         output_manifest_path:
           parameterType: STRING
           description: Path to the output manifest
-        consumes:
-          parameterType: STRUCT
-          description: A mapping to update the fields consumed by the operation as
-            defined in the component spec. The keys are the names of the fields to
-            be received by the component, while the values are the type of the field,
-            or the name of the field to map from the input dataset.
-          defaultValue: {}
-        produces:
-          parameterType: STRUCT
-          description: A mapping to update the fields produced by the operation as
-            defined in the component spec. The keys are the names of the fields to
-            be produced by the component, while the values are the type of the field,
-            or the name that should be used to write the field to the output dataset.
-          defaultValue: {}
         storage_args:
           parameterType: STRING
           description: Storage arguments
@@ -74,8 +59,8 @@ root:
           parameters:
             input_manifest_path:
               componentInputParameter: input_manifest_path
-            component_spec:
-              componentInputParameter: component_spec
+            operation_spec:
+              componentInputParameter: operation_spec
             input_partition_rows:
               componentInputParameter: input_partition_rows
             cache:
@@ -88,62 +73,10 @@ root:
               componentInputParameter: metadata
             output_manifest_path:
               componentInputParameter: output_manifest_path
-            consumes:
-              componentInputParameter: consumes
-            produces:
-              componentInputParameter: produces
             storage_args:
               componentInputParameter: storage_args
         taskInfo:
           name: example-component
-  inputDefinitions:
-    parameters:
-      input_manifest_path:
-        parameterType: STRING
-        description: Path to the input manifest
-        isOptional: true
-      component_spec:
-        parameterType: STRUCT
-        description: The component specification as a dictionary
-      input_partition_rows:
-        parameterType: NUMBER_INTEGER
-        description: The number of rows to load per partition.                         Set
-          to override the automatic partitioning
-        isOptional: true
-      cache:
-        parameterType: BOOLEAN
-        description: Set to False to disable caching, True by default.
-        defaultValue: true
-      cluster_type:
-        parameterType: STRING
-        description: The cluster type to use for the execution
-        defaultValue: default
-      client_kwargs:
-        parameterType: STRUCT
-        description: Keyword arguments to pass to the Dask client
-        defaultValue: {}
-      metadata:
-        parameterType: STRING
-        description: Metadata arguments containing the run id and base path
-      output_manifest_path:
-        parameterType: STRING
-        description: Path to the output manifest
-      consumes:
-        parameterType: STRUCT
-        description: A mapping to update the fields consumed by the operation as defined
-          in the component spec. The keys are the names of the fields to be received
-          by the component, while the values are the type of the field, or the name
-          of the field to map from the input dataset.
-        defaultValue: {}
-      produces:
-        parameterType: STRUCT
-        description: A mapping to update the fields produced by the operation as defined
-          in the component spec. The keys are the names of the fields to be produced
-          by the component, while the values are the type of the field, or the name
-          that should be used to write the field to the output dataset.
-        defaultValue: {}
-      storage_args:
-        parameterType: STRING
-        description: Storage arguments
+  inputDefinitions: *id001
 schemaVersion: 2.1.0
 sdkVersion: kfp-2.0.1

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -1,26 +1,7 @@
-import json
-
 import pyarrow as pa
 import pytest
-from fondant.component.executor import Executor
 from fondant.core.exceptions import InvalidTypeSchema
 from fondant.core.schema import Type
-from fondant.pipeline import ComponentOp
-
-
-def test_produces_parsing():
-    """Test that the produces argument can be properly serialized and deserialized."""
-    produces = {
-        "text": pa.string(),
-        "embedding": pa.list_(pa.int32()),
-    }
-    expected_produces_to_dict = {
-        "text": {"type": "string"},
-        "embedding": {"type": "array", "items": {"type": "int32"}},
-    }
-    actual_produces_to_dict = ComponentOp._dump_mapping(produces)
-    assert actual_produces_to_dict == expected_produces_to_dict
-    assert Executor._parse_mapping(json.dumps(actual_produces_to_dict)) == produces
 
 
 def test_valid_type():


### PR DESCRIPTION
Fixes #728 

We now construct the operation spec once during the compilation process, serialize it and pass it to the component as an argument. No need to pass in the `produces` and `consumes` arguments anymore. 

Some attributes like the arguments and the previous index that are part of the component spec can still be accessed through the operation spec since the component spec is it's attribute. 
