### PR TITLE
Propagate dataset schema eagerly

### DIFF
--- a/components/chunk_text/fondant_component.yaml
+++ b/components/chunk_text/fondant_component.yaml
@@ -19,6 +19,8 @@ produces:
   original_document_id:
     type: string
 
+previous_index: original_document_id
+
 args:
   chunk_size:
     description: Maximum size of chunks to return

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -34,8 +34,8 @@ class Metadata:
     base_path: str
     pipeline_name: str
     run_id: str
-    component_id: str
-    cache_key: str
+    component_id: t.Optional[str]
+    cache_key: t.Optional[str]
 
     def to_dict(self):
         return asdict(self)
@@ -96,8 +96,8 @@ class Manifest:
         pipeline_name: str,
         base_path: str,
         run_id: str,
-        component_id: str,
-        cache_key: str,
+        component_id: t.Optional[str] = None,
+        cache_key: t.Optional[str] = None,
     ) -> "Manifest":
         """Create an empty manifest.
 

--- a/src/fondant/core/schema.py
+++ b/src/fondant/core/schema.py
@@ -187,28 +187,13 @@ class Field:
         type: Type = Type("null"),
         location: str = "",
     ) -> None:
-        self._name = name
-        self._type = type
-        self._location = location
+        self.name = name
+        self.type = type
+        self.location = location
 
-    @property
-    def name(self) -> str:
-        """The name of the field."""
-        return self._name
-
-    @property
-    def type(self) -> Type:
-        """The absolute location of the field."""
-        return self._type
-
-    @property
-    def location(self) -> str:
-        """The relative location of the field."""
-        return self._location
-
-    @location.setter
-    def location(self, value) -> None:
-        self._location = value
+    def __repr__(self):
+        """Returns a string representation of the `Type` instance."""
+        return f"Field({vars(self)})"
 
 
 def validate_partition_size(arg_value):

--- a/src/fondant/core/schema.py
+++ b/src/fondant/core/schema.py
@@ -195,6 +195,9 @@ class Field:
         """Returns a string representation of the `Type` instance."""
         return f"Field({vars(self)})"
 
+    def __eq__(self, other):
+        return vars(self) == vars(other)
+
 
 def validate_partition_size(arg_value):
     if arg_value in ["disable", None, "None"]:

--- a/src/fondant/core/schemas/manifest.json
+++ b/src/fondant/core/schemas/manifest.json
@@ -16,14 +16,13 @@
           "type": "string"
         },
         "component_id": {
-          "type": "string"
+          "type": ["string", "null"]
         }
       },
       "required": [
         "base_path",
         "pipeline_name",
-        "run_id",
-        "component_id"
+        "run_id"
       ]
     },
     "index": {

--- a/src/fondant/pipeline/__init__.py
+++ b/src/fondant/pipeline/__init__.py
@@ -1,5 +1,6 @@
 from .pipeline import (  # noqa
     ComponentOp,
+    Dataset,
     Pipeline,
     Resources,
     VALID_ACCELERATOR_TYPES,

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -386,33 +386,6 @@ def test_invalid_pipeline_declaration(
         pipeline._validate_pipeline_definition("test_pipeline")
 
 
-def test_invalid_pipeline_validation(default_pipeline_args):
-    """
-    Test that an InvalidPipelineDefinition exception is raised when attempting to compile
-    an invalid pipeline definition.
-    """
-    components_path = Path(invalid_pipeline_path / "example_1")
-    component_args = {"storage_args": "a dummy string arg"}
-
-    first_component_op = ComponentOp(
-        Path(components_path / "first_component"),
-        arguments=component_args,
-    )
-    second_component_op = ComponentOp(
-        Path(components_path / "second_component"),
-        arguments=component_args,
-    )
-
-    # double dependency
-    pipeline1 = Pipeline(**default_pipeline_args)
-    dataset = pipeline1._apply(first_component_op)
-    with pytest.raises(InvalidPipelineDefinition):
-        pipeline1._apply(
-            second_component_op,
-            datasets=[dataset, dataset],
-        )
-
-
 def test_reusable_component_op():
     laion_retrieval_op = ComponentOp(
         name_or_path="retrieve_laion_by_prompt",


### PR DESCRIPTION
This PR propagates the dataset schema eagerly when an operation is applied. This is useful for iterative development in a notebook, since the schema of the current dataset can be inspected.

Result:

```
In [2]: from fondant.pipeline import Pipeline
In [3]: import pyarrow as pa
In [4]: pipeline = Pipeline(name="my-pipe", base_path="data")
In [5]: text_data = pipeline.read(
   ...:     "load_from_hf_hub",
   ...:     arguments={
   ...:         "dataset_name": "wikitext@~parquet",
   ...:         "n_rows_to_load": 1000,
   ...:     },
   ...:     produces={
   ...:         "text": pa.string(),
   ...:     },
   ...: )
In [6]: text_data.fields
Out[6]: {'text': Field({'name': 'text', 'type': Type(DataType(string)), 'location': '/my-pipe-20231227152908/load_from_hugging_face_hub'})}
In [7]: chunk_data = text_data.apply(
   ...:     "chunk_text",
   ...:     arguments={
   ...:         "chunk_size": 256,
   ...:         "chunk_overlap": 32,
   ...:     },
   ...: )
In [8]: chunk_data.fields
Out[8]: 
{'text': Field({'name': 'text', 'type': Type(DataType(string)), 'location': '/my-pipe-20231227152920/chunk_text'}),
 'original_document_id': Field({'name': 'original_document_id', 'type': Type(DataType(string)), 'location': '/my-pipe-20231227152920/chunk_text'})}
```