### PR TITLE
Fix ragas component

### DIFF
--- a/components/evaluate_ragas/README.md
+++ b/components/evaluate_ragas/README.md
@@ -34,9 +34,9 @@ The component takes the following arguments to alter its behavior:
 
 | argument | type | description | default |
 | -------- | ---- | ----------- | ------- |
-| module | str | Module from which the LLM is imported. Defaults to langchain.llms | langchain.llms |
-| llm_name | str | Name of the selected llm | / |
-| llm_kwargs | dict | Arguments of the selected llm | / |
+| llm_module_name | str | Module from which the LLM is imported. Defaults to langchain.llms | langchain.chat_models |
+| llm_class_name | str | Name of the selected llm | ChatOpenAI |
+| llm_kwargs | dict | Arguments of the selected llm | {'model_name': 'gpt-4'} |
 
 <a id="evalute_ragas#usage"></a>
 ## Usage 
@@ -55,9 +55,9 @@ dataset = dataset.apply(
     "evaluate_ragas",
     arguments={
         # Add arguments
-        # "module": "langchain.llms",
-        # "llm_name": ,
-        # "llm_kwargs": {},
+        # "llm_module_name": "langchain.chat_models",
+        # "llm_class_name": "ChatOpenAI",
+        # "llm_kwargs": {'model_name': 'gpt-4'},
     },
     produces={
          <field_name>: <field_schema>,

--- a/components/evaluate_ragas/README.md
+++ b/components/evaluate_ragas/README.md
@@ -36,7 +36,7 @@ The component takes the following arguments to alter its behavior:
 | -------- | ---- | ----------- | ------- |
 | llm_module_name | str | Module from which the LLM is imported. Defaults to langchain.llms | langchain.chat_models |
 | llm_class_name | str | Name of the selected llm | ChatOpenAI |
-| llm_kwargs | dict | Arguments of the selected llm | {'model_name': 'gpt-4'} |
+| llm_kwargs | dict | Arguments of the selected llm | {'model_name': 'gpt-3.5-turbo'} |
 
 <a id="evalute_ragas#usage"></a>
 ## Usage 
@@ -57,7 +57,7 @@ dataset = dataset.apply(
         # Add arguments
         # "llm_module_name": "langchain.chat_models",
         # "llm_class_name": "ChatOpenAI",
-        # "llm_kwargs": {'model_name': 'gpt-4'},
+        # "llm_kwargs": {'model_name': 'gpt-3.5-turbo'},
     },
     produces={
          <field_name>: <field_schema>,

--- a/components/evaluate_ragas/fondant_component.yaml
+++ b/components/evaluate_ragas/fondant_component.yaml
@@ -19,13 +19,15 @@ produces:
 
 
 args:
-  module:
+  llm_module_name:
     description: Module from which the LLM is imported. Defaults to langchain.llms
     type: str
-    default: "langchain.llms"
-  llm_name:
+    default: "langchain.chat_models"
+  llm_class_name:
     description: Name of the selected llm
     type: str
+    default: "ChatOpenAI"
   llm_kwargs:
     description: Arguments of the selected llm
     type: dict
+    default: {"model_name":"gpt-4"}

--- a/components/evaluate_ragas/fondant_component.yaml
+++ b/components/evaluate_ragas/fondant_component.yaml
@@ -30,4 +30,4 @@ args:
   llm_kwargs:
     description: Arguments of the selected llm
     type: dict
-    default: {"model_name":"gpt-4"}
+    default: {"model_name":"gpt-3.5-turbo"}

--- a/components/index_aws_opensearch/README.md
+++ b/components/index_aws_opensearch/README.md
@@ -1,11 +1,14 @@
 # Index AWS OpenSearch
 
+<a id="index_aws_opensearch#description"></a>
 ## Description
 Component that takes embeddings of text snippets and indexes them into AWS OpenSearch vector database.
 
-## Inputs / outputs
+<a id="index_aws_opensearch#inputs_outputs"></a>
+## Inputs / outputs 
 
-### Consumes
+<a id="index_aws_opensearch#consumes"></a>
+### Consumes 
 **This component consumes:**
 
 - text: string
@@ -14,12 +17,13 @@ Component that takes embeddings of text snippets and indexes them into AWS OpenS
 
 
 
-
-### Produces
+<a id="index_aws_opensearch#produces"></a>  
+### Produces 
 
 
 **This component does not produce data.**
 
+<a id="index_aws_opensearch#arguments"></a>
 ## Arguments
 
 The component takes the following arguments to alter its behavior:
@@ -35,7 +39,8 @@ The component takes the following arguments to alter its behavior:
 | verify_certs | bool | A boolean flag indicating whether to verify SSL certificates when connecting to the OpenSearch cluster. | True |
 | pool_maxsize | int | The maximum size of the connection pool to the AWS OpenSearch cluster. | 20 |
 
-## Usage
+<a id="index_aws_opensearch#usage"></a>
+## Usage 
 
 You can add this component to your pipeline using the following code:
 
@@ -65,6 +70,7 @@ dataset.write(
 )
 ```
 
+<a id="index_aws_opensearch#testing"></a>
 ## Testing
 
 You can run the tests using docker with BuildKit. From this directory, run:


### PR DESCRIPTION
Fix to issue that @mrchtr raised

* `model_name` was actually referring to the class name used to import the model which can be `OpenAI` or `ChatOpenAI`. This caused some issues because we were trying to set `model_name` to `gpt-4`. Changed the arguments and default to reflect that. 

* ChatOpenAI seems to be the new default of defining models, changed the default model class to that one 

When initializing GPT-4 with `OpenAI()`:

```
UserWarning: You are trying to use a chat model. This way of initializing it is no longer supported. Instead, please use: `from langchain_community.chat_models import ChatOpenAI`
```

Also how it's set in RAGAS [LINK](https://docs.ragas.io/en/latest/howtos/customisations/llms.html#:~:text=Copy%20code-,from%20langchain.chat_models%20import%20ChatOpenAI,-gpt4%20%3D%20ChatOpenAI)

Changes will be required to RAG pipeline after new release 