### PR TITLE
add teardown method

### DIFF
--- a/docs/components/component_spec.md
+++ b/docs/components/component_spec.md
@@ -302,3 +302,38 @@ class ExampleComponent(PandasTransformComponent):
         A pandas dataframe containing the transformed data
     """
 ```
+
+Afterwards, we pass all keyword arguments to the `__init__()` method of the component.
+
+
+You can also use the a `teardown()` method to perform any cleanup after the component has been executed.
+This is a good place to close any open connections or files.
+
+```python
+import pandas as pd
+from fondant.component import PandasTransformComponent
+from my_library import Client
+
+  def __init__(self, *, client_url, **kwargs) -> None:
+    """
+    Args:
+        x_argument: An argument passed to the component
+    """
+    # Initialize your component here based on the arguments
+    self.client = Client(client_url)
+    
+  def transform(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+    """Implement your custom logic in this single method
+
+    Args:
+        dataframe: A Pandas dataframe containing the data
+
+    Returns:
+        A pandas dataframe containing the transformed data
+    """
+    
+  def teardown(self):
+    """Perform any cleanup after the component has been executed
+    """
+    self.client.shutdown()
+```

--- a/src/fondant/component/component.py
+++ b/src/fondant/component/component.py
@@ -26,6 +26,11 @@ class BaseComponent:
     ):
         pass
 
+    def teardown(self) -> None:
+        """Method called after the component has been executed."""
+
+    pass
+
 
 class DaskLoadComponent(BaseComponent):
     """Component that loads data and returns a Dask DataFrame."""

--- a/src/fondant/component/executor.py
+++ b/src/fondant/component/executor.py
@@ -335,7 +335,7 @@ class Executor(t.Generic[Component]):
         input_manifest: Manifest,
     ) -> Manifest:
         logging.info("Executing component")
-        component = component_cls(
+        component: Component = component_cls(
             consumes=self.operation_spec.inner_consumes,
             produces=self.operation_spec.inner_produces,
             **self.user_arguments,
@@ -349,6 +349,8 @@ class Executor(t.Generic[Component]):
             run_id=self.metadata.run_id,
         )
         self._write_data(dataframe=output_df, manifest=output_manifest)
+
+        component.teardown()
 
         return output_manifest
 


### PR DESCRIPTION
PR that adds a teardown method to every component. Useful for shutting down database connections and clients instead of it happening abruptly after the container is shutdown. 

Related to https://github.com/ml6team/fondant-use-cases/issues/59