### PR TITLE
Add teardown method to components

### DIFF
--- a/components/index_aws_opensearch/src/main.py
+++ b/components/index_aws_opensearch/src/main.py
@@ -39,6 +39,9 @@ class IndexAWSOpenSearchComponent(DaskWriteComponent):
         )
         self.create_index(index_body)
 
+    def teardown(self) -> None:
+        self.client.close()
+
     def create_index(self, index_body: Dict[str, Any]):
         """Creates an index if not existing in AWS OpenSearch.
 

--- a/components/index_qdrant/src/main.py
+++ b/components/index_qdrant/src/main.py
@@ -47,6 +47,9 @@ class IndexQdrantComponent(DaskWriteComponent):
         self.batch_size = batch_size
         self.parallelism = parallelism
 
+    def teardown(self) -> None:
+        self.client.close()
+
     def write(self, dataframe: dd.DataFrame) -> None:
         """
         Writes the data from the given Dask DataFrame to the Qdrant collection.

--- a/components/index_weaviate/src/main.py
+++ b/components/index_weaviate/src/main.py
@@ -53,6 +53,9 @@ class IndexWeaviateComponent(DaskWriteComponent):
                 },
             )
 
+    def teardown(self) -> None:
+        del self.client
+
     def write(self, dataframe: dd.DataFrame) -> None:
         with self.client.batch as batch:
             for part in tqdm(

--- a/components/retrieve_from_weaviate/src/main.py
+++ b/components/retrieve_from_weaviate/src/main.py
@@ -24,6 +24,9 @@ class RetrieveFromWeaviateComponent(PandasTransformComponent):
         self.class_name = class_name
         self.k = top_k
 
+    def teardown(self) -> None:
+        del self.client
+
     def retrieve_chunks(self, vector_query: list):
         """Get results from weaviate database."""
         result = (


### PR DESCRIPTION
**Weaviate:** https://github.com/weaviate/weaviate-python-client/blob/fa28abb55c96c0e1034d1c24cc1780f25a369ad4/weaviate/client.py#L295C1-L298C37

**Qdrant:** https://github.com/qdrant/qdrant-client/blob/6d019e67a133bea87a96bce388f5b901cdae1287/qdrant_client/qdrant_client.py#L131


**Opensearch:** https://github.com/opensearch-project/opensearch-py/blob/2ab3a40307d23a63d83977aa3adf146b6f02b5fa/opensearchpy/client/__init__.py#L254

ClipClient does not have an implement method 

https://github.com/rom1504/clip-retrieval/blob/37e482b99ee36fe51aa4f8ab1e6930dc809edb6d/clip_retrieval/clip_client.py#L17