### PR TITLE
Move cloud auth to sdk

### DIFF
--- a/docs/runners/local.md
+++ b/docs/runners/local.md
@@ -31,19 +31,19 @@ about this in the [installation](../guides/installation.md) guide.
     === "GCP"
     
         ```bash
-        fondant run local <pipeline_ref> --auth-gcp
+        fondant run local <pipeline_ref> --auth-provider gcp
         ```
 
     === "AWS"
     
         ```bash
-        fondant run local <pipeline_ref> --auth-aws
+        fondant run local <pipeline_ref> --auth-provider aws
         ```
 
     === "Azure"
     
         ```bash
-        fondant run local <pipeline_ref> --auth-azure
+        fondant run local <pipeline_ref> --auth-provider azure
         ```
 
     You can also use the `--extra-volumes` argument to mount extra credentials or additional files.
@@ -66,27 +66,30 @@ about this in the [installation](../guides/installation.md) guide.
     
         ```python
         from fondant.pipeline.runner import DockerRunner
+        from fondant.core.schema import CloudCredentialsMount
 
         runner = DockerRunner()
-        runner.run(auth_gcp=True)
+        runner.run(auth_provider=CloudCredentialsMount.GCP)
         ```
 
     === "AWS"
     
         ```python
         from fondant.pipeline.runner import DockerRunner
+        from fondant.core.schema import CloudCredentialsMount
 
         runner = DockerRunner()
-        runner.run(auth_aws=True)
+        runner.run(auth_provider=CloudCredentialsMount.AWS)
         ```
 
     === "Azure"
     
         ```python
         from fondant.pipeline.runner import DockerRunner
+        from fondant.core.schema import CloudCredentialsMount
 
         runner = DockerRunner()
-        runner.run(auth_azure=True)
+        runner.run(auth_provider=CloudCredentialsMount.AZURE)
         ```
 
     This will mount your default local cloud credentials to the pipeline. Make sure you are authenticated locally before running the pipeline and

--- a/docs/runners/local.md
+++ b/docs/runners/local.md
@@ -53,62 +53,40 @@ about this in the [installation](../guides/installation.md) guide.
 === "Python"
 
     ```python 
-    from fondant.pipeline.compiler import DockerCompiler
     from fondant.pipeline.runner import DockerRunner
-    
-    EXTRA_VOLUMES = <str_or_list_of_optional_extra_volumes_to_mount>
-    compiler = DockerCompiler(extra_volumes=EXTRA_VOLUMES)
-    compiler.compile(pipeline=<pipeline_object>)
 
     runner = DockerRunner()
-    runner.run(input_spec=<path_to_compiled_spec>)
+    runner.run(extra_volumes=<str_or_list_of_optional_extra_volumes_to_mount>)
     ```
 
-    If you want to use remote paths (GCS, S3, etc.) you can use pass the default local cloud credentials to the pipeline.
+    If you want to use remote paths (GCS, S3, etc.) you can use the authentification argument 
+    in your pipeline
 
     === "GCP"
     
         ```python
-        from fondant.pipeline.compiler import DockerCompiler
         from fondant.pipeline.runner import DockerRunner
-        from fondant.core.schema import CloudCredentialsMount
-        
-        gcp_mount_dir = CloudCredentialsMount.GCP.value
-        compiler = DockerCompiler(extra_volumes=gcp_mount_dir)
-        compiler.compile(pipeline=<pipeline_object>)
 
         runner = DockerRunner()
-        runner.run(input_spec=<path_to_compiled_spec>)
+        runner.run(auth_gcp=True)
         ```
 
     === "AWS"
     
         ```python
-        from fondant.pipeline.compiler import DockerCompiler
         from fondant.pipeline.runner import DockerRunner
-        from fondant.core.schema import CloudCredentialsMount
-        
-        aws_mount_dir = CloudCredentialsMount.AWS.value
-        compiler = DockerCompiler(extra_volumes=aws_mount_dir)
-        compiler.compile(pipeline=<pipeline_object>)
 
         runner = DockerRunner()
-        runner.run(input_spec=<path_to_compiled_spec>)
+        runner.run(auth_aws=True)
         ```
 
     === "Azure"
     
         ```python
-        from fondant.pipeline.compiler import DockerCompiler
         from fondant.pipeline.runner import DockerRunner
-        from fondant.core.schema import CloudCredentialsMount
-        
-        azure_mount_dir = CloudCredentialsMount.AZURE.value
-        compiler = DockerCompiler(extra_volumes=azure_mount_dir)
-        compiler.compile(pipeline=<pipeline_object>)
 
         runner = DockerRunner()
-        runner.run(input_spec=<path_to_compiled_spec>)
+        runner.run(auth_azure=True)
         ```
 
     This will mount your default local cloud credentials to the pipeline. Make sure you are authenticated locally before running the pipeline and

--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -37,17 +37,6 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_cloud_credentials(args) -> t.Optional[str]:
-    if args.auth_gcp:
-        return CloudCredentialsMount.GCP.value
-    if args.auth_aws:
-        return CloudCredentialsMount.AWS.value
-    if args.auth_azure:
-        return CloudCredentialsMount.AZURE.value
-
-    return None
-
-
 def entrypoint():
     """Entrypoint for the fondant CLI."""
     parser = argparse.ArgumentParser(
@@ -204,11 +193,6 @@ def start_explore(args):
 
     extra_volumes = []
 
-    cloud_cred = get_cloud_credentials(args)
-
-    if cloud_cred:
-        extra_volumes.append(cloud_cred)
-
     if args.extra_volumes:
         extra_volumes.extend(args.extra_volumes)
 
@@ -218,6 +202,9 @@ def start_explore(args):
         tag=args.tag,
         port=args.port,
         extra_volumes=extra_volumes,
+        auth_gcp=args.auth_gcp,
+        auth_aws=args.auth_aws,
+        auth_azure=args.auth_azure,
     )
 
 
@@ -449,13 +436,9 @@ def compile_local(args):
     from fondant.pipeline.compiler import DockerCompiler
 
     extra_volumes = []
-    cloud_cred = get_cloud_credentials(args)
 
     if args.extra_volumes:
         extra_volumes.extend(args.extra_volumes)
-
-    if cloud_cred:
-        extra_volumes.append(cloud_cred)
 
     pipeline = pipeline_from_string(args.ref)
     compiler = DockerCompiler()
@@ -464,6 +447,9 @@ def compile_local(args):
         extra_volumes=extra_volumes,
         output_path=args.output_path,
         build_args=args.build_arg,
+        auth_gcp=args.auth_gcp,
+        auth_aws=args.auth_aws,
+        auth_azure=args.auth_azure,
     )
 
 
@@ -661,13 +647,9 @@ def run_local(args):
     from fondant.pipeline.runner import DockerRunner
 
     extra_volumes = []
-    cloud_cred = get_cloud_credentials(args)
 
     if args.extra_volumes:
         extra_volumes.extend(args.extra_volumes)
-
-    if cloud_cred:
-        extra_volumes.append(cloud_cred)
 
     try:
         ref = pipeline_from_string(args.ref)
@@ -679,6 +661,9 @@ def run_local(args):
         input=ref,
         extra_volumes=extra_volumes,
         build_args=args.build_arg,
+        auth_gcp=args.auth_gcp,
+        auth_aws=args.auth_aws,
+        auth_azure=args.auth_azure,
     )
 
 

--- a/src/fondant/core/schema.py
+++ b/src/fondant/core/schema.py
@@ -10,7 +10,7 @@ from enum import Enum, auto
 
 import pyarrow as pa
 
-from fondant.core.exceptions import InvalidPipelineDefinition, InvalidTypeSchema
+from fondant.core.exceptions import InvalidTypeSchema
 
 
 @dataclass
@@ -48,35 +48,6 @@ class CloudCredentialsMount(Enum):
 
         if self == CloudCredentialsMount.AZURE:
             return f"{home_dir}/.azure:/root/.azure"
-
-        return None
-
-    @staticmethod
-    def get_cloud_credentials(
-        *,
-        auth_gcp: t.Optional[bool] = None,
-        auth_azure: t.Optional[bool] = None,
-        auth_aws: t.Optional[bool] = None,
-    ) -> t.Optional[str]:
-        """Get the appropriate cloud credentials based on authentication flags."""
-        auth_flags = [auth_gcp, auth_azure, auth_aws]
-        count_true = sum(flag is True for flag in auth_flags if flag is not None)
-
-        if count_true > 1:
-            msg = (
-                "You can only provide one of the following authentication flags:"
-                " auth_gcp, auth_aws, auth_azure"
-            )
-            raise InvalidPipelineDefinition(
-                msg,
-            )
-
-        if auth_gcp:
-            return CloudCredentialsMount.GCP.get_path()
-        if auth_aws:
-            return CloudCredentialsMount.AWS.get_path()
-        if auth_azure:
-            return CloudCredentialsMount.AZURE.get_path()
 
         return None
 

--- a/src/fondant/explore.py
+++ b/src/fondant/explore.py
@@ -29,27 +29,20 @@ def _generate_explorer_spec(
     container: str = CONTAINER,
     tag: t.Optional[str] = None,
     extra_volumes: t.Union[t.Optional[list], t.Optional[str]] = None,
-    auth_gcp: t.Optional[bool] = None,
-    auth_aws: t.Optional[bool] = None,
-    auth_azure: t.Optional[bool] = None,
+    auth_provider: t.Optional[CloudCredentialsMount] = None,
 ) -> t.Dict[str, t.Any]:
     """Generate a Docker Compose specification for the Explorer App."""
     if tag is None:
         tag = version("fondant") if version("fondant") != "0.1.dev0" else "latest"
 
-    cloud_creds = CloudCredentialsMount.get_cloud_credentials(
-        auth_gcp=auth_gcp,
-        auth_azure=auth_azure,
-        auth_aws=auth_aws,
-    )
     if extra_volumes is None:
         extra_volumes = []
 
     if isinstance(extra_volumes, str):
         extra_volumes = [extra_volumes]
 
-    if cloud_creds:
-        extra_volumes.append(cloud_creds)
+    if auth_provider:
+        extra_volumes.append(auth_provider.get_path())
 
     # Mount extra volumes to the container
     volumes: t.List[t.Union[str, dict]] = []
@@ -116,9 +109,7 @@ def run_explorer_app(  # type: ignore  # noqa: PLR0913
     output_path: str = OUTPUT_PATH,
     tag: t.Optional[str] = None,
     extra_volumes: t.Union[t.Optional[list], t.Optional[str]] = None,
-    auth_gcp: t.Optional[bool] = None,
-    auth_aws: t.Optional[bool] = None,
-    auth_azure: t.Optional[bool] = None,
+    auth_provider: t.Optional[CloudCredentialsMount] = None,
 ):  # type: ignore
     """
     Run an Explorer App in a Docker container.
@@ -135,9 +126,7 @@ def run_explorer_app(  # type: ignore  # noqa: PLR0913
         - to mount data directories to be used by the pipeline (note that if your pipeline's
             base_path is local it will already be mounted for you).
         - to mount cloud credentials
-      auth_gcp: Flag to enable authentication with GCP
-      auth_aws: Flag to enable authentication with AWS
-      auth_azure: Flag to enable authentication with Azure
+      auth_provider: The cloud provider to use for authentication. Default is None.
     """
     os.makedirs(".fondant", exist_ok=True)
 
@@ -147,9 +136,7 @@ def run_explorer_app(  # type: ignore  # noqa: PLR0913
         container=container,
         tag=tag,
         extra_volumes=extra_volumes,
-        auth_gcp=auth_gcp,
-        auth_aws=auth_aws,
-        auth_azure=auth_azure,
+        auth_provider=auth_provider,
     )
 
     with open(output_path, "w") as outfile:

--- a/src/fondant/pipeline/compiler.py
+++ b/src/fondant/pipeline/compiler.py
@@ -56,9 +56,7 @@ class DockerCompiler(Compiler):
         output_path: str = "docker-compose.yml",
         extra_volumes: t.Union[t.Optional[list], t.Optional[str]] = None,
         build_args: t.Optional[t.List[str]] = None,
-        auth_gcp: t.Optional[bool] = None,
-        auth_aws: t.Optional[bool] = None,
-        auth_azure: t.Optional[bool] = None,
+        auth_provider: t.Optional[CloudCredentialsMount] = None,
     ) -> None:
         """Compile a pipeline to docker-compose spec and save it to a specified output path.
 
@@ -69,24 +67,17 @@ class DockerCompiler(Compiler):
               https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5)
               to mount in the docker-compose spec.
             build_args: List of build arguments to pass to docker
-            auth_gcp: Flag to enable authentication with GCP
-            auth_aws: Flag to enable authentication with AWS
-            auth_azure: Flag to enable authentication with Azure
-        """
-        cloud_creds = CloudCredentialsMount.get_cloud_credentials(
-            auth_gcp=auth_gcp,
-            auth_azure=auth_azure,
-            auth_aws=auth_aws,
-        )
+            auth_provider: The cloud provider to use for authentication. Default is None.
 
+        """
         if extra_volumes is None:
             extra_volumes = []
 
         if isinstance(extra_volumes, str):
             extra_volumes = [extra_volumes]
 
-        if cloud_creds:
-            extra_volumes.append(cloud_creds)
+        if auth_provider:
+            extra_volumes.append(auth_provider.get_path())
 
         logger.info(f"Compiling {pipeline.name} to {output_path}")
 

--- a/src/fondant/pipeline/runner.py
+++ b/src/fondant/pipeline/runner.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 
 import yaml
 
+from fondant.core.schema import CloudCredentialsMount
 from fondant.pipeline import Pipeline
 from fondant.pipeline.compiler import (
     DockerCompiler,
@@ -56,21 +57,17 @@ class DockerRunner(Runner):
         *,
         extra_volumes: t.Union[t.Optional[list], t.Optional[str]] = None,
         build_args: t.Optional[t.List[str]] = None,
-        auth_gcp: t.Optional[bool] = None,
-        auth_aws: t.Optional[bool] = None,
-        auth_azure: t.Optional[bool] = None,
+        auth_provider: t.Optional[CloudCredentialsMount] = None,
     ) -> None:
         """Run a pipeline, either from a compiled docker-compose spec or from a fondant pipeline.
 
         Args:
             input: the pipeline to compile or a path to a already compiled docker-compose spec
             extra_volumes: a list of extra volumes (using the Short syntax:
-            https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5)
-            to mount in the docker-compose spec.
+             https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5)
+             to mount in the docker-compose spec.
             build_args: List of build arguments to pass to docker
-            auth_gcp: Flag to enable authentication with GCP
-            auth_aws: Flag to enable authentication with AWS
-            auth_azure: Flag to enable authentication with Azure
+            auth_provider: The cloud provider to use for authentication. Default is None.
         """
         self.check_docker_install()
         self.check_docker_compose_install()
@@ -87,9 +84,7 @@ class DockerRunner(Runner):
                 output_path=output_path,
                 extra_volumes=extra_volumes,
                 build_args=build_args,
-                auth_gcp=auth_gcp,
-                auth_aws=auth_aws,
-                auth_azure=auth_azure,
+                auth_provider=auth_provider,
             )
             self._run(output_path)
         else:

--- a/src/fondant/pipeline/runner.py
+++ b/src/fondant/pipeline/runner.py
@@ -56,6 +56,9 @@ class DockerRunner(Runner):
         *,
         extra_volumes: t.Union[t.Optional[list], t.Optional[str]] = None,
         build_args: t.Optional[t.List[str]] = None,
+        auth_gcp: t.Optional[bool] = None,
+        auth_aws: t.Optional[bool] = None,
+        auth_azure: t.Optional[bool] = None,
     ) -> None:
         """Run a pipeline, either from a compiled docker-compose spec or from a fondant pipeline.
 
@@ -65,6 +68,9 @@ class DockerRunner(Runner):
             https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5)
             to mount in the docker-compose spec.
             build_args: List of build arguments to pass to docker
+            auth_gcp: Flag to enable authentication with GCP
+            auth_aws: Flag to enable authentication with AWS
+            auth_azure: Flag to enable authentication with Azure
         """
         self.check_docker_install()
         self.check_docker_compose_install()
@@ -81,6 +87,9 @@ class DockerRunner(Runner):
                 output_path=output_path,
                 extra_volumes=extra_volumes,
                 build_args=build_args,
+                auth_gcp=auth_gcp,
+                auth_aws=auth_aws,
+                auth_azure=auth_azure,
             )
             self._run(output_path)
         else:

--- a/tests/pipeline/test_compiler.py
+++ b/tests/pipeline/test_compiler.py
@@ -261,19 +261,8 @@ def test_docker_remote_path(setup_pipeline, tmp_path_factory):
 @pytest.mark.usefixtures("_freeze_time")
 def test_docker_extra_volumes(setup_pipeline, tmp_path_factory):
     """Test that extra volumes are applied correctly."""
-    for cloud_auth in CloudCredentialsMount:
-        auth_gcp, auth_aws, auth_azure = False, False, False
-
-        if cloud_auth.name == "GCP":
-            auth_gcp = True
-
-        if cloud_auth.name == "AWS":
-            auth_aws = True
-
-        if cloud_auth.name == "AZURE":
-            auth_azure = True
-
-        cloud_auth.get_path()
+    for auth_provider in CloudCredentialsMount:
+        extra_auth_volume = auth_provider.get_path()
 
         with tmp_path_factory.mktemp("temp") as fn:
             # this is the directory mounted in the container
@@ -282,15 +271,14 @@ def test_docker_extra_volumes(setup_pipeline, tmp_path_factory):
             compiler = DockerCompiler()
             # define some extra volumes to be mounted
             extra_volumes = ["hello:there", "general:kenobi"]
+            extra_volumes.append(extra_auth_volume)
             output_path = str(fn / "docker-compose.yml")
 
             compiler.compile(
                 pipeline=pipeline,
                 output_path=output_path,
                 extra_volumes=extra_volumes,
-                auth_gcp=auth_gcp,
-                auth_aws=auth_aws,
-                auth_azure=auth_azure,
+                auth_provider=auth_provider,
             )
 
             pipeline_configs = DockerComposeConfigs.from_spec(output_path)

--- a/tests/pipeline/test_compiler.py
+++ b/tests/pipeline/test_compiler.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 import pytest
 from fondant.core.exceptions import InvalidPipelineDefinition
 from fondant.core.manifest import Manifest, Metadata
+from fondant.core.schema import CloudCredentialsMount
 from fondant.pipeline import ComponentOp, Dataset, Pipeline, Resources
 from fondant.pipeline.compiler import (
     DockerCompiler,
@@ -260,26 +261,43 @@ def test_docker_remote_path(setup_pipeline, tmp_path_factory):
 @pytest.mark.usefixtures("_freeze_time")
 def test_docker_extra_volumes(setup_pipeline, tmp_path_factory):
     """Test that extra volumes are applied correctly."""
-    with tmp_path_factory.mktemp("temp") as fn:
-        # this is the directory mounted in the container
-        _, pipeline, _ = setup_pipeline
-        pipeline.base_path = str(fn)
-        compiler = DockerCompiler()
-        # define some extra volumes to be mounted
-        extra_volumes = ["hello:there", "general:kenobi"]
-        output_path = str(fn / "docker-compose.yml")
+    for cloud_auth in CloudCredentialsMount:
+        auth_gcp, auth_aws, auth_azure = False, False, False
 
-        compiler.compile(
-            pipeline=pipeline,
-            output_path=output_path,
-            extra_volumes=extra_volumes,
-        )
+        if cloud_auth.name == "GCP":
+            auth_gcp = True
 
-        pipeline_configs = DockerComposeConfigs.from_spec(output_path)
-        for _, service in pipeline_configs.component_configs.items():
-            assert all(
-                extra_volume in service.volumes for extra_volume in extra_volumes
+        if cloud_auth.name == "AWS":
+            auth_aws = True
+
+        if cloud_auth.name == "AZURE":
+            auth_azure = True
+
+        cloud_auth.get_path()
+
+        with tmp_path_factory.mktemp("temp") as fn:
+            # this is the directory mounted in the container
+            _, pipeline, _ = setup_pipeline
+            pipeline.base_path = str(fn)
+            compiler = DockerCompiler()
+            # define some extra volumes to be mounted
+            extra_volumes = ["hello:there", "general:kenobi"]
+            output_path = str(fn / "docker-compose.yml")
+
+            compiler.compile(
+                pipeline=pipeline,
+                output_path=output_path,
+                extra_volumes=extra_volumes,
+                auth_gcp=auth_gcp,
+                auth_aws=auth_aws,
+                auth_azure=auth_azure,
             )
+
+            pipeline_configs = DockerComposeConfigs.from_spec(output_path)
+            for _, service in pipeline_configs.component_configs.items():
+                assert all(
+                    extra_volume in service.volumes for extra_volume in extra_volumes
+                )
 
 
 @pytest.mark.usefixtures("_freeze_time")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from fondant.cli import (
 )
 from fondant.component import DaskLoadComponent
 from fondant.component.executor import Executor, ExecutorFactory
+from fondant.core.schema import CloudCredentialsMount
 from fondant.pipeline import Pipeline
 from fondant.pipeline.runner import DockerRunner
 
@@ -195,9 +196,7 @@ def test_local_compile(tmp_path_factory):
             extra_volumes=[],
             build_arg=[],
             credentials=None,
-            auth_gcp=False,
-            auth_azure=False,
-            auth_aws=False,
+            auth_provider=None,
         )
         compile_local(args)
 
@@ -206,9 +205,7 @@ def test_local_compile(tmp_path_factory):
             extra_volumes=[],
             output_path=str(fn / "docker-compose.yml"),
             build_args=[],
-            auth_gcp=False,
-            auth_azure=False,
-            auth_aws=False,
+            auth_provider=None,
         )
 
 
@@ -275,9 +272,7 @@ def test_local_run(mock_docker_installation):
         local=True,
         ref="some/path",
         output_path=None,
-        auth_gcp=False,
-        auth_azure=False,
-        auth_aws=False,
+        auth_provider=None,
         credentials=None,
         extra_volumes=[],
         build_arg=[],
@@ -307,9 +302,7 @@ def test_local_run(mock_docker_installation):
             ref=__name__,
             extra_volumes=[],
             build_arg=[],
-            auth_gcp=False,
-            auth_azure=False,
-            auth_aws=False,
+            auth_provider=None,
             credentials=None,
         )
         run_local(args1)
@@ -330,13 +323,7 @@ def test_local_run(mock_docker_installation):
 
 
 def test_local_run_cloud_credentials(mock_docker_installation):
-    namespace_creds_kwargs = [
-        {"auth_gcp": True, "auth_azure": False, "auth_aws": False},
-        {"auth_gcp": False, "auth_azure": True, "auth_aws": False},
-        {"auth_gcp": False, "auth_azure": False, "auth_aws": True},
-    ]
-
-    for namespace_cred_kwargs in namespace_creds_kwargs:
+    for auth_provider in CloudCredentialsMount:
         with patch(
             "fondant.pipeline.compiler.DockerCompiler.compile",
         ) as mock_compiler, patch(
@@ -347,7 +334,7 @@ def test_local_run_cloud_credentials(mock_docker_installation):
                 vertex=False,
                 kubeflow=False,
                 ref=__name__,
-                **namespace_cred_kwargs,
+                auth_provider=auth_provider,
                 credentials=None,
                 extra_volumes=[],
                 build_arg=[],
@@ -359,7 +346,7 @@ def test_local_run_cloud_credentials(mock_docker_installation):
                 extra_volumes=[],
                 output_path=".fondant/compose.yaml",
                 build_args=[],
-                **namespace_cred_kwargs,
+                auth_provider=auth_provider,
             )
 
             mock_runner.assert_called_once_with(

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -77,19 +77,8 @@ def test_run_data_explorer_remote_base_path(
     tmp_path_factory,
 ):
     """Test that the data explorer can be run with a remote base path."""
-    for cloud_auth in CloudCredentialsMount:
-        auth_gcp, auth_aws, auth_azure = False, False, False
-
-        if cloud_auth.name == "GCP":
-            auth_gcp = True
-
-        if cloud_auth.name == "AWS":
-            auth_aws = True
-
-        if cloud_auth.name == "AZURE":
-            auth_azure = True
-
-        extra_auth_volume = cloud_auth.get_path()
+    for auth_provider in CloudCredentialsMount:
+        extra_auth_volume = auth_provider.get_path()
 
         with tmp_path_factory.mktemp("temp") as fn, patch(
             "subprocess.check_call",
@@ -101,9 +90,7 @@ def test_run_data_explorer_remote_base_path(
                 port=DEFAULT_PORT,
                 container=DEFAULT_CONTAINER,
                 tag=DEFAULT_TAG,
-                auth_gcp=auth_gcp,
-                auth_aws=auth_aws,
-                auth_azure=auth_azure,
+                auth_provider=auth_provider,
             )
 
             pipeline_configs = DockerComposeConfigs.from_spec(output_path)

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from fondant.core.schema import CloudCredentialsMount
 from fondant.explore import run_explorer_app, stop_explorer_app
 from fondant.testing import DockerComposeConfigs
 
@@ -22,14 +23,6 @@ def remote_path() -> str:
 
 
 @pytest.fixture()
-def extra_volumes() -> str:
-    return (
-        "$HOME/.config/gcloud/application_default_credentials.json:/root/.config/"
-        "gcloud/application_default_credentials.json"
-    )
-
-
-@pytest.fixture()
 def container_path() -> str:
     return "/source"
 
@@ -37,7 +30,6 @@ def container_path() -> str:
 def test_run_data_explorer_local_base_path(
     host_path,
     container_path,
-    extra_volumes,
     tmp_path_factory,
 ):
     """Test that the data explorer can be run with a local base path."""
@@ -51,7 +43,6 @@ def test_run_data_explorer_local_base_path(
             port=DEFAULT_PORT,
             container=DEFAULT_CONTAINER,
             tag=DEFAULT_TAG,
-            extra_volumes=extra_volumes,
         )
 
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
@@ -61,9 +52,8 @@ def test_run_data_explorer_local_base_path(
         assert data_explorer_config.arguments["base_path"] == container_path
         assert data_explorer_config.image == f"{DEFAULT_CONTAINER}:{DEFAULT_TAG}"
         assert data_explorer_config.ports == [f"{DEFAULT_PORT}:8501"]
-        assert volumes[0] == extra_volumes
-        assert volumes[1]["source"] == str(Path(host_path).resolve())
-        assert volumes[1]["target"] == container_path
+        assert volumes[0]["source"] == str(Path(host_path).resolve())
+        assert volumes[0]["target"] == container_path
 
         mock_call.assert_called_once_with(
             [
@@ -84,52 +74,66 @@ def test_run_data_explorer_local_base_path(
 
 def test_run_data_explorer_remote_base_path(
     remote_path,
-    extra_volumes,
     tmp_path_factory,
 ):
     """Test that the data explorer can be run with a remote base path."""
-    with tmp_path_factory.mktemp("temp") as fn, patch(
-        "subprocess.check_call",
-    ) as mock_call:
-        output_path = str(fn / OUTPUT_FILE)
-        run_explorer_app(
-            base_path=remote_path,
-            output_path=output_path,
-            port=DEFAULT_PORT,
-            container=DEFAULT_CONTAINER,
-            tag=DEFAULT_TAG,
-            extra_volumes=extra_volumes,
-        )
+    for cloud_auth in CloudCredentialsMount:
+        auth_gcp, auth_aws, auth_azure = False, False, False
 
-        pipeline_configs = DockerComposeConfigs.from_spec(output_path)
-        data_explorer_config = pipeline_configs.component_configs["data_explorer"]
-        volumes = data_explorer_config.volumes
+        if cloud_auth.name == "GCP":
+            auth_gcp = True
 
-        assert data_explorer_config.arguments["base_path"] == remote_path
-        assert data_explorer_config.image == f"{DEFAULT_CONTAINER}:{DEFAULT_TAG}"
-        assert data_explorer_config.ports == [f"{DEFAULT_PORT}:8501"]
-        assert volumes[0] == extra_volumes
+        if cloud_auth.name == "AWS":
+            auth_aws = True
 
-        mock_call.assert_called_once_with(
-            [
-                "docker",
-                "compose",
-                "-f",
-                output_path,
-                "up",
-                "--build",
-                "--pull",
-                "always",
-                "--remove-orphans",
-                "--detach",
-            ],
-            stdout=-1,
-        )
+        if cloud_auth.name == "AZURE":
+            auth_azure = True
+
+        extra_auth_volume = cloud_auth.get_path()
+
+        with tmp_path_factory.mktemp("temp") as fn, patch(
+            "subprocess.check_call",
+        ) as mock_call:
+            output_path = str(fn / OUTPUT_FILE)
+            run_explorer_app(
+                base_path=remote_path,
+                output_path=output_path,
+                port=DEFAULT_PORT,
+                container=DEFAULT_CONTAINER,
+                tag=DEFAULT_TAG,
+                auth_gcp=auth_gcp,
+                auth_aws=auth_aws,
+                auth_azure=auth_azure,
+            )
+
+            pipeline_configs = DockerComposeConfigs.from_spec(output_path)
+            data_explorer_config = pipeline_configs.component_configs["data_explorer"]
+            volumes = data_explorer_config.volumes
+
+            assert data_explorer_config.arguments["base_path"] == remote_path
+            assert data_explorer_config.image == f"{DEFAULT_CONTAINER}:{DEFAULT_TAG}"
+            assert data_explorer_config.ports == [f"{DEFAULT_PORT}:8501"]
+            assert volumes[0] == extra_auth_volume
+
+            mock_call.assert_called_once_with(
+                [
+                    "docker",
+                    "compose",
+                    "-f",
+                    output_path,
+                    "up",
+                    "--build",
+                    "--pull",
+                    "always",
+                    "--remove-orphans",
+                    "--detach",
+                ],
+                stdout=-1,
+            )
 
 
 def test_stop_data_explorer(
     remote_path,
-    extra_volumes,
     tmp_path_factory,
 ):
     """Test that the data explorer can be run with a remote base path."""


### PR DESCRIPTION
The arguments that enabled authenticating to different clouds through volume mounting credentials were restricted to the CLI and were not explicitly available in the SDK.

This PR that moves the argument for authenticating to one of the clouds in the DockerRunner for the CLI to the SDK 

e.g 

authenticating to gcp 

```python
runner.run(auth_gcp=True)
```