### PR TITLE
Fix code inspection notebook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ python = ">= 3.8, <3.12"
 
 fsspec = ">= 2023.4.0"
 importlib-resources = { version = ">= 1.3", python = "<3.9" }
+ipython = ">= 8.21.0"
 jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ python = ">= 3.8, <3.12"
 
 fsspec = ">= 2023.4.0"
 importlib-resources = { version = ">= 1.3", python = "<3.9" }
-ipython = ">= 8.21.0"
 jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"

--- a/src/fondant/pipeline/lightweight_component.py
+++ b/src/fondant/pipeline/lightweight_component.py
@@ -9,12 +9,13 @@ from functools import wraps
 from importlib import metadata
 
 import pyarrow as pa
+from IPython import get_ipython
+from IPython.core.magics.code import extract_symbols
 
 from fondant.component import BaseComponent, Component
 from fondant.core.schema import Field, Type
 
 logger = logging.getLogger(__name__)
-
 
 MIN_PYTHON_VERSION = (3, 8)
 MAX_PYTHON_VERSION = (3, 11)
@@ -264,6 +265,33 @@ def lightweight_component(
     return wrapper
 
 
+def new_getfile(_object, _old_getfile=inspect.getfile):
+    if not inspect.isclass(_object):
+        return _old_getfile(_object)
+
+    # Lookup by parent module (as in current inspect)
+    if hasattr(_object, "__module__"):
+        object_ = sys.modules.get(_object.__module__)
+        if hasattr(object_, "__file__"):
+            return object_.__file__
+
+    # If parent module is __main__, lookup by methods (NEW)
+    for name, member in inspect.getmembers(_object):
+        if (
+            inspect.isfunction(member)
+            and _object.__qualname__ + "." + member.__name__ == member.__qualname__
+        ):
+            return inspect.getfile(member)
+
+    msg = f"Source for {_object!r} not found"
+    raise TypeError(msg)
+
+
+def is_running_in_jupyter():
+    shell = get_ipython().__class__.__name__
+    return shell == "ZMQInteractiveShell"
+
+
 def build_python_script(component_cls: t.Type[Component]) -> str:
     """Build a self-contained python script for the provided component class, which will act as
     the `src/main.py` script to execute the component.
@@ -281,7 +309,19 @@ def build_python_script(component_cls: t.Type[Component]) -> str:
     """,
     )
 
-    component_source = inspect.getsource(component_cls)
+    if is_running_in_jupyter():
+        inspect.getfile = new_getfile
+        component_source = "".join(
+            inspect.linecache.getlines(  # type: ignore[attr-defined]
+                new_getfile(component_cls),
+            ),
+        )
+        component_source = extract_symbols(component_source, component_cls.__name__)[0][
+            0
+        ]
+    else:
+        component_source = inspect.getsource(component_cls)
+
     component_source = textwrap.dedent(component_source)
     component_source_lines = component_source.split("\n")
 

--- a/src/fondant/pipeline/lightweight_component.py
+++ b/src/fondant/pipeline/lightweight_component.py
@@ -290,13 +290,7 @@ def is_running_interactively():
     try:
         from IPython import get_ipython
 
-        shell = get_ipython().__class__.__name__
-        return shell in [
-            "Shell",
-            "ZMQInteractiveShell",
-            "TerminalInteractiveShell",
-            "PyDevTerminalInteractiveShell",
-        ]
+        return get_ipython() is not None
     except ModuleNotFoundError:
         return False
 

--- a/src/fondant/pipeline/lightweight_component.py
+++ b/src/fondant/pipeline/lightweight_component.py
@@ -292,6 +292,7 @@ def is_running_interactively():
 
         shell = get_ipython().__class__.__name__
         return shell in [
+            "Shell",
             "ZMQInteractiveShell",
             "TerminalInteractiveShell",
             "PyDevTerminalInteractiveShell",


### PR DESCRIPTION
When running the lightweight components in a notebook, the component class code inspection fails with error `source code is not available`. 
Full error log here [log.txt](https://github.com/ml6team/fondant/files/14114022/new.3.txt)

The error is related to the fact that `inspect` relies on the class located in a source file which is not the case in a notebook where everything runs interactively. This is described in details [here](https://stackoverflow.com/questions/35854373/python-get-source-code-of-class-using-inspect#:~:text=getsource%20works%20by%20actually%20opening%20the%20source%20file%20that%20defines%20the%20object%20you%27re%20looking%20at.)

Implemented the workaround suggested [here](https://github.com/ipython/ipython/issues/11249)