### PR TITLE
Adjust packages import lightweight components

### DIFF
--- a/tests/pipeline/test_compiler.py
+++ b/tests/pipeline/test_compiler.py
@@ -441,7 +441,7 @@ def test_kubeflow_component_spec_from_lightweight_component(
         assert pipeline_configs.component_configs["createdata"].command == [
             "sh",
             "-ec",
-            '                printf \'pandas\ndask\' > \'requirements.txt\'\n                python3 -m pip install -r requirements.txt\n            printf \'from typing import *\nimport typing as t\n\nimport dask.dataframe as dd\nimport fondant\nimport pandas as pd\nfrom fondant.component import *\nfrom fondant.core import *\n\n\nclass CreateData(DaskLoadComponent):\n    def load(self) -> dd.DataFrame:\n        df = pd.DataFrame(\n            {\n                "x": [1, 2, 3],\n                "y": [4, 5, 6],\n            },\n            index=pd.Index(["a", "b", "c"], name="id"),\n        )\n        return dd.from_pandas(df, npartitions=1)\n\' > \'main.py\'\n            fondant execute main "$@"\n',  # noqa E501
+            '                printf \'pandas\ndask\' > \'requirements.txt\'\n                python3 -m pip install -r requirements.txt\n            printf \'from typing import *\nimport typing as t\n\nimport dask.dataframe as dd\nimport fondant\nimport pandas as pd\nfrom fondant.component import *\nfrom fondant.core import *\n\n\n\nclass CreateData(DaskLoadComponent):\n    def load(self) -> dd.DataFrame:\n        df = pd.DataFrame(\n            {\n                "x": [1, 2, 3],\n                "y": [4, 5, 6],\n            },\n            index=pd.Index(["a", "b", "c"], name="id"),\n        )\n        return dd.from_pandas(df, npartitions=1)\n\' > \'main.py\'\n            fondant execute main "$@"\n',  # noqa E501
             "--",
         ]
 

--- a/tests/pipeline/test_lightweight_component.py
+++ b/tests/pipeline/test_lightweight_component.py
@@ -40,6 +40,13 @@ def load_pipeline(caplog):
         produces={"x": pa.int32(), "y": pa.int32(), "z": pa.int32()},
     )
     class CreateData(DaskLoadComponent):
+        import numpy as np
+
+        def __init__(self):
+            import torch  # noqa: F401
+
+            pass
+
         def load(self) -> dd.DataFrame:
             df = pd.DataFrame(
                 {
@@ -74,8 +81,15 @@ def test_build_python_script(load_pipeline):
         from fondant.component import *
         from fondant.core import *
 
+        import numpy as np
+        import torch  # noqa: F401
 
         class CreateData(DaskLoadComponent):
+
+            def __init__(self):
+
+                pass
+
             def load(self) -> dd.DataFrame:
                 df = pd.DataFrame(
                     {


### PR DESCRIPTION
PR that adjusts the import defines in lightweight components to be defined on top of the packaged file. This is to have imports available at a global scope. With the previous implementation, imports defined in `__init__` or other functions in the components were only available within those functions. 

