### PR TITLE
Add reusable write to file component to getting started examples

### DIFF
--- a/docs/guides/build_a_simple_pipeline.md
+++ b/docs/guides/build_a_simple_pipeline.md
@@ -188,7 +188,7 @@ you will be able to view the images that have been downloaded.
 
 If you want to inspect your final dataset without using the data explorer or use the 
 dataset for further tasks, we recommend to write the final dataset to a destination. 
-We offer a write component to perform this task. You can leverage the `write_to_file` component, 
+We offer [write components](../components//hub.md) to perform this task, for instance the `write_to_file` component, 
 which allows you to export the dataset either to a local file or a remote storage bucket.
 
 ```python

--- a/docs/guides/build_a_simple_pipeline.md
+++ b/docs/guides/build_a_simple_pipeline.md
@@ -183,6 +183,20 @@ you will be able to view the images that have been downloaded.
 
 ![explorer](../art/guides/explorer.png?raw=true)
 
+
+## Export the dataset
+
+If you want to inspect your final dataset without using the data explorer or use the 
+dataset for further tasks, we recommend to write the final dataset to a destination. 
+We offer a write component to perform this task. You can leverage the `write_to_file` component, 
+which allows you to export the dataset either to a local file or a remote storage bucket.
+
+```python
+uppercase_alt_text.write(ref="write_to_file", arguments={"path": "/data/export"})
+```
+
+You can open the path and use any tools of your choice to inspect the resulting Parquet dataset.
+
 Well done! You have now acquired the skills to construct a simple Fondant pipeline by leveraging 
 reusable components. In the [next tutorial](implement_custom_components.md), we'll demonstrate how 
 you can customise the pipeline by implementing a custom component.

--- a/docs/guides/build_a_simple_pipeline.md
+++ b/docs/guides/build_a_simple_pipeline.md
@@ -192,7 +192,7 @@ We offer a write component to perform this task. You can leverage the `write_to_
 which allows you to export the dataset either to a local file or a remote storage bucket.
 
 ```python
-uppercase_alt_text.write(ref="write_to_file", arguments={"path": "/data/export"})
+english_images.write(ref="write_to_file", arguments={"path": "/data/export"})
 ```
 
 You can open the path and use any tools of your choice to inspect the resulting Parquet dataset.

--- a/docs/guides/implement_custom_components.md
+++ b/docs/guides/implement_custom_components.md
@@ -138,7 +138,13 @@ pipeline, helping you connect reusable components to each other.
 We now have a pipeline that downloads a dataset from the HuggingFace hub, filters the urls by
 image type, downloads the images, and filters them by alt text language.
 
-One final step still remaining, is to write the final dataset to its destination. You could for
-instance use the [`write_to_hf_hub`](../components/hub.md#write_to_hugging_face_hub#description)
-component to write it to
-the HuggingFace Hub, or create a custom `WriteComponent`.
+If you want to inspect your final dataset without using the data explorer or use the 
+dataset for further tasks, we recommend to write the final dataset to a destination. 
+We offer a write component to perform this task. You can leverage the `write_to_file` component, 
+which allows you to export the dataset either to a local file or a remote storage bucket.
+
+```python
+uppercase_alt_text.write(ref="write_to_file", arguments={"path": "/data/export"})
+```
+
+You can open the path and use any tools of your choice to inspect the resulting Parquet dataset.

--- a/docs/guides/implement_custom_components.md
+++ b/docs/guides/implement_custom_components.md
@@ -140,7 +140,7 @@ image type, downloads the images, and filters them by alt text language.
 
 If you want to inspect your final dataset without using the data explorer or use the 
 dataset for further tasks, we recommend to write the final dataset to a destination. 
-We offer a write component to perform this task. You can leverage the `write_to_file` component, 
+We offer [write components](../components//hub.md) to perform this task, for instance the `write_to_file` component, 
 which allows you to export the dataset either to a local file or a remote storage bucket.
 
 ```python


### PR DESCRIPTION
Added `write_to_file` to both getting started guides. #826 already added the component to the example pipeline.

fix #825