### PR TITLE
Install only test deps before running tox

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install poetry==1.4.0
-          poetry install --all-extras --with test
+          poetry install --only test
       - name: Test with tox
         run: poetry run tox
       - name: Coveralls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,17 +73,19 @@ vertex = ["docker", "kfp", "google-cloud-aiplatform"]
 sagemaker = ["sagemaker", "boto3"]
 docker = ["docker"]
 
-[tool.poetry.group.test.dependencies]
+[tool.poetry.group.test]
 optional = true
 
+[tool.poetry.group.test.dependencies]
 pre-commit = "^3.1.1"
 tox = "^4.6.4"
 tox-gh-actions = "^3.1.3"
 coveralls = "^3.3.1"
 
-[tool.poetry.group.docs.dependencies]
+[tool.poetry.group.docs]
 optional = true
 
+[tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.1.8"
 mkdocstrings = { version = "^0.20", extras = ["python"]}
 mkdocs-redirects = "1.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,16 @@ sagemaker = ["sagemaker", "boto3"]
 docker = ["docker"]
 
 [tool.poetry.group.test.dependencies]
+optional = true
+
 pre-commit = "^3.1.1"
 tox = "^4.6.4"
 tox-gh-actions = "^3.1.3"
 coveralls = "^3.3.1"
 
 [tool.poetry.group.docs.dependencies]
+optional = true
+
 mkdocs-material = "^9.1.8"
 mkdocstrings = { version = "^0.20", extras = ["python"]}
 mkdocs-redirects = "1.2.1"


### PR DESCRIPTION
Tox will install the necessary dependencies per environment, so we don't need to do this beforehand. This should speed up the builds a bit.