### PR TITLE
Make unique index sorted

### DIFF
--- a/src/fondant/components/load_from_csv/src/main.py
+++ b/src/fondant/components/load_from_csv/src/main.py
@@ -72,14 +72,15 @@ class CSVReader(DaskLoadComponent):
                 Function that sets a unique index
                 based on the partition and row number.
                 """
+                n_digits = len(str(len(dataframe)))
+
                 dataframe["id"] = 1
                 dataframe["id"] = (
                     str(partition_info["number"])
                     + "_"
-                    + (dataframe.id.cumsum()).astype(str)
+                    + dataframe.id.cumsum().astype(str).str.zfill(n_digits)
                 )
-                dataframe.index = dataframe.pop("id")
-                return dataframe
+                return dataframe.set_index("id", drop=True)
 
             def _get_meta_df() -> pd.DataFrame:
                 meta_dict = {"id": pd.Series(dtype="object")}

--- a/src/fondant/components/load_from_hf_hub/src/main.py
+++ b/src/fondant/components/load_from_hf_hub/src/main.py
@@ -81,14 +81,15 @@ class LoadFromHubComponent(DaskLoadComponent):
 
             def _set_unique_index(dataframe: pd.DataFrame, partition_info=None):
                 """Function that sets a unique index based on the partition and row number."""
+                n_digits = len(str(len(dataframe)))
+
                 dataframe["id"] = 1
                 dataframe["id"] = (
                     str(partition_info["number"])
                     + "_"
-                    + (dataframe.id.cumsum()).astype(str)
+                    + dataframe.id.cumsum().astype(str).str.zfill(n_digits)
                 )
-                dataframe.index = dataframe.pop("id")
-                return dataframe
+                return dataframe.set_index("id", drop=True)
 
             def _get_meta_df() -> pd.DataFrame:
                 meta_dict = {"id": pd.Series(dtype="object")}

--- a/src/fondant/components/load_from_parquet/src/main.py
+++ b/src/fondant/components/load_from_parquet/src/main.py
@@ -68,14 +68,15 @@ class LoadFromParquet(DaskLoadComponent):
 
             def _set_unique_index(dataframe: pd.DataFrame, partition_info=None):
                 """Function that sets a unique index based on the partition and row number."""
+                n_digits = len(str(len(dataframe)))
+
                 dataframe["id"] = 1
                 dataframe["id"] = (
                     str(partition_info["number"])
                     + "_"
-                    + (dataframe.id.cumsum()).astype(str)
+                    + dataframe.id.cumsum().astype(str).str.zfill(n_digits)
                 )
-                dataframe.index = dataframe.pop("id")
-                return dataframe
+                return dataframe.set_index("id", drop=True)
 
             def _get_meta_df() -> pd.DataFrame:
                 meta_dict = {"id": pd.Series(dtype="object")}

--- a/src/fondant/components/load_from_pdf/src/main.py
+++ b/src/fondant/components/load_from_pdf/src/main.py
@@ -47,14 +47,15 @@ class PDFReader(DaskLoadComponent):
 
             def _set_unique_index(dataframe: pd.DataFrame, partition_info=None):
                 """Function that sets a unique index based on the partition and row number."""
+                n_digits = len(str(len(dataframe)))
+
                 dataframe["id"] = 1
                 dataframe["id"] = (
                     str(partition_info["number"])
                     + "_"
-                    + (dataframe.id.cumsum()).astype(str)
+                    + dataframe.id.cumsum().astype(str).str.zfill(n_digits)
                 )
-                dataframe.index = dataframe.pop("id")
-                return dataframe
+                return dataframe.set_index("id", drop=True)
 
             def _get_meta_df() -> pd.DataFrame:
                 meta_dict = {"id": pd.Series(dtype="object")}


### PR DESCRIPTION
The unique index we create is not sorted, while I believe this was originally the goal. Ran into some issues merging large dataframes and this was one of them.