### PR TITLE
Add dask-cuda to Fondant dependencies

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
 dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"], optional = true }
+dask-cuda = { version = ">=2023.4.1", optional = true }
 
 gcsfs = { version = ">= 2023.10.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }
@@ -64,6 +65,7 @@ boto3 = {version = "1.28.64", optional = true}
 
 [tool.poetry.extras]
 component = ["dask"]
+gpu = ["dask-cuda"]
 
 aws = ["s3fs"]
 azure = ["adlfs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
 dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"], optional = true }
-dask-cuda = { version = ">=2023.4.1", optional = true }
+dask-cuda = { version = ">=23.4.1", python = ">3.9", optional = true }
 
 gcsfs = { version = ">= 2023.10.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">= 3.8, <3.12"
+python = ">= 3.9, <3.12"
 
 fsspec = ">= 2023.4.0"
 importlib-resources = { version = ">= 1.3", python = "<3.9" }
@@ -51,7 +51,7 @@ pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
 dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"], optional = true }
-dask-cuda = { version = ">=23.4.1", python = ">3.9", optional = true }
+dask-cuda = { version = ">=23.4.1", optional = true }
 
 gcsfs = { version = ">= 2023.10.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }

--- a/scripts/build_components.sh
+++ b/scripts/build_components.sh
@@ -20,7 +20,7 @@ function usage {
 
 # Parse the arguments
 while [[ "$#" -gt 0 ]]; do case $1 in
-  -r |--registry) registry="$2"; shift;;
+  -rg|--registry) registry="$2"; shift;;
   -n |--namespace) namespace="$2"; shift;;
   -d |--components-dir ) components_dir="$2"; shift;;
   -r |--repo) repo="$2"; shift;;
@@ -40,7 +40,7 @@ fi
 
 # Set default values for optional arguments if not passed
 component="${components:-all}"
-components_dir="${components_dir:-components}"
+components_dir="${components_dir:-src/fondant/components}"
 namespace="${namespace:-fndnt}"
 repo="${repo:-ml6team/fondant}"
 
@@ -107,7 +107,7 @@ for dir in "${components_to_build[@]}"; do
   echo "Freezing Fondant dependency version to ${tags[0]}"
   docker build --push "${args[@]}" \
    --build-arg="FONDANT_VERSION=${tags[0]}" \
-   --label org.opencontainers.image.source=https://github.com/${repo}/components/{BASENAME} \
+   --label org.opencontainers.image.source=https://github.com/${repo}/src/fondant/components/{BASENAME} \
    .
 
   docker pushrm ${full_image_name} | echo "

--- a/src/fondant/component/component.py
+++ b/src/fondant/component/component.py
@@ -38,7 +38,7 @@ class DaskComponent(BaseComponent):
         # mode is not possible in our docker container setup.
         dask.config.set({"distributed.worker.daemon": False})
 
-        self.dask_client()
+        self.client = self.dask_client()
 
     def dask_client(self) -> Client:
         """Initialize the dask client to use for this component."""
@@ -48,6 +48,9 @@ class DaskComponent(BaseComponent):
             threads_per_worker=1,
         )
         return Client(cluster)
+
+    def teardown(self) -> None:
+        self.client.shutdown()
 
 
 class DaskLoadComponent(DaskComponent):

--- a/src/fondant/components/chunk_text/Dockerfile
+++ b/src/fondant/components/chunk_text/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/crop_images/Dockerfile
+++ b/src/fondant/components/crop_images/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/download_images/Dockerfile
+++ b/src/fondant/components/download_images/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/embed_images/Dockerfile
+++ b/src/fondant/components/embed_images/Dockerfile
@@ -12,7 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Install Fondant
 # This is split from other requirements to leverage caching
 ARG FONDANT_VERSION=main
-RUN pip3 install fondant[component,aws,azure,gcp]@git+https://github.com/ml6team/fondant@${FONDANT_VERSION}
+RUN pip3 install fondant[component,gpu,aws,azure,gcp]@git+https://github.com/ml6team/fondant@${FONDANT_VERSION}
 
 # Set the working directory to the component folder
 WORKDIR /component/src

--- a/src/fondant/components/embed_images/requirements.txt
+++ b/src/fondant/components/embed_images/requirements.txt
@@ -1,3 +1,2 @@
 Pillow==10.0.1
 transformers==4.28.0
-dask-cuda==23.12.0

--- a/src/fondant/components/extract_image_resolution/Dockerfile
+++ b/src/fondant/components/extract_image_resolution/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/filter_image_resolution/Dockerfile
+++ b/src/fondant/components/filter_image_resolution/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/filter_language/Dockerfile
+++ b/src/fondant/components/filter_language/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 ## System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/filter_text_length/Dockerfile
+++ b/src/fondant/components/filter_text_length/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/generate_minhash/Dockerfile
+++ b/src/fondant/components/generate_minhash/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/index_aws_opensearch/Dockerfile
+++ b/src/fondant/components/index_aws_opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/index_qdrant/Dockerfile
+++ b/src/fondant/components/index_qdrant/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/index_weaviate/Dockerfile
+++ b/src/fondant/components/index_weaviate/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_csv/Dockerfile
+++ b/src/fondant/components/load_from_csv/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_files/Dockerfile
+++ b/src/fondant/components/load_from_files/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_hf_hub/Dockerfile
+++ b/src/fondant/components/load_from_hf_hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_parquet/Dockerfile
+++ b/src/fondant/components/load_from_parquet/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_pdf/Dockerfile
+++ b/src/fondant/components/load_from_pdf/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/resize_images/Dockerfile
+++ b/src/fondant/components/resize_images/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 ## System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/retrieve_laion_by_embedding/Dockerfile
+++ b/src/fondant/components/retrieve_laion_by_embedding/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/retrieve_laion_by_prompt/Dockerfile
+++ b/src/fondant/components/retrieve_laion_by_prompt/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/write_to_hf_hub/Dockerfile
+++ b/src/fondant/components/write_to_hf_hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,10 @@ isolated_build = True
 envlist =
     pre-commit
     check-licenses
-    py{38,39,310,311}
+    py{39,310,311}
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: pre-commit,check-licenses,py310
     3.11: py311
@@ -32,7 +31,7 @@ commands_pre=
 commands=
     poetry run liccheck -s license_strategy.ini -r /tmp/requirements.txt -l PARANOID
 
-[testenv:py{38,39,310,311}]
+[testenv:py{39,310,311}]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}
 skip_install=true
 deps=


### PR DESCRIPTION
The `embed_images` component is failing. Unfortunately I'm not receiving any logs, but I assume it's due to different dask and dask-related versions. This PR adds `dask-cuda` as an extra `gpu` dependency to Fondant, so it's resolved together with the other dependencies.