### PR TITLE
Change dask_client to general setup method

### DIFF
--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -3,6 +3,7 @@ import os
 import typing as t
 from collections import defaultdict
 
+import dask
 import dask.dataframe as dd
 from dask.diagnostics import ProgressBar
 from dask.distributed import Client
@@ -30,6 +31,10 @@ class DaskDataLoader(DataIO):
         input_partition_rows: t.Optional[int] = None,
     ):
         super().__init__(manifest=manifest, operation_spec=operation_spec)
+        # Don't assume every object is a string
+        # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
+        dask.config.set({"dataframe.convert-string": False})
+
         self.input_partition_rows = input_partition_rows
 
     def partition_loaded_dataframe(self, dataframe: dd.DataFrame) -> dd.DataFrame:

--- a/src/fondant/component/executor.py
+++ b/src/fondant/component/executor.py
@@ -287,6 +287,8 @@ class Executor(t.Generic[Component]):
         component.consumes = self.operation_spec.inner_consumes
         component.produces = self.operation_spec.inner_produces
 
+        state = component.setup()
+
         output_df = self._execute_component(
             component,
             manifest=input_manifest,
@@ -298,7 +300,7 @@ class Executor(t.Generic[Component]):
         )
         self._write_data(dataframe=output_df, manifest=output_manifest)
 
-        component.teardown()
+        component.teardown(state)
 
         return output_manifest
 

--- a/src/fondant/components/embed_images/src/main.py
+++ b/src/fondant/components/embed_images/src/main.py
@@ -40,12 +40,12 @@ class EmbedImagesComponent(PandasTransformComponent):
 
         super().__init__()
 
-    def dask_client(self) -> Client:
+    def setup(self) -> Client:
         if self.device == "cuda":
             cluster = LocalCUDACluster()
             return Client(cluster)
 
-        return super().dask_client()
+        return super().setup()
 
     def process_image_batch(self, images: np.ndarray) -> t.List[torch.Tensor]:
         """

--- a/src/fondant/components/index_aws_opensearch/src/main.py
+++ b/src/fondant/components/index_aws_opensearch/src/main.py
@@ -38,7 +38,7 @@ class IndexAWSOpenSearchComponent(DaskWriteComponent):
         )
         self.create_index(index_body)
 
-    def teardown(self) -> None:
+    def teardown(self, _) -> None:
         self.client.close()
 
     def create_index(self, index_body: Dict[str, Any]):

--- a/src/fondant/components/index_qdrant/src/main.py
+++ b/src/fondant/components/index_qdrant/src/main.py
@@ -47,7 +47,7 @@ class IndexQdrantComponent(DaskWriteComponent):
         self.batch_size = batch_size
         self.parallelism = parallelism
 
-    def teardown(self) -> None:
+    def teardown(self, _) -> None:
         self.client.close()
 
     def write(self, dataframe: dd.DataFrame) -> None:

--- a/src/fondant/components/index_weaviate/src/main.py
+++ b/src/fondant/components/index_weaviate/src/main.py
@@ -85,7 +85,7 @@ class IndexWeaviateComponent(DaskWriteComponent):
 
         return class_schema
 
-    def teardown(self) -> None:
+    def teardown(self, _) -> None:
         del self.client
 
     def write(self, dataframe: dd.DataFrame) -> None:


### PR DESCRIPTION
This PR changes the `dask_client` method introduced in #852 into a general `setup` method.

This method differs from `__init__` in that it allows users to return a state, which is passed into the `teardown` method by Fondant.  This is necessary since the Dask client is not pickleable, and setting it as an instance attribute leads to issues when executing the `transform` method across processes (as is the case in the `PandasTransformComponent`).