### PR TITLE
Add `gpu` extra with `dask-cuda` and bump minimum Python version to 3.9

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/data_explorer/Dockerfile
+++ b/data_explorer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING=UTF-8

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -12,7 +12,7 @@ mkdocs:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
   jobs:
     post_create_environment:
       # Install poetry

--- a/docs/components/containerized_components.md
+++ b/docs/components/containerized_components.md
@@ -48,7 +48,7 @@ The `Dockerfile` defines how to build the component into a Docker image. An exam
 defined below.
 
 ```bash
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # install requirements
 COPY requirements.txt ./

--- a/docs/components/lightweight_components.md
+++ b/docs/components/lightweight_components.md
@@ -89,7 +89,7 @@ image instead of the default one. Make sure you install Fondant in the base imag
 in the `extra_requires` argument.
 
 ```python title="pipeline.py"
-@lightweight_component(base_image="python:3.8-slim")
+@lightweight_component(base_image="python:3.10-slim")
 ```
 
 ## Optimizing loaded data

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -65,7 +65,7 @@ Check out the [guide](../components/publishing_components.md) on publishing comp
 ## Docker installation
 
 To execute pipelines locally, you must
-have [Docker compose](https://docs.docker.com/compose/install/) and Python >=3.8
+have [Docker compose](https://docs.docker.com/compose/install/) and Python >=3.9
 installed on your system. We only support Docker compose V2 and above. If you have an older version of
 Docker compose, please upgrade to the latest version as described in the [Docker compose migration doc](https://docs.docker.com/compose/migrate/).
 

--- a/examples/sample_pipeline/components/dummy_component/Dockerfile
+++ b/examples/sample_pipeline/components/dummy_component/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/examples/sample_pipeline/pipeline.py
+++ b/examples/sample_pipeline/pipeline.py
@@ -41,7 +41,7 @@ dataset = dataset.apply(
 
 
 @lightweight_component(
-    base_image="python:3.8",
+    base_image="python:3.10",
     extra_requires=[
         f"fondant[component]@git+https://github.com/ml6team/fondant@"
         f"{os.environ.get('FONDANT_VERSION', 'main')}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">= 3.8, <3.12"
+python = ">= 3.9, <3.12"
 
 fsspec = ">= 2023.4.0"
 importlib-resources = { version = ">= 1.3", python = "<3.9" }
@@ -51,7 +51,7 @@ pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
 dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"], optional = true }
-dask-cuda = { version = ">=2023.4.1", optional = true }
+dask-cuda = { version = ">=23.4.1", optional = true }
 
 gcsfs = { version = ">= 2023.10.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
 dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"], optional = true }
+dask-cuda = { version = ">=2023.4.1", optional = true }
 
 gcsfs = { version = ">= 2023.10.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }
@@ -64,6 +65,7 @@ boto3 = {version = "1.28.64", optional = true}
 
 [tool.poetry.extras]
 component = ["dask"]
+gpu = ["dask-cuda"]
 
 aws = ["s3fs"]
 azure = ["adlfs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/scripts/build_base_image.sh
+++ b/scripts/build_base_image.sh
@@ -17,7 +17,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 esac; shift; done
 
 # Supported Python versions
-python_versions=("3.8" "3.9" "3.10" "3.11")
+python_versions=("3.9" "3.10" "3.11")
 
 for tag in "${tags[@]}"; do
   for python_version in "${python_versions[@]}"; do

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -3,6 +3,7 @@ import os
 import typing as t
 from collections import defaultdict
 
+import dask
 import dask.dataframe as dd
 from dask.diagnostics import ProgressBar
 from dask.distributed import Client
@@ -30,6 +31,10 @@ class DaskDataLoader(DataIO):
         input_partition_rows: t.Optional[int] = None,
     ):
         super().__init__(manifest=manifest, operation_spec=operation_spec)
+        # Don't assume every object is a string
+        # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
+        dask.config.set({"dataframe.convert-string": False})
+
         self.input_partition_rows = input_partition_rows
 
     def partition_loaded_dataframe(self, dataframe: dd.DataFrame) -> dd.DataFrame:

--- a/src/fondant/component/executor.py
+++ b/src/fondant/component/executor.py
@@ -287,6 +287,8 @@ class Executor(t.Generic[Component]):
         component.consumes = self.operation_spec.inner_consumes
         component.produces = self.operation_spec.inner_produces
 
+        state = component.setup()
+
         output_df = self._execute_component(
             component,
             manifest=input_manifest,
@@ -298,7 +300,7 @@ class Executor(t.Generic[Component]):
         )
         self._write_data(dataframe=output_df, manifest=output_manifest)
 
-        component.teardown()
+        component.teardown(state)
 
         return output_manifest
 

--- a/src/fondant/components/chunk_text/Dockerfile
+++ b/src/fondant/components/chunk_text/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/crop_images/Dockerfile
+++ b/src/fondant/components/crop_images/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/download_images/Dockerfile
+++ b/src/fondant/components/download_images/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/embed_images/Dockerfile
+++ b/src/fondant/components/embed_images/Dockerfile
@@ -12,7 +12,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Install Fondant
 # This is split from other requirements to leverage caching
 ARG FONDANT_VERSION=main
-RUN pip3 install fondant[component,aws,azure,gcp]@git+https://github.com/ml6team/fondant@${FONDANT_VERSION}
+RUN pip3 install fondant[component,gpu,aws,azure,gcp]@git+https://github.com/ml6team/fondant@${FONDANT_VERSION}
 
 # Set the working directory to the component folder
 WORKDIR /component/src

--- a/src/fondant/components/embed_images/requirements.txt
+++ b/src/fondant/components/embed_images/requirements.txt
@@ -1,3 +1,2 @@
 Pillow==10.0.1
 transformers==4.28.0
-dask-cuda==23.12.0

--- a/src/fondant/components/embed_images/src/main.py
+++ b/src/fondant/components/embed_images/src/main.py
@@ -40,12 +40,12 @@ class EmbedImagesComponent(PandasTransformComponent):
 
         super().__init__()
 
-    def dask_client(self) -> Client:
+    def setup(self) -> Client:
         if self.device == "cuda":
             cluster = LocalCUDACluster()
             return Client(cluster)
 
-        return super().dask_client()
+        return super().setup()
 
     def process_image_batch(self, images: np.ndarray) -> t.List[torch.Tensor]:
         """

--- a/src/fondant/components/extract_image_resolution/Dockerfile
+++ b/src/fondant/components/extract_image_resolution/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/filter_image_resolution/Dockerfile
+++ b/src/fondant/components/filter_image_resolution/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/filter_language/Dockerfile
+++ b/src/fondant/components/filter_language/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 ## System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/filter_text_length/Dockerfile
+++ b/src/fondant/components/filter_text_length/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/generate_minhash/Dockerfile
+++ b/src/fondant/components/generate_minhash/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/index_aws_opensearch/Dockerfile
+++ b/src/fondant/components/index_aws_opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/index_aws_opensearch/src/main.py
+++ b/src/fondant/components/index_aws_opensearch/src/main.py
@@ -38,7 +38,7 @@ class IndexAWSOpenSearchComponent(DaskWriteComponent):
         )
         self.create_index(index_body)
 
-    def teardown(self) -> None:
+    def teardown(self, _) -> None:
         self.client.close()
 
     def create_index(self, index_body: Dict[str, Any]):

--- a/src/fondant/components/index_qdrant/Dockerfile
+++ b/src/fondant/components/index_qdrant/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/index_qdrant/src/main.py
+++ b/src/fondant/components/index_qdrant/src/main.py
@@ -47,7 +47,7 @@ class IndexQdrantComponent(DaskWriteComponent):
         self.batch_size = batch_size
         self.parallelism = parallelism
 
-    def teardown(self) -> None:
+    def teardown(self, _) -> None:
         self.client.close()
 
     def write(self, dataframe: dd.DataFrame) -> None:

--- a/src/fondant/components/index_weaviate/Dockerfile
+++ b/src/fondant/components/index_weaviate/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/index_weaviate/src/main.py
+++ b/src/fondant/components/index_weaviate/src/main.py
@@ -85,7 +85,7 @@ class IndexWeaviateComponent(DaskWriteComponent):
 
         return class_schema
 
-    def teardown(self) -> None:
+    def teardown(self, _) -> None:
         del self.client
 
     def write(self, dataframe: dd.DataFrame) -> None:

--- a/src/fondant/components/load_from_csv/Dockerfile
+++ b/src/fondant/components/load_from_csv/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_files/Dockerfile
+++ b/src/fondant/components/load_from_files/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_hf_hub/Dockerfile
+++ b/src/fondant/components/load_from_hf_hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_parquet/Dockerfile
+++ b/src/fondant/components/load_from_parquet/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/load_from_pdf/Dockerfile
+++ b/src/fondant/components/load_from_pdf/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/resize_images/Dockerfile
+++ b/src/fondant/components/resize_images/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 ## System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/retrieve_laion_by_embedding/Dockerfile
+++ b/src/fondant/components/retrieve_laion_by_embedding/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/retrieve_laion_by_prompt/Dockerfile
+++ b/src/fondant/components/retrieve_laion_by_prompt/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/components/write_to_hf_hub/Dockerfile
+++ b/src/fondant/components/write_to_hf_hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # System dependencies
 RUN apt-get update && \

--- a/src/fondant/pipeline/lightweight_component.py
+++ b/src/fondant/pipeline/lightweight_component.py
@@ -15,7 +15,7 @@ from fondant.core.schema import Field, Type
 
 logger = logging.getLogger(__name__)
 
-MIN_PYTHON_VERSION = (3, 8)
+MIN_PYTHON_VERSION = (3, 9)
 MAX_PYTHON_VERSION = (3, 11)
 
 

--- a/tests/examples/example_component/Dockerfile
+++ b/tests/examples/example_component/Dockerfile
@@ -1,1 +1,1 @@
-FROM --platform=linux/amd64 python:3.8-slim as base
+FROM --platform=linux/amd64 python:3.10-slim as base

--- a/tests/pipeline/test_compiler.py
+++ b/tests/pipeline/test_compiler.py
@@ -417,7 +417,7 @@ def test_kubeflow_component_spec_from_lightweight_component(
     )
 
     @lightweight_component(
-        base_image="python:3.8-slim-buster",
+        base_image="python:3.10-slim-buster",
         extra_requires=["pandas", "dask"],
         produces={"x": pa.int32(), "y": pa.int32()},
     )
@@ -442,7 +442,7 @@ def test_kubeflow_component_spec_from_lightweight_component(
         compiler.compile(pipeline=pipeline, output_path=output_path)
         pipeline_configs = KubeflowPipelineConfigs.from_spec(output_path)
         assert pipeline_configs.component_configs["createdata"].image == (
-            "python:3.8-slim-buster"
+            "python:3.10-slim-buster"
         )
         assert pipeline_configs.component_configs["createdata"].command == [
             "sh",
@@ -793,7 +793,7 @@ def test_sagemaker_generate_script(tmp_path_factory):
 
 def test_sagemaker_generate_script_lightweight_component(tmp_path_factory):
     @lightweight_component(
-        base_image="python:3.8-slim-buster",
+        base_image="python:3.10-slim-buster",
         extra_requires=["pandas", "dask"],
     )
     class CreateData(DaskLoadComponent):

--- a/tests/pipeline/test_lightweight_component.py
+++ b/tests/pipeline/test_lightweight_component.py
@@ -35,7 +35,7 @@ def load_pipeline(caplog):
     )
 
     @lightweight_component(
-        base_image="python:3.8-slim-buster",
+        base_image="python:3.10-slim-buster",
         extra_requires=["pandas", "dask"],
         produces={"x": pa.int32(), "y": pa.int32(), "z": pa.int32()},
     )
@@ -100,7 +100,7 @@ def test_lightweight_component_sdk(default_fondant_image, load_pipeline):
     assert operation_spec_dict == {
         "specification": {
             "name": "CreateData",
-            "image": "python:3.8-slim-buster",
+            "image": "python:3.10-slim-buster",
             "description": "lightweight component",
             "consumes": {"additionalProperties": True},
             "produces": {
@@ -159,7 +159,7 @@ def test_lightweight_component_sdk(default_fondant_image, load_pipeline):
 
 def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
     @lightweight_component(
-        base_image="python:3.8",
+        base_image="python:3.10",
         extra_requires=[
             "fondant[component]@git+https://github.com/ml6team/fondant@main",
         ],
@@ -194,7 +194,7 @@ def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
 
 def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
     @lightweight_component(
-        base_image="python:3.8",
+        base_image="python:3.10",
         extra_requires=[
             "fondant[component]@git+https://github.com/ml6team/fondant@main",
         ],
@@ -231,7 +231,7 @@ def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
 
 def test_consumes_mapping_additional_fields(tmp_path_factory, load_pipeline):
     @lightweight_component(
-        base_image="python:3.8",
+        base_image="python:3.10",
         extra_requires=[
             "fondant[component]@git+https://github.com/ml6team/fondant@main",
         ],
@@ -268,7 +268,7 @@ def test_consumes_mapping_additional_fields(tmp_path_factory, load_pipeline):
 
 def test_produces_mapping_additional_fields(tmp_path_factory, load_pipeline):
     @lightweight_component(
-        base_image="python:3.8",
+        base_image="python:3.10",
         extra_requires=[
             "fondant[component]@git+https://github.com/ml6team/fondant@main",
         ],
@@ -322,7 +322,7 @@ def test_lightweight_component_missing_decorator():
 
 def test_valid_load_component():
     @lightweight_component(
-        base_image="python:3.8-slim-buster",
+        base_image="python:3.10-slim-buster",
     )
     class CreateData(DaskLoadComponent):
         def load(self) -> dd.DataFrame:
@@ -351,7 +351,7 @@ def test_valid_load_component():
     assert operation_spec_without_image == {
         "specification": {
             "name": "CreateData",
-            "image": "python:3.8-slim-buster",
+            "image": "python:3.10-slim-buster",
             "description": "lightweight component",
             "consumes": {"additionalProperties": True},
             "produces": {"additionalProperties": True},
@@ -369,7 +369,7 @@ def test_invalid_load_component():
     ):
 
         @lightweight_component(
-            base_image="python:3.8-slim-buster",
+            base_image="python:3.10-slim-buster",
         )
         class CreateData(DaskLoadComponent):
             def custom_load(self) -> int:
@@ -386,7 +386,7 @@ def test_invalid_load_transform_component():
     ):
 
         @lightweight_component(
-            base_image="python:3.8-slim-buster",
+            base_image="python:3.10-slim-buster",
         )
         class CreateData(DaskLoadComponent, PandasTransformComponent):
             def load(self) -> dd.DataFrame:
@@ -409,7 +409,7 @@ def test_invalid_load_component_wrong_return_type():
     ):
 
         @lightweight_component(
-            base_image="python:3.8-slim-buster",
+            base_image="python:3.10-slim-buster",
         )
         class CreateData(DaskLoadComponent):
             def load(self) -> int:

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,10 @@ isolated_build = True
 envlist =
     pre-commit
     check-licenses
-    py{38,39,310,311}
+    py{39,310,311}
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: pre-commit,check-licenses,py310
     3.11: py311
@@ -32,7 +31,7 @@ commands_pre=
 commands=
     poetry run liccheck -s license_strategy.ini -r /tmp/requirements.txt -l PARANOID
 
-[testenv:py{38,39,310,311}]
+[testenv:py{39,310,311}]
 setenv=PYTHONPATH = {toxinidir}:{toxinidir}
 skip_install=true
 deps=


### PR DESCRIPTION
Separately resolving `dask-cuda` in our components leads to dependency conflicts. Since we put a lot of focus on ML components, I think it makes sense to add it as an extra.

It only supports Python 3.9+ though, so we need to drop Python 3.8, which will be end of life later this year.