### PR TITLE
Write metadata file

### DIFF
--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -239,6 +239,7 @@ class DaskDataWriter(DataIO):
             schema=schema,
             overwrite=False,
             compute=False,
+            write_metadata_file=True,
         )
         logging.info(f"Creating write task for: {location}")
         return write_task


### PR DESCRIPTION
We currently don't preserve the divisions of the data when writing and reading again, which leads to errors when merging datasets with a low and high amount of partitions. This PR enables the writing of a metadata file which should fix this.

This was originally introduced in #391, which contains more information, but then later reverted in #403 without a clear reasoning.

Let's reactivate it, and if there's a reason to remove it again, let's document it properly.