### PR TITLE
Renaming inner and outer consumes/produces

### DIFF
--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -136,7 +136,9 @@ class DaskDataLoader(DataIO):
             msg = "No data could be loaded"
             raise RuntimeError(msg)
 
-        if consumes_mapping := self.operation_spec.operations_consumes:
+        if (
+            consumes_mapping := self.operation_spec.operations_consumes_to_dataset_consumes
+        ):
             dataframe = dataframe.rename(
                 columns={
                     v: k for k, v in consumes_mapping.items() if isinstance(v, str)
@@ -209,7 +211,7 @@ class DaskDataWriter(DataIO):
 
         schema = {
             field.name: field.type.value
-            for field in self.operation_spec.produces_to_dataset.values()
+            for field in self.operation_spec.produces_to_dataset_schema.values()
         }
         return self._create_write_task(dataframe, location=location, schema=schema)
 

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -106,7 +106,7 @@ class DaskDataLoader(DataIO):
             DEFAULT_INDEX_NAME,
         )
 
-        for field_name in self.operation_spec.outer_consumes:
+        for field_name in self.operation_spec.consumes_of_dataset:
             location = self.manifest.get_field_location(field_name)
             field_mapping[location].append(field_name)
 
@@ -136,7 +136,7 @@ class DaskDataLoader(DataIO):
             msg = "No data could be loaded"
             raise RuntimeError(msg)
 
-        if consumes_mapping := self.operation_spec._mappings["consumes"]:
+        if consumes_mapping := self.operation_spec.operations_consumes:
             dataframe = dataframe.rename(
                 columns={
                     v: k for k, v in consumes_mapping.items() if isinstance(v, str)
@@ -167,7 +167,7 @@ class DaskDataWriter(DataIO):
         dataframe.index = dataframe.index.rename(DEFAULT_INDEX_NAME)
 
         # validation that all columns are in the dataframe
-        expected_columns = list(self.operation_spec.inner_produces)
+        expected_columns = list(self.operation_spec.operations_produces)
         self.validate_dataframe_columns(dataframe, expected_columns)
 
         dataframe = dataframe[expected_columns]
@@ -209,7 +209,7 @@ class DaskDataWriter(DataIO):
 
         schema = {
             field.name: field.type.value
-            for field in self.operation_spec.outer_produces.values()
+            for field in self.operation_spec.produces_to_dataset.values()
         }
         return self._create_write_task(dataframe, location=location, schema=schema)
 

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -106,7 +106,7 @@ class DaskDataLoader(DataIO):
             DEFAULT_INDEX_NAME,
         )
 
-        for field_name in self.operation_spec.consumes_of_dataset:
+        for field_name in self.operation_spec.consumes_from_dataset:
             location = self.manifest.get_field_location(field_name)
             field_mapping[location].append(field_name)
 

--- a/src/fondant/component/executor.py
+++ b/src/fondant/component/executor.py
@@ -284,8 +284,8 @@ class Executor(t.Generic[Component]):
 
         component: Component = component_cls(**self.user_arguments)
 
-        component.consumes = self.operation_spec.inner_consumes
-        component.produces = self.operation_spec.inner_produces
+        component.consumes = self.operation_spec.operations_consumes
+        component.produces = self.operation_spec.operations_produces
 
         state = component.setup()
 
@@ -495,7 +495,9 @@ class PandasTransformExecutor(TransformExecutor[PandasTransformComponent]):
             dataframe = transform(dataframe)
 
             # Drop columns not in specification
-            columns = [name for name, field in operation_spec.inner_produces.items()]
+            columns = [
+                name for name, field in operation_spec.operations_produces.items()
+            ]
 
             return dataframe[columns]
 
@@ -523,7 +525,7 @@ class PandasTransformExecutor(TransformExecutor[PandasTransformComponent]):
 
         # Create meta dataframe with expected format
         meta_dict = {"id": pd.Series(dtype="object")}
-        for field_name, field in self.operation_spec.inner_produces.items():
+        for field_name, field in self.operation_spec.operations_produces.items():
             meta_dict[field_name] = pd.Series(dtype=pd.ArrowDtype(field.type.value))
         meta_df = pd.DataFrame(meta_dict).set_index("id")
 

--- a/src/fondant/components/load_from_pdf/tests/component_test.py
+++ b/src/fondant/components/load_from_pdf/tests/component_test.py
@@ -21,7 +21,7 @@ def test_pdf_reader():
 
     for path in pdf_path:
         component = PDFReader(
-            produces=dict(spec.inner_produces),
+            produces=dict(spec.operations_produces),
             pdf_path=path,
             n_rows_to_load=None,
             index_column=None,

--- a/src/fondant/core/component_spec.py
+++ b/src/fondant/core/component_spec.py
@@ -353,10 +353,10 @@ class OperationSpec:
         }
         self._validate_mappings()
 
-        self._inner_consumes: t.Optional[t.Mapping[str, Field]] = None
-        self._outer_consumes: t.Optional[t.Mapping[str, Field]] = None
-        self._inner_produces: t.Optional[t.Mapping[str, Field]] = None
-        self._outer_produces: t.Optional[t.Mapping[str, Field]] = None
+        self._operation_consumes: t.Optional[t.Mapping[str, Field]] = None
+        self._consumes_of_dataset: t.Optional[t.Mapping[str, Field]] = None
+        self._operation_produces: t.Optional[t.Mapping[str, Field]] = None
+        self._produces_to_dataset: t.Optional[t.Mapping[str, Field]] = None
 
     def to_dict(self) -> dict:
         def _dump_mapping(
@@ -414,11 +414,14 @@ class OperationSpec:
                     msg = f"Unexpected type {type(value)} received for key {key} in {name} mapping"
                     raise InvalidPipelineDefinition(msg)
 
-    def _inner_mapping(self, name: str) -> t.Mapping[str, Field]:
-        """Calculate the "inner mapping" of the operation. This is the mapping that the component
+    def _dataset_to_operations_mapping(self, name: str) -> t.Mapping[str, Field]:
+        """Calculate the operations mapping.
+        Maps dataset fields to the fields that the operation will receive.
+        This is the mapping that the component
         `transform` (or equivalent) method will receive. This is calculated by starting from the
         component spec section, and updating it with any string to type mappings from the
         argument mapping.
+
 
         Args:
             name: "consumes" or "produces"
@@ -453,15 +456,16 @@ class OperationSpec:
 
         return types.MappingProxyType(mapping)
 
-    def _outer_mapping(self, name: str) -> t.Mapping[str, Field]:
-        """Calculate the "outer mapping" of the operation. This is the mapping that the dataIO
-        needs to read / write. This is calculated by starting from the "inner mapping" updating it
+    def _operation_to_dataset_mapping(self, name: str) -> t.Mapping[str, Field]:
+        """
+        Maps the operations fields to the dataset fields which will be written in DataIO.
+        This is calculated by starting from the "inner mapping" updating it
         with any string to string mappings from the argument mapping.
 
         Args:
             name: "consumes" or "produces"
         """
-        spec_mapping = getattr(self, f"inner_{name}")
+        spec_mapping = getattr(self, f"operations_{name}")
         args_mapping = self._mappings[name]
 
         if not args_mapping:
@@ -486,40 +490,40 @@ class OperationSpec:
         return types.MappingProxyType(mapping)
 
     @property
-    def inner_consumes(self) -> t.Mapping[str, Field]:
-        """The "inner" `consumes` mapping which the component `transform` (or equivalent) method
+    def operations_consumes(self) -> t.Mapping[str, Field]:
+        """The operations `consumes` mapping which the component `transform` (or equivalent) method
         will receive.
         """
-        if self._inner_consumes is None:
-            self._inner_consumes = self._inner_mapping("consumes")
+        if self._operation_consumes is None:
+            self._operation_consumes = self._dataset_to_operations_mapping("consumes")
 
-        return self._inner_consumes
-
-    @property
-    def outer_consumes(self) -> t.Mapping[str, Field]:
-        """The "outer" `consumes` mapping which the dataIO needs to read / write."""
-        if self._outer_consumes is None:
-            self._outer_consumes = self._outer_mapping("consumes")
-
-        return self._outer_consumes
+        return self._operation_consumes
 
     @property
-    def inner_produces(self) -> t.Mapping[str, Field]:
-        """The "inner" `produces` mapping which the component `transform` (or equivalent) method
+    def consumes_of_dataset(self) -> t.Mapping[str, Field]:
+        """Defines which fields of the dataset are consumed by the operation."""
+        if self._consumes_of_dataset is None:
+            self._consumes_of_dataset = self._operation_to_dataset_mapping("consumes")
+
+        return self._consumes_of_dataset
+
+    @property
+    def operations_produces(self) -> t.Mapping[str, Field]:
+        """The operations `produces` mapping which the component `transform` (or equivalent) method
         will receive.
         """
-        if self._inner_produces is None:
-            self._inner_produces = self._inner_mapping("produces")
+        if self._operation_produces is None:
+            self._operation_produces = self._dataset_to_operations_mapping("produces")
 
-        return self._inner_produces
+        return self._operation_produces
 
     @property
-    def outer_produces(self) -> t.Mapping[str, Field]:
-        """The "outer" `produces` mapping which the dataIO needs to read / write."""
-        if self._outer_produces is None:
-            self._outer_produces = self._outer_mapping("produces")
+    def produces_to_dataset(self) -> t.Mapping[str, Field]:
+        """The produces mapping that the dataIO needs write to the dataset fields."""
+        if self._produces_to_dataset is None:
+            self._produces_to_dataset = self._operation_to_dataset_mapping("produces")
 
-        return self._outer_produces
+        return self._produces_to_dataset
 
     @property
     def component_name(self) -> str:

--- a/src/fondant/core/component_spec.py
+++ b/src/fondant/core/component_spec.py
@@ -354,7 +354,7 @@ class OperationSpec:
         self._validate_mappings()
 
         self._operation_consumes: t.Optional[t.Mapping[str, Field]] = None
-        self._consumes_of_dataset: t.Optional[t.Mapping[str, Field]] = None
+        self._consumes_from_dataset: t.Optional[t.Mapping[str, Field]] = None
         self._operation_produces: t.Optional[t.Mapping[str, Field]] = None
         self._produces_to_dataset: t.Optional[t.Mapping[str, Field]] = None
 
@@ -500,12 +500,12 @@ class OperationSpec:
         return self._operation_consumes
 
     @property
-    def consumes_of_dataset(self) -> t.Mapping[str, Field]:
+    def consumes_from_dataset(self) -> t.Mapping[str, Field]:
         """Defines which fields of the dataset are consumed by the operation."""
-        if self._consumes_of_dataset is None:
-            self._consumes_of_dataset = self._operation_to_dataset_mapping("consumes")
+        if self._consumes_from_dataset is None:
+            self._consumes_from_dataset = self._operation_to_dataset_mapping("consumes")
 
-        return self._consumes_of_dataset
+        return self._consumes_from_dataset
 
     @property
     def operations_produces(self) -> t.Mapping[str, Field]:

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -271,7 +271,7 @@ class Manifest:
                 evolved_manifest.remove_field(field_name)
 
         # Add or update all produced fields defined in the component spec
-        for name, field in operation_spec.produces_to_dataset.items():
+        for name, field in operation_spec.produces_to_dataset_schema.items():
             # If field was not part of the input manifest, add field to output manifest.
             # If field was part of the input manifest and got produced by the component, update
             # the manifest field.

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -271,7 +271,7 @@ class Manifest:
                 evolved_manifest.remove_field(field_name)
 
         # Add or update all produced fields defined in the component spec
-        for name, field in operation_spec.outer_produces.items():
+        for name, field in operation_spec.produces_to_dataset.items():
             # If field was not part of the input manifest, add field to output manifest.
             # If field was part of the input manifest and got produced by the component, update
             # the manifest field.

--- a/src/fondant/pipeline/pipeline.py
+++ b/src/fondant/pipeline/pipeline.py
@@ -565,7 +565,7 @@ class Pipeline:
                 for (
                     component_field_name,
                     component_field,
-                ) in operation_spec.consumes_of_dataset.items():
+                ) in operation_spec.consumes_from_dataset.items():
                     if component_field_name not in manifest.fields:
                         msg = (
                             f"Component '{component_op.component_name}' is trying to invoke the"

--- a/src/fondant/pipeline/pipeline.py
+++ b/src/fondant/pipeline/pipeline.py
@@ -565,7 +565,7 @@ class Pipeline:
                 for (
                     component_field_name,
                     component_field,
-                ) in operation_spec.outer_consumes.items():
+                ) in operation_spec.consumes_of_dataset.items():
                     if component_field_name not in manifest.fields:
                         msg = (
                             f"Component '{component_op.component_name}' is trying to invoke the"

--- a/tests/pipeline/test_lightweight_component.py
+++ b/tests/pipeline/test_lightweight_component.py
@@ -192,7 +192,7 @@ def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
             pipeline_configs.component_configs["addn"].arguments["operation_spec"],
         )
         assert all(k in ["a", "y", "z"] for k in operation_spec.operations_consumes)
-        assert "x" in operation_spec.consumes_of_dataset
+        assert "x" in operation_spec.consumes_from_dataset
 
 
 def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
@@ -228,7 +228,7 @@ def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
             pipeline_configs.component_configs["addn"].arguments["operation_spec"],
         )
         assert "a" in operation_spec.operations_consumes
-        assert "x" in operation_spec.consumes_of_dataset
+        assert "x" in operation_spec.consumes_from_dataset
         assert "z" not in operation_spec.operations_consumes
 
 

--- a/tests/pipeline/test_lightweight_component.py
+++ b/tests/pipeline/test_lightweight_component.py
@@ -191,8 +191,8 @@ def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
         operation_spec = OperationSpec.from_json(
             pipeline_configs.component_configs["addn"].arguments["operation_spec"],
         )
-        assert all(k in ["a", "y", "z"] for k in operation_spec.inner_consumes)
-        assert "x" in operation_spec.outer_consumes
+        assert all(k in ["a", "y", "z"] for k in operation_spec.operations_consumes)
+        assert "x" in operation_spec.consumes_of_dataset
 
 
 def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
@@ -227,9 +227,9 @@ def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
         operation_spec = OperationSpec.from_json(
             pipeline_configs.component_configs["addn"].arguments["operation_spec"],
         )
-        assert "a" in operation_spec.inner_consumes
-        assert "x" in operation_spec.outer_consumes
-        assert "z" not in operation_spec.inner_consumes
+        assert "a" in operation_spec.operations_consumes
+        assert "x" in operation_spec.consumes_of_dataset
+        assert "z" not in operation_spec.operations_consumes
 
 
 def test_consumes_mapping_additional_fields(tmp_path_factory, load_pipeline):
@@ -264,9 +264,9 @@ def test_consumes_mapping_additional_fields(tmp_path_factory, load_pipeline):
         operation_spec = OperationSpec.from_json(
             pipeline_configs.component_configs["addn"].arguments["operation_spec"],
         )
-        assert "x" in operation_spec.inner_consumes
-        assert "a" in operation_spec.inner_produces
-        assert "z" not in operation_spec.inner_consumes
+        assert "x" in operation_spec.operations_consumes
+        assert "a" in operation_spec.operations_produces
+        assert "z" not in operation_spec.operations_consumes
 
 
 def test_produces_mapping_additional_fields(tmp_path_factory, load_pipeline):
@@ -303,7 +303,7 @@ def test_produces_mapping_additional_fields(tmp_path_factory, load_pipeline):
         operation_spec = OperationSpec.from_json(
             pipeline_configs.component_configs["addn"].arguments["operation_spec"],
         )
-        assert all(k in ["a", "b", "c"] for k in operation_spec.inner_produces)
+        assert all(k in ["a", "b", "c"] for k in operation_spec.operations_produces)
 
 
 def test_lightweight_component_missing_decorator():


### PR DESCRIPTION
Propose to rename the inner and outer consumes/produces to something more meaningful. 

Idea was to have self explaining names. An OperationSpec is consuming fields from the dataset, and produces fields to dataset (previous outer). The OperationSpec holding `operation_consumes`, and `operation_produces` (previous inner). As well as the mapping (`operation_to_dataset_mapping` and `dataset_to_operation_mapping`).