### PR TITLE
Update component directory in tag component script

### DIFF
--- a/scripts/tag_components.sh
+++ b/scripts/tag_components.sh
@@ -30,7 +30,7 @@ namespace="fndnt"
 # Get the component directory
 scripts_dir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 root_dir=$(dirname "$scripts_dir")
-component_dir=$root_dir/"components"
+component_dir=$root_dir/"src/fondant/components"
 
 # Loop through all subdirectories
 for dir in "$component_dir"/*/; do


### PR DESCRIPTION
The release pipeline failed since the component directory was not updated in the `tag_components.sh` script.