### PR TITLE
Catch Dask client shutdown error

### DIFF
--- a/src/fondant/component/component.py
+++ b/src/fondant/component/component.py
@@ -1,4 +1,5 @@
 """This module defines interfaces which components should implement to be executed by fondant."""
+import logging
 import os
 import typing as t
 from abc import abstractmethod
@@ -57,7 +58,12 @@ class DaskComponent(BaseComponent):
         return Client(cluster)
 
     def teardown(self, client: t.Any) -> None:
-        return client.shutdown()
+        try:
+            client.shutdown()
+        except Exception:
+            msg = "Caught error while shutting down Client. Exiting anyway."
+            logging.exception(msg)
+            pass
 
 
 class DaskLoadComponent(DaskComponent):


### PR DESCRIPTION
A component in [my pipeline failed due to an error](https://console.cloud.google.com/logs/query;cursorTimestamp=2024-02-21T09:55:20.056323035Z;endTime=2024-02-21T11:00:14.204778Z;query=resource.type%3D%22ml_job%22%0Aresource.labels.job_id%3D%228518404145068113920%22%0Aseverity%3E%3DDEFAULT%0A--Hide%20similar%20entries%0A-%2528jsonPayload.message%3D~%22%2528%5Cd%7B4%7D-%25280%5B1-9%5D%7C1%5B0-2%5D%2529-%25280%5B1-9%5D%7C%5B12%5D%5B0-9%5D%7C3%5B01%5D%2529%2529%20%2528%2528%5Cd%7B2%7D%2529:%2528%5Cd%7B2%7D%2529%2528%3F::%2528%5Cd%7B2%7D%2528%3F:%5C.%5Cd*%2529%3F%2529%2529%3F%2528%3F:%2528%5B%2B-%5D%2528%3F:%5Cd%7B2%7D%2529:%3F%2528%3F:%5Cd%7B2%7D%2529%3F%7CZ%2529%3F%2529%2529%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20%5C%7C%20httpx%20%5C%7C%20INFO%5C%5D%20HTTP%20Request:%20GET%20%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%2528%20%5C%22%7C%3D%7C%5C%2528%7C%3D%3D%2529%3F%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%2528%20%7C%20%5C%22%7C%3D%7C%5C%2529%2529%3F%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%2528%20%7C%20%5C%22%7C%3D%2529%3F%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D*%2528%5C%22%7C%20%7C%20%5C%22%7C%3D%2529%3F%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D*%2528%5C%22%7C%20%7C%20%5C%22%7C%3D%2529%3F%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D*%2528%20%7C%5C%22%7C%3D%20%5C%22%2529%3F%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D*%2528%5C%22%7C%20%2529%3F%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D*%2528%5C%22%7C%20%2529%3F%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D*%22%2529%0A--End%20of%20hide%20similar%20entries%0Atimestamp%3D%222024-02-21T09:55:20.056323035Z%22%0AinsertId%3D%22gnvep3eyw4qz%22;startTime=2024-02-21T07:00:14.204Z?project=soy-audio-379412) during the client shutdown. While this is not ideal, it should not make the component fail.

I'm just wondering if we should fix it one level up and wrap the `component.teardown()` method in the `try ... exctept ...` block instead.