### PR TITLE
Move convert-string into component setup method

### DIFF
--- a/src/fondant/component/component.py
+++ b/src/fondant/component/component.py
@@ -47,6 +47,9 @@ class DaskComponent(BaseComponent):
         super().__init__()
 
     def setup(self) -> t.Any:
+        # Don't assume every object is a string
+        # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
+        dask.config.set({"dataframe.convert-string": False})
         # worker.daemon is set to false because creating a worker process in daemon
         # mode is not possible in our docker container setup.
         dask.config.set({"distributed.worker.daemon": False})

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -3,7 +3,6 @@ import os
 import typing as t
 from collections import defaultdict
 
-import dask
 import dask.dataframe as dd
 from dask.diagnostics import ProgressBar
 from dask.distributed import Client
@@ -31,10 +30,6 @@ class DaskDataLoader(DataIO):
         input_partition_rows: t.Optional[int] = None,
     ):
         super().__init__(manifest=manifest, operation_spec=operation_spec)
-        # Don't assume every object is a string
-        # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
-        dask.config.set({"dataframe.convert-string": False})
-
         self.input_partition_rows = input_partition_rows
 
     def partition_loaded_dataframe(self, dataframe: dd.DataFrame) -> dd.DataFrame:


### PR DESCRIPTION
Dask config needs to be set before starting the `LocalCluster`. I first put it into the `DaskDataIO` since it's central to the working of Fondant that this is set correctly, and I didn't want this to be overwritten. That's too late in our flow though. The other place we could put it is in the executor, but we currently try to keep that Dask-agnostic.