### PR TITLE
Temporarily disabled exposing the Dask diagnostic dashboard 

### DIFF
--- a/src/fondant/pipeline/compiler.py
+++ b/src/fondant/pipeline/compiler.py
@@ -27,6 +27,12 @@ from fondant.pipeline import (
 logger = logging.getLogger(__name__)
 
 DASK_DIAGNOSTIC_DASHBOARD_PORT = 8787
+
+# Temporarily disabled exposing the Dask diagnostic dashboard port to the docker setup.
+# Executing docker containers after each other using docker compose,
+# leads sometimes to the case that the port is already in use.
+EXPOSING_DASK_DIAGNOSTIC_DASHBOARD = False
+
 KubeflowCommandArguments = t.List[t.Union[str, t.Dict[str, str]]]
 
 
@@ -259,16 +265,16 @@ class DockerCompiler(Compiler):
                 volumes.extend(extra_volumes)
 
             ports: t.List[t.Union[str, dict]] = []
-            ports.append(
-                f"{DASK_DIAGNOSTIC_DASHBOARD_PORT}:{DASK_DIAGNOSTIC_DASHBOARD_PORT}",
-            )
+            if EXPOSING_DASK_DIAGNOSTIC_DASHBOARD:
+                ports.append(
+                    f"{DASK_DIAGNOSTIC_DASHBOARD_PORT}:{DASK_DIAGNOSTIC_DASHBOARD_PORT}",
+                )
 
             services[component_id] = {
                 "entrypoint": entrypoint,
                 "command": command,
                 "depends_on": depends_on,
                 "volumes": volumes,
-                "ports": ports,
                 "labels": {
                     "pipeline_description": pipeline.description,
                 },

--- a/src/fondant/pipeline/compiler.py
+++ b/src/fondant/pipeline/compiler.py
@@ -26,7 +26,8 @@ from fondant.pipeline import (
 
 logger = logging.getLogger(__name__)
 
-DASK_DIAGNOSTIC_DASHBOARD_PORT = 8787
+# export DASK_DIAGNOSTICS_PORT="" to get a dynamic port assigned
+DASK_DIAGNOSTICS_PORT = os.environ.get("DASK_DIAGNOSTICS_PORT", ":8787")
 
 KubeflowCommandArguments = t.List[t.Union[str, t.Dict[str, str]]]
 
@@ -259,7 +260,7 @@ class DockerCompiler(Compiler):
             if extra_volumes:
                 volumes.extend(extra_volumes)
 
-            ports: t.List[int] = [DASK_DIAGNOSTIC_DASHBOARD_PORT]
+            ports = [f"8787{DASK_DIAGNOSTICS_PORT}"]
 
             services[component_id] = {
                 "entrypoint": entrypoint,

--- a/src/fondant/pipeline/compiler.py
+++ b/src/fondant/pipeline/compiler.py
@@ -28,11 +28,6 @@ logger = logging.getLogger(__name__)
 
 DASK_DIAGNOSTIC_DASHBOARD_PORT = 8787
 
-# Temporarily disabled exposing the Dask diagnostic dashboard port to the docker setup.
-# Executing docker containers after each other using docker compose,
-# leads sometimes to the case that the port is already in use.
-EXPOSING_DASK_DIAGNOSTIC_DASHBOARD = False
-
 KubeflowCommandArguments = t.List[t.Union[str, t.Dict[str, str]]]
 
 
@@ -264,17 +259,14 @@ class DockerCompiler(Compiler):
             if extra_volumes:
                 volumes.extend(extra_volumes)
 
-            ports: t.List[t.Union[str, dict]] = []
-            if EXPOSING_DASK_DIAGNOSTIC_DASHBOARD:
-                ports.append(
-                    f"{DASK_DIAGNOSTIC_DASHBOARD_PORT}:{DASK_DIAGNOSTIC_DASHBOARD_PORT}",
-                )
+            ports: t.List[int] = [DASK_DIAGNOSTIC_DASHBOARD_PORT]
 
             services[component_id] = {
                 "entrypoint": entrypoint,
                 "command": command,
                 "depends_on": depends_on,
                 "volumes": volumes,
+                "ports": ports,
                 "labels": {
                     "pipeline_description": pipeline.description,
                 },


### PR DESCRIPTION
Temporarily disabled exposing the Dask diagnostic dashboard  port to the docker setup.
Executing docker containers after each other using docker compose, leads sometimes to the case that the port is already in use.

We should come up with a solution if we want to use the dask dashboard again. 

Fix: #870 