### PR TITLE
Specify schema when writing to parquet in write_to_file component

### DIFF
--- a/src/fondant/components/write_to_file/src/main.py
+++ b/src/fondant/components/write_to_file/src/main.py
@@ -21,7 +21,8 @@ class WriteToFile(DaskWriteComponent):
             self.path = self.path + "/export-*.csv"
             dataframe.to_csv(self.path)
         elif self.format.lower() == "parquet":
-            dataframe.to_parquet(self.path)
+            schema = {field.name: field.type.value for field in self.consumes.values()}
+            dataframe.to_parquet(self.path, schema=schema, write_metadata_file=True)
         else:
             msg = (
                 f"Not supported file format {self.format}. Writing to file is only "


### PR DESCRIPTION
I ran into some issues writing embeddings with this component since the inferred schema was incorrect. Specifying it explicitly solved it.