### PR TITLE
Don't write metadata file

### DIFF
--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 
 import dask.dataframe as dd
 from dask.diagnostics import ProgressBar
-from dask.distributed import Client
 
 from fondant.core.component_spec import OperationSpec
 from fondant.core.manifest import Manifest
@@ -157,7 +156,6 @@ class DaskDataWriter(DataIO):
     def write_dataframe(
         self,
         dataframe: dd.DataFrame,
-        dask_client: t.Optional[Client] = None,
     ) -> None:
         dataframe.index = dataframe.index.rename(DEFAULT_INDEX_NAME)
 
@@ -176,7 +174,7 @@ class DaskDataWriter(DataIO):
 
         with ProgressBar():
             logging.info("Writing data...")
-            dd.compute(write_task, scheduler=dask_client)
+            dd.compute(write_task)
 
     @staticmethod
     def validate_dataframe_columns(dataframe: dd.DataFrame, columns: t.List[str]):
@@ -234,7 +232,6 @@ class DaskDataWriter(DataIO):
             schema=schema,
             overwrite=False,
             compute=False,
-            write_metadata_file=True,
         )
         logging.info(f"Creating write task for: {location}")
         return write_task


### PR DESCRIPTION
We reintroduced writing the metadata file in #864 to preserve the divisions of the data when writing and reading again. We turned this behavior off in the past, but without proper documentation of the reason.

I'm now running into issues with Dask workers dying when writing large datasets though, presumably because of the metadata file, as documented in these Dask issues:
- https://github.com/dask/dask/issues/6600
- https://github.com/dask/dask/issues/3873
- https://github.com/dask/dask/issues/8901

Also, while I ran into issues with the preservation of divisions before, I can't reproduce this locally with a small example. Let's turn writing metadata off again and validate if we are still having issues with this.