### PR TITLE
Allow more supported docker versions

### DIFF
--- a/src/fondant/pipeline/runner.py
+++ b/src/fondant/pipeline/runner.py
@@ -113,10 +113,10 @@ class DockerRunner(Runner):
             )
             docker_version = DockerRunner._versionify(res)
 
-            if docker_version <= (24, 0, 0):
+            if docker_version <= (20, 10, 0):
                 sys.exit(
                     "Docker version is not compatible. Please make sure "
-                    "You have Docker version 24.0.0 or higher installed. "
+                    "You have Docker version 20.10.0 or higher installed. "
                     "Your current version is: " + res,
                 )
 

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -101,7 +101,7 @@ def test_docker_is_not_available():
 def test_docker_version_is_not_supported():
     expected_msg = (
         "Docker version is not compatible. Please make sure "
-        "You have Docker version 24.0.0 or higher installed. "
+        "You have Docker version 20.10.0 or higher installed. "
         "Your current version is: "
     )
     with mock.patch(


### PR DESCRIPTION
The docker version installed on the VM I'm using is `20.10.17` and everything is working if I remove this check. So we can lower it to support a wider range.