### PR TITLE
Enable timezone type for timestamp pyarrow type

### DIFF
--- a/src/fondant/core/schema.py
+++ b/src/fondant/core/schema.py
@@ -159,6 +159,7 @@ class Type:
             else:
                 type_ = cls._validate_data_type(data_type)
             validated_fields.append(pa.field(name, type_))
+
         return cls(pa.struct(validated_fields))
 
     @classmethod
@@ -194,16 +195,17 @@ class Type:
             if not isinstance(properties, dict):
                 msg = "Invalid 'properties' type in object schema."
                 raise InvalidTypeSchema(msg)
-            fields = [(name, cls.from_dict(prop)) for name, prop in properties.items()]
-            return cls.struct(fields)
 
-        if type_name == "timestamp":
-            return cls(type_name)
+            fields = [(name, cls.from_dict(prop)) for name, prop in properties.items()]
+
+            return cls.struct(fields)
 
         if isinstance(type_name, str):
             type_format = json_schema.get("format", None)
+
             if type_format == "date-time":
                 return cls(pa.timestamp("us", tz="UTC"))
+
             return cls(type_name)
 
         msg = f"Invalid 'type' value: {type_name}"
@@ -220,6 +222,7 @@ class Type:
             items = self.value.value_type
             if isinstance(items, pa.DataType):
                 return {"type": "array", "items": Type(items).to_dict()}
+
         elif isinstance(self.value, pa.StructType):
             fields = [(field.name, Type(field.type).to_dict()) for field in self.value]
             return {"type": "object", "properties": dict(fields)}

--- a/src/fondant/core/schema.py
+++ b/src/fondant/core/schema.py
@@ -197,7 +197,13 @@ class Type:
             fields = [(name, cls.from_dict(prop)) for name, prop in properties.items()]
             return cls.struct(fields)
 
+        if type_name == "timestamp":
+            return cls(type_name)
+
         if isinstance(type_name, str):
+            type_format = json_schema.get("format", None)
+            if type_format == "date-time":
+                return cls(pa.timestamp("us", tz="UTC"))
             return cls(type_name)
 
         msg = f"Invalid 'type' value: {type_name}"
@@ -217,6 +223,9 @@ class Type:
         elif isinstance(self.value, pa.StructType):
             fields = [(field.name, Type(field.type).to_dict()) for field in self.value]
             return {"type": "object", "properties": dict(fields)}
+
+        elif isinstance(self.value, pa.TimestampType):
+            return {"type": "string", "format": "date-time"}
 
         type_ = None
         for type_name, data_type in _TYPES.items():

--- a/src/fondant/core/schemas/common.json
+++ b/src/fondant/core/schemas/common.json
@@ -38,6 +38,10 @@
           "type": "string",
           "$ref": "#/definitions/subset_data_type"
         },
+        "format": {
+          "type": "string",
+          "description": "additional format information for the field"
+        },
         "properties": {
           "type": "object",
           "properties": {

--- a/tests/component/examples/component_specs/component.yaml
+++ b/tests/component/examples/component_specs/component.yaml
@@ -30,6 +30,9 @@ produces:
         number:
           type: int32
 
+  date:
+    type: string
+    format: date-time
 
 args:
   flag:

--- a/tests/component/test_component.py
+++ b/tests/component/test_component.py
@@ -55,6 +55,11 @@ def _patched_data_loading(monkeypatch):
         return dd.from_dict(
             {
                 "images_data": [1, 2, 3],
+                "date": [
+                    "2024-02-29T12:30:45",
+                    "2024-02-29T12:30:45",
+                    "2024-02-29T12:30:45",
+                ],
                 "element": [
                     ("1", 1),
                     ("2", 2),

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -11,6 +11,10 @@ def test_valid_type():
     assert Type.list(Type("int8")).value == pa.list_(pa.int8())
     assert Type.list(Type.list(Type("string"))).value == pa.list_(pa.list_(pa.string()))
     assert Type("int8").to_dict() == {"type": "int8"}
+    assert Type(pa.timestamp("us", tz="UTC")).to_dict() == {
+        "type": "string",
+        "format": "date-time",
+    }
     assert Type.list("float32").to_dict() == {
         "type": "array",
         "items": {"type": "float32"},
@@ -42,6 +46,9 @@ def test_valid_json_schema():
     assert Type.from_dict(
         {"type": "array", "items": {"type": "array", "items": {"type": "int8"}}},
     ).value == pa.list_(pa.list_(pa.int8()))
+    assert Type.from_dict(
+        {"type": "string", "format": "date-time"},
+    ).value == pa.timestamp("us", tz="UTC")
     assert Type.from_dict(
         {
             "type": "object",


### PR DESCRIPTION
Fixes https://github.com/ml6team/fondant/issues/882

openapi spec: https://swagger.io/docs/specification/data-models/data-types/#:~:text=date%2Dtime%20%E2%80%93%20the%20date%2Dtime%20notation%20as%20defined%20by%20RFC%203339%2C%20section%205.6%2C%20for%20example%2C%202017%2D07%2D21T17%3A32%3A28Z

