### PR TITLE
Don't run build action on every PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Merged this accidentally. FYI, the `workflow_dispatch` event means you can already trigger this workflow manually for a PR via the actions page.