### PR TITLE
Initialise dataset from manifest

### DIFF
--- a/examples/sample_pipeline/pipeline.py
+++ b/examples/sample_pipeline/pipeline.py
@@ -8,26 +8,20 @@ import pandas as pd
 import pyarrow as pa
 
 from fondant.component import PandasTransformComponent
-from fondant.dataset import Workspace, lightweight_component, Dataset
-
-BASE_PATH = Path("./.artifacts").resolve()
-
-# Define pipeline
-workspace = Workspace(name="dummy-pipeline", base_path=str(BASE_PATH))
+from fondant.dataset import lightweight_component, Dataset
 
 # Load from hub component
 load_component_column_mapping = {
     "text": "text_data",
 }
 
-dataset = Dataset.read(
+dataset = Dataset.create(
     "load_from_parquet",
     arguments={
         "dataset_uri": "/data/sample.parquet",
         "column_name_mapping": load_component_column_mapping,
     },
     produces={"text_data": pa.string()},
-    workspace=workspace,
 )
 
 dataset = dataset.apply("./components/dummy_component")

--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from types import ModuleType
 
 from fondant.core.schema import CloudCredentialsMount
-from fondant.dataset import Dataset, Workspace
+from fondant.dataset import Dataset
 
 if t.TYPE_CHECKING:
     from fondant.component import Component
@@ -610,12 +610,9 @@ def run_local(args):
     # use workspace from cli command
     # if args.workspace exists
 
-    workspace = getattr(args, "workspace", None)
-    if workspace is None:
-        workspace = Workspace(
-            name="dummy_workspace",
-            base_path=".artifacts",
-        )  # TODO: handle in #887 -> retrieve global workspace or init default one
+    working_directory = getattr(args, "working_directory", None)
+    if working_directory is None:
+        working_directory = "./.fondant"
 
     if args.extra_volumes:
         extra_volumes.extend(args.extra_volumes)
@@ -628,7 +625,7 @@ def run_local(args):
     runner = DockerRunner()
     runner.run(
         dataset=dataset,
-        workspace=workspace,
+        working_directory=working_directory,
         extra_volumes=extra_volumes,
         build_args=args.build_arg,
         auth_provider=args.auth_provider,

--- a/src/fondant/cli.py
+++ b/src/fondant/cli.py
@@ -607,12 +607,10 @@ def run_local(args):
     from fondant.dataset.runner import DockerRunner
 
     extra_volumes = []
-    # use workspace from cli command
-    # if args.workspace exists
 
     working_directory = getattr(args, "working_directory", None)
     if working_directory is None:
-        working_directory = "./.fondant"
+        working_directory = "./.artifacts/dataset"
 
     if args.extra_volumes:
         extra_volumes.extend(args.extra_volumes)
@@ -644,7 +642,12 @@ def run_kfp(args):
         ref = args.ref
 
     runner = KubeflowRunner(host=args.host)
-    runner.run(dataset=ref)
+
+    working_directory = getattr(args, "working_directory", None)
+    if working_directory is None:
+        working_directory = "./.artifacts/dataset"
+
+    runner.run(dataset=ref, working_directory=working_directory)
 
 
 def run_vertex(args):
@@ -661,7 +664,12 @@ def run_vertex(args):
         service_account=args.service_account,
         network=args.network,
     )
-    runner.run(input=ref)
+
+    working_directory = getattr(args, "working_directory", None)
+    if working_directory is None:
+        working_directory = "./.artifacts/dataset"
+
+    runner.run(input=ref, working_directory=working_directory)
 
 
 def run_sagemaker(args):
@@ -673,10 +681,16 @@ def run_sagemaker(args):
         ref = args.ref
 
     runner = SagemakerRunner()
+
+    working_directory = getattr(args, "working_directory", None)
+    if working_directory is None:
+        working_directory = "./.artifacts/dataset"
+
     runner.run(
         input=ref,
         pipeline_name=args.pipeline_name,
         role_arn=args.role_arn,
+        working_directory=working_directory,
     )
 
 
@@ -702,6 +716,12 @@ def register_execute(parent_parser):
     )
     parser.add_argument(
         "ref",
+        help="""Reference to the module containing the component to run""",
+        action="store",
+    )
+
+    parser.add_argument(
+        "working_directory",
         help="""Reference to the module containing the component to run""",
         action="store",
     )

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -196,10 +196,7 @@ class DaskDataWriter(DataIO):
 
     def _write_dataframe(self, dataframe: dd.DataFrame) -> None:
         """Create dataframe writing task."""
-        location = (
-            f"{self.manifest.base_path}/{self.manifest.pipeline_name}/"
-            f"{self.manifest.run_id}/{self.operation_spec.component_name}"
-        )
+        location = self.manifest.dataset_location
 
         # Create directory the dataframe will be written to, since this is not handled by Pandas
         # `to_parquet` method.

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -196,24 +196,23 @@ class DaskDataWriter(DataIO):
 
     def _write_dataframe(self, dataframe: dd.DataFrame) -> None:
         """Create dataframe writing task."""
-        location = self.manifest.get_dataset_locations(columns=dataframe.columns)
+        location = self.manifest.get_dataset_columns_locations(
+            columns=dataframe.columns,
+        )
 
         if len(set(location)) > 1:
-            logger.warning(
-                "Writing to multiple locations is currently not supported. "
-                "Using the first location.",
+            msg = "Writing to multiple locations is currently not supported."
+            raise ValueError(
+                msg,
             )
-        location = location[0]
 
-        if location is None:
-            msg = "No location found to write the dataframe to."
-            raise ValueError(msg)
+        output_location_path = location[0]
 
         # Create directory the dataframe will be written to, since this is not handled by Pandas
         # `to_parquet` method.
-        protocol = fsspec.utils.get_protocol(location)
+        protocol = fsspec.utils.get_protocol(output_location_path)
         fs = fsspec.get_filesystem_class(protocol)
-        fs().makedirs(location)
+        fs().makedirs(output_location_path)
 
         schema = {
             field.name: field.type.value
@@ -234,7 +233,7 @@ class DaskDataWriter(DataIO):
         # https://dask.discourse.group/t/improving-pipeline-resilience-when-using-to-parquet-and-preemptible-workers/2141
         to_parquet_tasks = [
             d.to_parquet(
-                os.path.join(location, f"part.{i}.parquet"),
+                os.path.join(output_location_path, f"part.{i}.parquet"),
                 schema=pa.schema(list(schema.items())),
                 index=True,
             )

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -196,7 +196,18 @@ class DaskDataWriter(DataIO):
 
     def _write_dataframe(self, dataframe: dd.DataFrame) -> None:
         """Create dataframe writing task."""
-        location = self.manifest.dataset_location
+        location = self.manifest.get_dataset_locations(columns=dataframe.columns)
+
+        if len(set(location)) > 1:
+            logger.warning(
+                "Writing to multiple locations is currently not supported. "
+                "Using the first location.",
+            )
+        location = location[0]
+
+        if location is None:
+            msg = "No location found to write the dataframe to."
+            raise ValueError(msg)
 
         # Create directory the dataframe will be written to, since this is not handled by Pandas
         # `to_parquet` method.

--- a/src/fondant/component/executor.py
+++ b/src/fondant/component/executor.py
@@ -312,8 +312,6 @@ class Executor(t.Generic[Component]):
             component_cls: The class of the component to execute
         """
         input_manifest = self._load_or_create_manifest()
-        base_path = input_manifest.base_path
-        pipeline_name = input_manifest.pipeline_name
 
         if self.cache and self._is_previous_cached(input_manifest):
             cache_reference_content = self._get_cache_reference_content()
@@ -342,8 +340,8 @@ class Executor(t.Generic[Component]):
             self.upload_manifest(output_manifest, save_path=self.output_manifest_path)
 
         self._upload_cache_reference_content(
-            base_path=base_path,
-            pipeline_name=pipeline_name,
+            base_path="todo",
+            pipeline_name="todo",
         )
 
     def _upload_cache_reference_content(
@@ -408,8 +406,7 @@ class DaskLoadExecutor(Executor[DaskLoadComponent]):
 
     def _load_or_create_manifest(self) -> Manifest:
         return Manifest.create(
-            pipeline_name=self.metadata.pipeline_name,
-            base_path=self.metadata.base_path,
+            dataset_name=self.metadata.dataset_name,
             run_id=self.metadata.run_id,
             component_id=self.metadata.component_id,
             cache_key=self.metadata.cache_key,

--- a/src/fondant/component/executor.py
+++ b/src/fondant/component/executor.py
@@ -314,6 +314,8 @@ class Executor(t.Generic[Component]):
         input_manifest = self._load_or_create_manifest()
 
         if self.cache and self._is_previous_cached(input_manifest):
+            logger.info("Caching is currently temporarily disabled.")
+            """
             cache_reference_content = self._get_cache_reference_content()
 
             if cache_reference_content is not None:
@@ -331,7 +333,7 @@ class Executor(t.Generic[Component]):
                     output_manifest = None
             else:
                 output_manifest = self._run_execution(component_cls, input_manifest)
-
+            """
         else:
             logger.info("Caching disabled for the component")
             output_manifest = self._run_execution(component_cls, input_manifest)

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -30,7 +30,7 @@ class Metadata:
         cache_key: the cache key of the component.
     """
 
-    pipeline_name: str
+    dataset_name: t.Optional[str]
     run_id: str
     component_id: t.Optional[str]
     cache_key: t.Optional[str]
@@ -91,7 +91,7 @@ class Manifest:
     def create(
         cls,
         *,
-        pipeline_name: str,
+        dataset_name: t.Optional[str] = None,
         run_id: str,
         component_id: t.Optional[str] = None,
         cache_key: t.Optional[str] = None,
@@ -99,13 +99,13 @@ class Manifest:
         """Create an empty manifest.
 
         Args:
-            pipeline_name: the name of the pipeline
+            dataset_name: the name of the dataset
             run_id: The id of the current pipeline run
             component_id: The id of the current component being executed
             cache_key: The component cache key
         """
         metadata = Metadata(
-            pipeline_name=pipeline_name,
+            dataset_name=dataset_name,
             run_id=run_id,
             component_id=component_id,
             cache_key=cache_key,
@@ -113,7 +113,7 @@ class Manifest:
 
         specification = {
             "metadata": metadata.to_dict(),
-            "index": {"location": f"/{run_id}/{component_id}"},
+            "index": {},
             "fields": {},
         }
         return cls(specification)

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -141,12 +141,20 @@ class Manifest:
     def manifest_location(self):
         return self._specification["metadata"]["manifest_location"]
 
-    def get_dataset_locations(self, columns: t.List[str]) -> t.List[t.Optional[str]]:
-        """Select the fields which matching the column names and return the locations."""
+    def get_dataset_columns_locations(
+        self,
+        columns: t.List[str],
+    ) -> t.List[str]:
+        """Select the fields which matching the column names and return their locations."""
         relevant_fields = [
             field for _, field in self.fields.items() if field.name in columns
         ]
-        return [field.location for field in relevant_fields if isinstance(field, Field)]
+
+        return [
+            field.location
+            for field in relevant_fields
+            if isinstance(field, Field) and field.location
+        ]
 
     def copy(self) -> "Manifest":
         """Return a deep copy of itself."""

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -24,13 +24,15 @@ class Metadata:
     Class representing the Metadata of the manifest.
 
     Args:
-        pipeline_name: the name of the pipeline
+        dataset_name: the name of the pipeline
+        manifest_location: path to the manifest file itself
         run_id: the run id of the pipeline
         component_id: the name of the component
         cache_key: the cache key of the component.
     """
 
     dataset_name: t.Optional[str]
+    manifest_location: t.Optional[str]
     run_id: str
     component_id: t.Optional[str]
     cache_key: t.Optional[str]
@@ -127,8 +129,12 @@ class Manifest:
 
     def to_file(self, path: t.Union[str, Path]) -> None:
         """Dump the manifest to the file specified by the provided path."""
+        self._specification["manifest_location"] = path
         with fs_open(path, "w", encoding="utf-8", auto_mkdir=True) as file_:
             json.dump(self._specification, file_)
+
+    def get_location(self):
+        return self._specification["metadata"]["manifest_location"]
 
     def copy(self) -> "Manifest":
         """Return a deep copy of itself."""
@@ -271,6 +277,12 @@ class Manifest:
             evolved_manifest.add_or_update_field(field, overwrite=True)
 
         return evolved_manifest
+
+    def contains_data(self) -> bool:
+        """Check if the manifest contains data. Checks if any dataset fields exists.
+        Is false in case the dataset manifest was initialised but no data added yet. In this case
+        the manifest only contains metadata like dataset name and run id."""
+        return bool(self._specification["fields"])
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._specification!r})"

--- a/src/fondant/core/manifest.py
+++ b/src/fondant/core/manifest.py
@@ -121,9 +121,15 @@ class Manifest:
             dataset_location=dataset_location,
         )
 
+        index = (
+            {"location": f"{dataset_location}/index"}
+            if dataset_location is not None
+            else {}
+        )
+
         specification = {
             "metadata": metadata.to_dict(),
-            "index": {},
+            "index": index,
             "fields": {},
         }
         return cls(specification)
@@ -137,7 +143,7 @@ class Manifest:
 
     def to_file(self, path: t.Union[str, Path]) -> None:
         """Dump the manifest to the file specified by the provided path."""
-        self._specification["manifest_location"] = path
+        self._specification["metadata"]["manifest_location"] = path
         with fs_open(path, "w", encoding="utf-8", auto_mkdir=True) as file_:
             json.dump(self._specification, file_)
 
@@ -292,6 +298,7 @@ class Manifest:
     ):
         """Evolve the manifest index and field locations based on the component spec."""
         # Update index location as this is always rewritten
+        # TODO: handle index location - do we have to update/rewrite the index to the new location?
         if working_dir:
             field = Field.create(
                 name="index",

--- a/src/fondant/core/schema.py
+++ b/src/fondant/core/schema.py
@@ -261,7 +261,7 @@ class Field:
         self,
         name: str,
         type: Type = Type("null"),
-        location: str = "",
+        location: t.Optional[str] = None,
     ) -> None:
         self.name = name
         self.type = type
@@ -273,6 +273,33 @@ class Field:
 
     def __eq__(self, other):
         return vars(self) == vars(other)
+
+    @classmethod
+    def create(  # noqa: PLR0913
+        cls,
+        name: str,
+        run_id: str,
+        component_id: str,
+        dataset_name: str,
+        working_dir: t.Optional[str] = None,
+    ):
+        """Create a Field instance with the correct location based on the provided parameters."""
+        if working_dir:
+            location = f"{working_dir}/{dataset_name}/{run_id}/{component_id}"
+            return Field(name=name, location=location)
+        return Field(name=name)
+
+    def update_location(
+        self,
+        run_id: str,
+        component_id: str,
+        dataset_name: str,
+        working_dir: t.Optional[str] = None,
+    ):
+        """Update the location of the field based on the provided parameters."""
+        if working_dir:
+            self.location = f"{working_dir}/{dataset_name}/{run_id}/{component_id}"
+        return self
 
 
 def validate_partition_size(arg_value):

--- a/src/fondant/core/schemas/manifest.json
+++ b/src/fondant/core/schemas/manifest.json
@@ -5,11 +5,7 @@
     "metadata": {
       "type": "object",
       "properties": {
-        "base_path": {
-          "type": "string",
-          "format": "uri"
-        },
-        "pipeline_name": {
+        "dataset_name": {
           "type": "string"
         },
         "run_id": {
@@ -20,8 +16,7 @@
         }
       },
       "required": [
-        "base_path",
-        "pipeline_name",
+        "dataset_name",
         "run_id"
       ]
     },

--- a/src/fondant/core/schemas/manifest.json
+++ b/src/fondant/core/schemas/manifest.json
@@ -6,13 +6,13 @@
       "type": "object",
       "properties": {
         "dataset_name": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "manifest_location": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "run_id": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "component_id": {
           "type": ["string", "null"]
@@ -29,10 +29,7 @@
         "location": {
           "type": "string"
         }
-      },
-      "required": [
-        "location"
-      ]
+      }
     },
     "fields": {
       "$ref": "#/definitions/fields"
@@ -40,7 +37,6 @@
   },
   "required": [
     "metadata",
-    "index",
     "fields"
   ],
   "definitions": {
@@ -48,12 +44,11 @@
       "type": "object",
       "properties": {
         "location": {
-          "type": "string",
+          "type": ["string", "null"],
           "pattern": "/.*"
         }
       },
       "required": [
-        "location",
         "type"
       ]
     },

--- a/src/fondant/core/schemas/manifest.json
+++ b/src/fondant/core/schemas/manifest.json
@@ -8,6 +8,9 @@
         "dataset_name": {
           "type": "string"
         },
+        "manifest_location": {
+          "type": "string"
+        },
         "run_id": {
           "type": "string"
         },

--- a/src/fondant/dataset/__init__.py
+++ b/src/fondant/dataset/__init__.py
@@ -8,6 +8,5 @@ from .dataset import (  # noqa
     VALID_VERTEX_ACCELERATOR_TYPES,
     ComponentOp,
     Dataset,
-    Workspace,
     Resources,
 )

--- a/src/fondant/dataset/compiler.py
+++ b/src/fondant/dataset/compiler.py
@@ -508,8 +508,6 @@ class KubeFlowCompiler(Compiler):
             working_directory: path of the working directory
             output_path: the path where to save the Kubeflow pipeline spec
         """
-        # TODO: add method call to retrieve workspace context, and make passing workspace optional
-
         run_id = dataset.manifest.run_id
         dataset.validate(run_id=run_id)
         logger.info(f"Compiling {dataset.name} to {output_path}")
@@ -572,11 +570,14 @@ class KubeFlowCompiler(Compiler):
                     run_id=run_id,
                     component_id=component_name,
                     cache_key=component_cache_key,
+                    dataset_name="dataset",
+                    manifest_location=f"{working_directory}/{dataset.name}/{run_id}/{component_name}/manifest.json",
+                    dataset_location=f"{working_directory}/{dataset.name}/{run_id}/{component_name}/data",
                 )
 
                 output_manifest_path = (
                     f"{working_directory}/{metadata.dataset_name}/{metadata.run_id}/"
-                    f"{metadata.component_id}/manifest.json",
+                    f"{metadata.component_id}/manifest.json"
                 )
                 # Set the execution order of the component task to be after the previous
                 # component task.

--- a/src/fondant/dataset/compiler.py
+++ b/src/fondant/dataset/compiler.py
@@ -92,7 +92,7 @@ class DockerCompiler(Compiler):
         self,
         dataset: Dataset,
         *,
-        working_directory: t.Optional[str],
+        working_directory: t.Optional[str] = None,
         output_path: str = "docker-compose.yml",
         extra_volumes: t.Union[t.Optional[list], t.Optional[str]] = None,
         build_args: t.Optional[t.List[str]] = None,
@@ -276,7 +276,7 @@ class DockerCompiler(Compiler):
                 command.extend(
                     [
                         "--input_manifest_path",
-                        f"{dataset.manifest.manifest_location()}",
+                        f"{dataset.manifest.manifest_location}",
                     ],
                 )
 

--- a/src/fondant/dataset/compiler.py
+++ b/src/fondant/dataset/compiler.py
@@ -204,7 +204,7 @@ class DockerCompiler(Compiler):
 
         services = {}
 
-        dataset.validate(run_id=run_id)
+        dataset.validate()
 
         component_cache_key = None
 
@@ -509,7 +509,7 @@ class KubeFlowCompiler(Compiler):
             output_path: the path where to save the Kubeflow pipeline spec
         """
         run_id = dataset.manifest.run_id
-        dataset.validate(run_id=run_id)
+        dataset.validate()
         logger.info(f"Compiling {dataset.name} to {output_path}")
 
         def set_component_exec_args(
@@ -873,7 +873,7 @@ class SagemakerCompiler(Compiler):  # pragma: no cover
         self._check_ecr_pull_through_rule()
 
         run_id = dataset.manifest.run_id
-        dataset.validate(run_id=run_id)
+        dataset.validate()
 
         component_cache_key = None
 

--- a/src/fondant/dataset/dataset.py
+++ b/src/fondant/dataset/dataset.py
@@ -467,12 +467,8 @@ class Dataset:
     def __init__(
         self,
         manifest: Manifest,
-        name: t.Optional[str] = None,
         description: t.Optional[str] = None,
     ):
-        if name is not None:
-            self.name = self._validate_dataset_name(name)
-
         self.description = description
         self._graph: t.OrderedDict[str, t.Any] = OrderedDict()
         self.task_without_dependencies_added = False
@@ -482,7 +478,7 @@ class Dataset:
     def _validate_dataset_name(name: str) -> str:
         pattern = r"^[a-z0-9][a-z0-9_-]*$"
         if not re.match(pattern, name):
-            msg = f"The workspace name violates the pattern {pattern}"
+            msg = f"The dataset name violates the pattern {pattern}"
             raise InvalidWorkspaceDefinition(msg)
         return name
 
@@ -491,6 +487,11 @@ class Dataset:
         """Get a unique run ID for the workspace."""
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
         return f"{name}-{timestamp}"
+
+    @property
+    def name(self) -> str:
+        """The name of the dataset."""
+        return self.manifest.dataset_name
 
     def register_operation(
         self,
@@ -820,8 +821,6 @@ class Dataset:
         Returns:
             An intermediate dataset.
         """
-        # TODO: add method call to retrieve workspace context, and make passing workspace optional
-
         operation = ComponentOp.from_ref(
             ref,
             fields=self.fields,

--- a/src/fondant/dataset/dataset.py
+++ b/src/fondant/dataset/dataset.py
@@ -440,29 +440,6 @@ class ComponentOp:
         return get_nested_dict_hash(component_op_uid_dict)
 
 
-class Workspace:
-    """Workspace holding environment information for a Fondants execution environment."""
-
-    def __init__(
-        self,
-        name: str,
-        base_path: str,
-        description: t.Optional[str] = None,
-    ):
-        self.name = self._validate_workspace_name(name)
-        self.description = description
-        self.base_path = base_path
-        self.package_path = f"{name}.tgz"
-
-    @staticmethod
-    def _validate_workspace_name(name: str) -> str:
-        pattern = r"^[a-z0-9][a-z0-9_-]*$"
-        if not re.match(pattern, name):
-            msg = f"The workspace name violates the pattern {pattern}"
-            raise InvalidWorkspaceDefinition(msg)
-        return name
-
-
 class Dataset:
     def __init__(
         self,
@@ -492,6 +469,12 @@ class Dataset:
     def name(self) -> str:
         """The name of the dataset."""
         return self.manifest.dataset_name
+
+    @property
+    def package_path(self) -> t.Optional[str]:
+        if self.name:
+            return f"{self.name}.tgz"
+        return None
 
     def register_operation(
         self,

--- a/src/fondant/dataset/dataset.py
+++ b/src/fondant/dataset/dataset.py
@@ -576,7 +576,7 @@ class Dataset:
 
         self._graph = OrderedDict((node, self._graph[node]) for node in sorted_graph)
 
-    def validate(self, run_id: str):
+    def validate(self):
         """Sort and run validation on the pipeline definition.
 
         Args:
@@ -585,9 +585,9 @@ class Dataset:
 
         """
         self.sort_graph()
-        self._validate_dataset_definition(run_id)
+        self._validate_dataset_definition()
 
-    def _validate_dataset_definition(self, run_id: str):
+    def _validate_dataset_definition(self):
         """
         Validates the workspace definition by ensuring that the consumed and produced subsets and
         their associated fields match and are invoked in the correct order.
@@ -599,6 +599,7 @@ class Dataset:
             base_path: the base path where to store the pipelines artifacts
             run_id: the run id of the component
         """
+        run_id = self.manifest.run_id
         if len(self._graph.keys()) == 0:
             logger.info("No components defined in the pipeline. Nothing to validate.")
             return

--- a/src/fondant/dataset/runner.py
+++ b/src/fondant/dataset/runner.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 import yaml
 
 from fondant.core.schema import CloudCredentialsMount
-from fondant.dataset import Dataset, Workspace
+from fondant.dataset import Dataset
 from fondant.dataset.compiler import (
     DockerCompiler,
     KubeFlowCompiler,
@@ -54,7 +54,7 @@ class DockerRunner(Runner):
     def run(
         self,
         dataset: t.Union[Dataset, str],
-        workspace: Workspace,
+        working_directory: str,
         *,
         extra_volumes: t.Union[t.Optional[list], t.Optional[str]] = None,
         build_args: t.Optional[t.List[str]] = None,
@@ -64,7 +64,7 @@ class DockerRunner(Runner):
 
         Args:
             dataset: the dataset to compile or a path to an already compiled docker-compose spec
-            workspace: The workspace to operate in
+            working_directory: path of the working directory
             extra_volumes: a list of extra volumes (using the Short syntax:
              https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5)
              to mount in the docker-compose spec.
@@ -83,7 +83,7 @@ class DockerRunner(Runner):
             compiler = DockerCompiler()
             compiler.compile(
                 dataset,
-                workspace=workspace,
+                working_directory=working_directory,
                 output_path=output_path,
                 extra_volumes=extra_volumes,
                 build_args=build_args,
@@ -185,7 +185,7 @@ class KubeflowRunner(Runner):
     def run(
         self,
         dataset: t.Union[Dataset, str],
-        workspace: Workspace,
+        working_directory: str,
         *,
         experiment_name: str = "Default",
     ):
@@ -193,7 +193,7 @@ class KubeflowRunner(Runner):
 
         Args:
             dataset: the dataset to compile or a path to an already compiled sagemaker spec
-            workspace: workspace to operate in
+            working_directory: path of the working directory
             experiment_name: the name of the experiment to create
         """
         if isinstance(dataset, Dataset):
@@ -205,7 +205,7 @@ class KubeflowRunner(Runner):
             compiler = KubeFlowCompiler()
             compiler.compile(
                 dataset,
-                workspace,
+                working_directory=working_directory,
                 output_path=output_path,
             )
             self._run(output_path, experiment_name=experiment_name)
@@ -271,13 +271,13 @@ class VertexRunner(Runner):
     def run(
         self,
         dataset: t.Union[Dataset, str],
-        workspace: Workspace,
+        working_directory: str,
     ):
         """Run a pipeline, either from a compiled vertex spec or from a fondant pipeline.
 
         Args:
             dataset: the dataset to compile or a path to an already compiled sagemaker spec
-            workspace: workspace to operate in
+            working_directory: path of the working directory
         """
         if isinstance(dataset, Dataset):
             os.makedirs(".fondant", exist_ok=True)
@@ -288,7 +288,7 @@ class VertexRunner(Runner):
             compiler = VertexCompiler()
             compiler.compile(
                 dataset,
-                workspace,
+                working_directory=working_directory,
                 output_path=output_path,
             )
             self._run(output_path)
@@ -333,7 +333,7 @@ class SagemakerRunner(Runner):
     def run(
         self,
         dataset: t.Union[Dataset, str],
-        workspace: Workspace,
+        working_directory: str,
         pipeline_name: str,
         role_arn: str,
     ):
@@ -342,7 +342,7 @@ class SagemakerRunner(Runner):
 
         Args:
             dataset: the dataset to compile or a path to a already compiled sagemaker spec
-            workspace: workspace to operate in
+            working_directory: path of the working directory
             pipeline_name: the name of the pipeline to create
             role_arn: the Amazon Resource Name role to use for the processing steps,
             if none provided the `sagemaker.get_execution_role()` role will be used.
@@ -356,7 +356,7 @@ class SagemakerRunner(Runner):
             compiler = SagemakerCompiler()
             compiler.compile(
                 dataset=dataset,
-                workspace=workspace,
+                working_directory=working_directory,
                 output_path=output_path,
                 role_arn=role_arn,
             )

--- a/tests/component/examples/component_specs/arguments/input_manifest.json
+++ b/tests/component/examples/component_specs/arguments/input_manifest.json
@@ -1,7 +1,6 @@
 {
   "metadata": {
-    "pipeline_name": "example_pipeline",
-    "base_path": "tests/example_data/subsets_input/mock_base_path",
+    "dataset_name": "example_pipeline",
     "run_id": "example_pipeline_123",
     "component_id": "component_1",
     "cache_key": "00"

--- a/tests/component/examples/component_specs/input_manifest.json
+++ b/tests/component/examples/component_specs/input_manifest.json
@@ -1,16 +1,15 @@
 {
   "metadata": {
-    "pipeline_name": "test_pipeline",
-    "base_path": "/bucket",
+    "dataset_name": "test_pipeline",
     "run_id": "test_pipeline_12345",
     "component_id": "67890"
   },
   "index": {
-    "location": "/example_component"
+    "location": "/bucket/example_component"
   },
   "fields": {
     "data": {
-      "location": "/example_component",
+      "location": "/bucket/example_component",
       "type": "binary"
     }
   }

--- a/tests/component/examples/data/manifest.json
+++ b/tests/component/examples/data/manifest.json
@@ -1,29 +1,28 @@
 {
   "metadata": {
-    "pipeline_name": "test_pipeline",
-    "base_path": "tests/component/examples/data",
+    "dataset_name": "test_pipeline",
     "run_id": "test_pipeline_12345",
     "component_id": "67890"
   },
   "index": {
-    "location": "/test_pipeline_12345/component_1"
+    "location": "tests/component/examples/data/test_pipeline/test_pipeline_12345/component_1"
   },
   "fields": {
     "Name": {
       "type": "string",
-      "location": "/test_pipeline_12345/component_1"
+      "location": "tests/component/examples/data/test_pipeline/test_pipeline_12345/component_1"
     },
     "HP": {
       "type": "int32",
-      "location": "/test_pipeline_12345/component_1"
+      "location": "tests/component/examples/data/test_pipeline/test_pipeline_12345/component_1"
     },
     "Type 1": {
       "type": "string",
-      "location": "/test_pipeline_12345/component_2"
+      "location": "tests/component/examples/data/test_pipeline/test_pipeline_12345/component_2"
     },
     "Type 2": {
       "type": "string",
-      "location": "/test_pipeline_12345/component_2"
+      "location": "tests/component/examples/data/test_pipeline/test_pipeline_12345/component_2"
     }
   }
 }

--- a/tests/component/examples/mock_base_path/example_pipeline/example_pipeline_2023/component_1/manifest.json
+++ b/tests/component/examples/mock_base_path/example_pipeline/example_pipeline_2023/component_1/manifest.json
@@ -1,7 +1,6 @@
 {
   "metadata": {
-    "pipeline_name": "example_pipeline",
-    "base_path": "tests/example_data/subsets_input/mock_base_path",
+    "dataset_name": "example_pipeline",
     "run_id": "example_pipeline_2023",
     "component_id": "component_1",
     "cache_key": "42"

--- a/tests/component/test_component.py
+++ b/tests/component/test_component.py
@@ -39,8 +39,9 @@ def yaml_file_to_json_string(file_path):
 @pytest.fixture()
 def metadata():
     return Metadata(
-        pipeline_name="example_pipeline",
-        base_path=str(base_path),
+        dataset_name="example_pipeline",
+        manifest_location="/foo/bar/manifest.json",
+        dataset_location="/foo/bar/data",
         component_id="component_2",
         run_id="example_pipeline_2024",
         cache_key="42",

--- a/tests/component/test_component.py
+++ b/tests/component/test_component.py
@@ -93,7 +93,7 @@ def _patched_data_writing(monkeypatch):
     monkeypatch.setattr(
         Executor,
         "_upload_cache_reference_content",
-        lambda self, base_path, pipeline_name: None,
+        lambda self, working_directory, dataset_name: None,
     )
 
 
@@ -179,7 +179,6 @@ def test_component_arguments(metadata):
     }
 
 
-@pytest.mark.skip(reason="The caching is temporarily disabled.")
 def test_run_with_cache(metadata, monkeypatch):
     input_manifest_path = str(components_path / "arguments/input_manifest.json")
 
@@ -208,6 +207,8 @@ def test_run_with_cache(metadata, monkeypatch):
         "3.14",
         "--override_default_arg_with_none",
         "None",
+        "--working_directory",
+        str(base_path),
     ]
 
     class MyExecutor(Executor):
@@ -227,7 +228,6 @@ def test_run_with_cache(metadata, monkeypatch):
     assert executor._is_previous_cached(Manifest.from_file(input_manifest_path)) is True
 
 
-@pytest.mark.skip(reason="The caching is temporarily disabled.")
 def test_run_with_no_cache(metadata):
     input_manifest_path = str(components_path / "arguments/input_manifest.json")
 

--- a/tests/component/test_component.py
+++ b/tests/component/test_component.py
@@ -41,7 +41,6 @@ def metadata():
     return Metadata(
         dataset_name="example_pipeline",
         manifest_location="/foo/bar/manifest.json",
-        dataset_location="/foo/bar/data",
         component_id="component_2",
         run_id="example_pipeline_2024",
         cache_key="42",

--- a/tests/component/test_component.py
+++ b/tests/component/test_component.py
@@ -180,6 +180,7 @@ def test_component_arguments(metadata):
     }
 
 
+@pytest.mark.skip(reason="The caching is temporarily disabled.")
 def test_run_with_cache(metadata, monkeypatch):
     input_manifest_path = str(components_path / "arguments/input_manifest.json")
 
@@ -227,6 +228,7 @@ def test_run_with_cache(metadata, monkeypatch):
     assert executor._is_previous_cached(Manifest.from_file(input_manifest_path)) is True
 
 
+@pytest.mark.skip(reason="The caching is temporarily disabled.")
 def test_run_with_no_cache(metadata):
     input_manifest_path = str(components_path / "arguments/input_manifest.json")
 

--- a/tests/component/test_data_io.py
+++ b/tests/component/test_data_io.py
@@ -126,17 +126,30 @@ def test_write_dataset(
     columns = ["Name", "HP", "Type 1", "Type 2"]
     with tmp_path_factory.mktemp("temp") as temp_dir:
         # override the base path of the manifest with the temp dir
-        manifest.update_metadata("dataset_location", str(temp_dir) + "/data")
+        run_id = "01"
+        operation_spec = OperationSpec(component_spec)
+        output_manifest = manifest.evolve(
+            operation_spec=operation_spec,
+            run_id=run_id,
+            working_directory=str(temp_dir),
+        )
+
         data_writer = DaskDataWriter(
-            manifest=manifest,
-            operation_spec=OperationSpec(component_spec),
+            manifest=output_manifest,
+            operation_spec=operation_spec,
         )
 
         # write dataframe to temp dir
         data_writer.write_dataframe(dataframe)
         # read written data and assert
         dataframe = dd.read_parquet(
-            manifest.dataset_location,
+            str(temp_dir)
+            + "/"
+            + manifest.dataset_name
+            + "/"
+            + run_id
+            + "/"
+            + operation_spec.component_name,
         )
         assert len(dataframe) == NUMBER_OF_TEST_ROWS
         assert list(dataframe.columns) == columns
@@ -164,24 +177,36 @@ def test_write_dataset_custom_produces(
     expected_columns = ["LastName", "HealthPoints", "CustomFieldName", "Type 2"]
     with tmp_path_factory.mktemp("temp") as temp_dir:
         # override the base path of the manifest with the temp dir
-        manifest.update_metadata("dataset_location", str(temp_dir) + "/data")
+        run_id = "01"
+        operation_spec = OperationSpec(component_spec_produces, produces=produces)
+        output_manifest = manifest.evolve(
+            operation_spec=operation_spec,
+            run_id=run_id,
+            working_directory=str(temp_dir),
+        )
+
         data_writer = DaskDataWriter(
-            manifest=manifest,
-            operation_spec=OperationSpec(component_spec_produces, produces=produces),
+            manifest=output_manifest,
+            operation_spec=operation_spec,
         )
 
         # write dataframe to temp dir
         data_writer.write_dataframe(dataframe)
         # # read written data and assert
         dataframe = dd.read_parquet(
-            manifest.dataset_location,
+            str(temp_dir)
+            + "/"
+            + manifest.dataset_name
+            + "/"
+            + run_id
+            + "/"
+            + operation_spec.component_name,
         )
         assert len(dataframe) == NUMBER_OF_TEST_ROWS
         assert sorted(dataframe.columns) == sorted(expected_columns)
         assert dataframe.index.name == "id"
 
 
-# TODO: check if this is still needed?
 def test_write_reset_index(
     tmp_path_factory,
     dataframe,
@@ -194,14 +219,25 @@ def test_write_reset_index(
     """
     dataframe = dataframe.reset_index(drop=True)
     with tmp_path_factory.mktemp("temp") as fn:
-        manifest.update_metadata("dataset_location", str(fn) + "/data")
+        operation_spec = OperationSpec(component_spec)
+        output_manifest = manifest.evolve(
+            operation_spec=operation_spec,
+            run_id="01",
+            working_directory=str(fn),
+        )
 
         data_writer = DaskDataWriter(
-            manifest=manifest,
-            operation_spec=OperationSpec(component_spec),
+            manifest=output_manifest,
+            operation_spec=operation_spec,
         )
         data_writer.write_dataframe(dataframe)
-        dataframe = dd.read_parquet(manifest.dataset_location)
+        dataframe = dd.read_parquet(
+            str(fn)
+            + "/"
+            + manifest.dataset_name
+            + "/01/"
+            + operation_spec.component_name,
+        )
         assert dataframe.index.name == "id"
 
 
@@ -219,16 +255,27 @@ def test_write_divisions(  # noqa: PLR0913
     dataframe = dataframe.repartition(npartitions=partitions)
 
     with tmp_path_factory.mktemp("temp") as fn:
-        manifest.update_metadata("dataset_location", str(fn) + "/data")
+        operation_spec = OperationSpec(component_spec)
+        output_manifest = manifest.evolve(
+            operation_spec=operation_spec,
+            run_id="01",
+            working_directory=str(fn),
+        )
 
         data_writer = DaskDataWriter(
-            manifest=manifest,
-            operation_spec=OperationSpec(component_spec),
+            manifest=output_manifest,
+            operation_spec=operation_spec,
         )
 
         data_writer.write_dataframe(dataframe)
 
-        dataframe = dd.read_parquet(manifest.dataset_location)
+        dataframe = dd.read_parquet(
+            str(fn)
+            + "/"
+            + manifest.dataset_name
+            + "/01/"
+            + operation_spec.component_name,
+        )
         assert dataframe.index.name == "id"
         assert dataframe.npartitions == partitions
 

--- a/tests/core/examples/evolution_examples/1/output_manifest.json
+++ b/tests/core/examples/evolution_examples/1/output_manifest.json
@@ -1,36 +1,36 @@
 {
    "metadata":{
-      "pipeline_name":"test_pipeline",
-      "base_path":"gs://bucket",
+      "dataset_name":"test_dataset",
+      "manifest_location":"gs://bucket/dataset",
       "run_id":"custom_run_id",
       "component_id":"example_component"
    },
    "index":{
-      "location":"/custom_run_id/example_component"
+      "location":"gs://bucket/dataset/test_dataset/custom_run_id/example_component"
    },
    "fields": {
-      "images_width": {
+       "images_width": {
          "type": "int32",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "images_height": {
          "type": "int32",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "images_data": {
          "type": "binary",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "captions_data": {
          "type": "binary",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "embeddings_data": {
         "type": "array",
         "items": {
            "type": "float32"
         },
-        "location":"/custom_run_id/example_component"
+        "location":"gs://bucket/dataset/test_dataset/custom_run_id/example_component"
       }
    }
 }

--- a/tests/core/examples/evolution_examples/2/output_manifest.json
+++ b/tests/core/examples/evolution_examples/2/output_manifest.json
@@ -1,17 +1,17 @@
 {
    "metadata":{
-      "pipeline_name":"test_pipeline",
-      "base_path":"gs://bucket",
+      "dataset_name": "test_dataset",
+      "manifest_location": "gs://bucket/dataset",
       "run_id":"custom_run_id",
       "component_id":"example_component"
    },
    "index":{
-      "location":"/custom_run_id/example_component"
+      "location":"gs://bucket/dataset/test_dataset/custom_run_id/example_component"
    },
    "fields": {
       "images_data": {
          "type": "binary",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/test_dataset/custom_run_id/example_component"
       }
    }
 }

--- a/tests/core/examples/evolution_examples/3/output_manifest.json
+++ b/tests/core/examples/evolution_examples/3/output_manifest.json
@@ -1,29 +1,29 @@
 {
    "metadata":{
-      "pipeline_name":"test_pipeline",
-      "base_path":"gs://bucket",
+      "dataset_name":"test_dataset",
+      "manifest_location":"gs://bucket/dataset",
       "run_id":"custom_run_id",
       "component_id":"example_component_1"
    },
    "index":{
-      "location":"/custom_run_id/example_component_1"
+      "location":"gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
    },
    "fields": {
       "images_width": {
          "type": "int32",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "images_height": {
          "type": "int32",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "images_data": {
          "type": "string",
-         "location":"/custom_run_id/example_component_1"
+         "location":"gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
       },
       "captions_data": {
          "type": "binary",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       }
    }
 }

--- a/tests/core/examples/evolution_examples/4/output_manifest.json
+++ b/tests/core/examples/evolution_examples/4/output_manifest.json
@@ -1,29 +1,29 @@
 {
    "metadata":{
-      "pipeline_name":"test_pipeline",
-      "base_path":"gs://bucket",
+      "dataset_name":"test_dataset",
       "run_id":"custom_run_id",
+      "manifest_location": "gs://bucket/dataset",
       "component_id":"example_component_1"
    },
    "index":{
-      "location":"/custom_run_id/example_component_1"
+      "location":"gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
    },
    "fields": {
       "images_width": {
          "type": "int32",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "images_height": {
          "type": "int32",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "images_data": {
          "type": "binary",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "captions_data": {
          "type": "binary",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       }
    }
 }

--- a/tests/core/examples/evolution_examples/5/output_manifest.json
+++ b/tests/core/examples/evolution_examples/5/output_manifest.json
@@ -1,44 +1,44 @@
 {
   "metadata": {
-    "pipeline_name": "test_pipeline",
-    "base_path": "gs://bucket",
+    "dataset_name": "test_dataset",
+    "manifest_location": "gs://bucket/dataset",
     "run_id": "custom_run_id",
     "component_id": "example_component_1"
   },
   "index": {
-    "location": "/custom_run_id/example_component_1"
+    "location": "gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
   },
   "fields": {
     "images_width": {
       "type": "int32",
-      "location": "/custom_run_id/example_component"
+      "location": "gs://bucket/dataset/custom_run_id/example_component"
     },
     "images_height": {
       "type": "int32",
-      "location": "/custom_run_id/example_component"
+      "location": "gs://bucket/dataset/custom_run_id/example_component"
     },
     "images_data": {
       "type": "binary",
-      "location": "/custom_run_id/example_component"
+      "location": "gs://bucket/dataset/custom_run_id/example_component"
     },
     "captions_data": {
       "type": "binary",
-      "location": "/custom_run_id/example_component"
+      "location": "gs://bucket/dataset/custom_run_id/example_component"
     },
     "images_caption": {
       "type": "string",
-      "location": "/custom_run_id/example_component_1"
+      "location": "gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
     },
     "audio_array": {
       "type": "binary",
-      "location": "/custom_run_id/example_component_1"
+      "location": "gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
     },
     "embedding_data": {
       "type": "array",
       "items": {
         "type": "float32"
       },
-      "location": "/custom_run_id/example_component_1"
+      "location": "gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
     }
   }
 }

--- a/tests/core/examples/evolution_examples/6/output_manifest.json
+++ b/tests/core/examples/evolution_examples/6/output_manifest.json
@@ -1,37 +1,37 @@
 {
   "metadata": {
-    "pipeline_name": "test_pipeline",
-    "base_path": "gs://bucket",
+    "dataset_name": "test_dataset",
+    "manifest_location": "gs://bucket/dataset",
     "run_id": "custom_run_id",
     "component_id": "example_component_1"
   },
   "index": {
-    "location": "/custom_run_id/example_component_1"
+    "location": "gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
   },
   "fields": {
     "images_width": {
       "type": "int32",
-      "location": "/custom_run_id/example_component"
+      "location": "gs://bucket/dataset/custom_run_id/example_component"
     },
     "images_height": {
       "type": "int32",
-      "location": "/custom_run_id/example_component"
+      "location": "gs://bucket/dataset/custom_run_id/example_component"
     },
     "images_array": {
       "type": "binary",
-      "location": "/custom_run_id/example_component_1"
+      "location": "gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
     },
     "images_data": {
-      "location": "/custom_run_id/example_component",
+      "location": "gs://bucket/dataset/custom_run_id/example_component",
       "type": "binary"
     },
     "text_string": {
       "type": "string",
-      "location": "/custom_run_id/example_component_1"
+      "location": "gs://bucket/dataset/test_dataset/custom_run_id/example_component_1"
     },
     "captions_data": {
       "type": "binary",
-      "location": "/custom_run_id/example_component"
+      "location": "gs://bucket/dataset/custom_run_id/example_component"
     }
   }
 }

--- a/tests/core/examples/evolution_examples/input_manifest.json
+++ b/tests/core/examples/evolution_examples/input_manifest.json
@@ -1,29 +1,29 @@
 {
    "metadata":{
-      "pipeline_name":"test_pipeline",
-      "base_path":"gs://bucket",
+      "dataset_name":"test_dataset",
+      "manifest_location":"gs://bucket/dataset",
       "run_id":"12345",
       "component_id":"example_component"
    },
    "index":{
-      "location":"/custom_run_id/example_component"
+      "location":"gs://bucket/dataset/custom_run_id/example_component"
    },
    "fields": {
        "images_width": {
          "type": "int32",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "images_height": {
          "type": "int32",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "images_data": {
          "type": "binary",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       },
       "captions_data": {
          "type": "binary",
-         "location":"/custom_run_id/example_component"
+         "location":"gs://bucket/dataset/custom_run_id/example_component"
       }
    }
 }

--- a/tests/core/examples/manifests/valid_manifest.json
+++ b/tests/core/examples/manifests/valid_manifest.json
@@ -1,28 +1,29 @@
 {
   "metadata": {
-    "pipeline_name": "test_pipeline",
-    "base_path": "gs://bucket",
+    "dataset_name": "test_pipeline",
     "run_id": "test_pipeline_12345",
-    "component_id": "67890"
+    "component_id": "67890",
+    "manifest_location": "gs://bucket/component1/manifest.json",
+    "dataset_location": "gs://bucket/component1"
   },
   "index": {
-    "location": "/component1"
+    "location": "gs://bucket/component1"
   },
   "fields":{
     "images": {
-      "location": "/component1",
+      "location": "gs://bucket/component1",
       "type": "binary"
     },
     "height": {
-      "location": "/component2",
+      "location": "gs://bucket/component2",
       "type": "int32"
     },
     "width": {
-      "location": "/component2",
+      "location": "gs://bucket/component2",
       "type": "int32"
     },
     "caption": {
-      "location": "/component3",
+      "location": "gs://bucket/component3",
       "type": "string"
     }
   }

--- a/tests/core/test_manifest.py
+++ b/tests/core/test_manifest.py
@@ -30,16 +30,13 @@ def test_manifest_validation(valid_manifest, invalid_manifest):
         Manifest(invalid_manifest)
 
 
-def test_update_manifest_and_dataset_location(valid_manifest):
+def test_update_manifest_location(valid_manifest):
     """Test altering the base path in the manifest."""
     manifest = Manifest(valid_manifest)
     tmp_path = "/foo/bar"
     manifest.update_metadata(key="manifest_location", value=tmp_path + "/manifest.json")
-    manifest.update_metadata(key="dataset_location", value=tmp_path)
 
     assert manifest.manifest_location == tmp_path + "/manifest.json"
-    assert manifest.dataset_location == tmp_path
-    assert manifest._specification["metadata"]["dataset_location"] == tmp_path
     assert (
         manifest._specification["metadata"]["manifest_location"]
         == tmp_path + "/manifest.json"
@@ -84,7 +81,6 @@ def test_manifest_creation():
     component_id = "component_id"
     cache_key = "42"
     manifest_location = "/manifest.json"
-    dataset_location = "/data"
 
     manifest = Manifest.create(
         dataset_name=dataset_name,
@@ -92,7 +88,6 @@ def test_manifest_creation():
         component_id=component_id,
         cache_key=cache_key,
         manifest_location=manifest_location,
-        dataset_location=dataset_location,
     )
 
     location = f"/{run_id}/{component_id}"
@@ -114,9 +109,8 @@ def test_manifest_creation():
             "component_id": component_id,
             "cache_key": cache_key,
             "manifest_location": manifest_location,
-            "dataset_location": dataset_location,
         },
-        "index": {"location": f"{dataset_location}/index"},
+        "index": {},
         "fields": {
             "width": {
                 "type": "int32",
@@ -144,8 +138,8 @@ def test_manifest_repr():
     assert (
         manifest.__repr__()
         == "Manifest({'metadata': {'dataset_name': 'NAME', 'run_id': 'A', "
-        "'component_id': '1', 'cache_key': '42', 'manifest_location': None, "
-        "'dataset_location': None}, 'index': {}, 'fields': {}})"
+        "'component_id': '1', 'cache_key': '42', 'manifest_location': None}, "
+        "'index': {}, 'fields': {}})"
     )
 
 
@@ -197,7 +191,6 @@ def test_evolve_manifest():
         run_id=run_id,
         component_id="component_1",
         cache_key="42",
-        dataset_location="/foo",
     )
 
     output_manifest = input_manifest.evolve(

--- a/tests/core/test_manifest_evolution.py
+++ b/tests/core/test_manifest_evolution.py
@@ -87,6 +87,7 @@ def test_evolution(input_manifest, component_spec, output_manifest, test_conditi
         evolved_manifest = manifest.evolve(
             operation_spec=operation_spec,
             run_id=run_id,
+            working_directory="gs://bucket/dataset",
         )
         assert evolved_manifest._specification == output_manifest
 
@@ -112,22 +113,3 @@ def test_invalid_evolution_examples(
                 operation_spec=operation_spec,
                 run_id=run_id,
             )
-
-
-def test_component_spec_location_update():
-    with open(EXAMPLES_PATH / "input_manifest.json") as f:
-        input_manifest = json.load(f)
-
-    with open(EXAMPLES_PATH / "4/component.yaml") as f:
-        specification = yaml.safe_load(f)
-
-    manifest = Manifest(input_manifest)
-    component_spec = ComponentSpec.from_dict(specification)
-    evolved_manifest = manifest.evolve(
-        operation_spec=OperationSpec(component_spec),
-        run_id="123",
-    )
-
-    assert evolved_manifest.index.location.endswith(
-        component_spec.safe_name,
-    )

--- a/tests/examples/example_modules/dataset.py
+++ b/tests/examples/example_modules/dataset.py
@@ -2,11 +2,11 @@ from fondant.dataset import Dataset
 
 
 def create_dataset_with_args(name):
-    return Dataset(name)
+    return Dataset.create("load_from_parquet", dataset_name=name)
 
 
 def create_dataset():
-    return Dataset("test_dataset")
+    return Dataset.create("load_from_parquet", dataset_name="test_dataset")
 
 
 def not_implemented():

--- a/tests/examples/example_modules/invalid_double_workspace.py
+++ b/tests/examples/example_modules/invalid_double_workspace.py
@@ -1,4 +1,0 @@
-from fondant.dataset import Workspace
-
-TEST_WORKSPACE = Workspace(name="test_pipeline", base_path="some/path")
-TEST_WORKSPACE_2 = Workspace(name="test_pipeline", base_path="some/path")

--- a/tests/pipeline/test_compiler.py
+++ b/tests/pipeline/test_compiler.py
@@ -252,8 +252,6 @@ def test_docker_local_path(setup_pipeline, tmp_path_factory):
                 "component_id": component_name,
                 "manifest_location": f"{working_directory}/{dataset.name}/"
                 f"{expected_run_id}/{component_name}/manifest.json",
-                "dataset_location": f"{working_directory}/{dataset.name}/"
-                f"{expected_run_id}/{component_name}/data",
             }
 
             assert (
@@ -302,8 +300,6 @@ def test_docker_remote_path(setup_pipeline, tmp_path_factory):
                 "component_id": component_name,
                 "manifest_location": f"{working_directory}/{dataset.name}/"
                 f"{expected_run_id}/{component_name}/manifest.json",
-                "dataset_location": f"{working_directory}/{dataset.name}/"
-                f"{expected_run_id}/{component_name}/data",
             }
 
             assert (
@@ -772,7 +768,6 @@ def test_sagemaker_build_command():
     compiler = SagemakerCompiler()
     metadata = Metadata(
         dataset_name="example_pipeline",
-        dataset_location="/foo/bar/data",
         manifest_location="/foo/bar/manifest.json",
         component_id="component_2",
         run_id="example_pipeline_2024",
@@ -789,15 +784,16 @@ def test_sagemaker_build_command():
         "--metadata",
         '\'{"dataset_name": "example_pipeline", "run_id": "example_pipeline_2024", '
         '"component_id": "component_2", "cache_key": "42", "manifest_location": '
-        '"/foo/bar/manifest.json", "dataset_location": "/foo/bar/data"}\'',
+        '"/foo/bar/manifest.json"}\'',
         "--output_manifest_path",
         "/foo/bar/example_pipeline/example_pipeline_2024/component_2/manifest.json",
         "--foo",
         "'bar'",
         "--baz",
         "'qux'",
+        "--working_directory",
+        "/foo/bar",
     ]
-
     # with dependencies
     dependencies = ["component_1"]
 
@@ -809,9 +805,20 @@ def test_sagemaker_build_command():
     )
 
     assert command2 == [
-        *command,
+        "--metadata",
+        '\'{"dataset_name": "example_pipeline", "run_id": "example_pipeline_2024", '
+        '"component_id": "component_2", "cache_key": "42", "manifest_location": '
+        '"/foo/bar/manifest.json"}\'',
+        "--output_manifest_path",
+        "/foo/bar/example_pipeline/example_pipeline_2024/component_2/manifest.json",
+        "--foo",
+        "'bar'",
+        "--baz",
+        "'qux'",
         "--input_manifest_path",
         "/foo/bar/example_pipeline/example_pipeline_2024/component_1/manifest.json",
+        "--working_directory",
+        "/foo/bar",
     ]
 
 
@@ -863,7 +870,6 @@ def test_sagemaker_generate_script_lightweight_component(tmp_path_factory):
     metadata = Metadata(
         dataset_name="example_pipeline",
         manifest_location="/foo/bar/manifest.json",
-        dataset_location="/foo/bar/data",
         component_id="component_2",
         run_id="example_pipeline_2024",
         cache_key="42",

--- a/tests/pipeline/test_lightweight_component.py
+++ b/tests/pipeline/test_lightweight_component.py
@@ -166,7 +166,7 @@ def test_lightweight_component_sdk(default_fondant_image, load_pipeline):
         },
         "produces": {},
     }
-    dataset._validate_dataset_definition(run_id="dummy-run-id")
+    dataset._validate_dataset_definition()
 
     DockerCompiler().compile(dataset=dataset)
 

--- a/tests/pipeline/test_lightweight_component.py
+++ b/tests/pipeline/test_lightweight_component.py
@@ -171,7 +171,7 @@ def test_lightweight_component_sdk(default_fondant_image, load_pipeline):
         },
         "produces": {},
     }
-    dataset._validate_workspace_definition(run_id="dummy-run-id", workspace=workspace)
+    dataset._validate_dataset_definition(run_id="dummy-run-id", workspace=workspace)
 
     DockerCompiler().compile(dataset=dataset, workspace=workspace)
 

--- a/tests/pipeline/test_lightweight_component.py
+++ b/tests/pipeline/test_lightweight_component.py
@@ -86,7 +86,11 @@ def test_build_python_script(load_pipeline):
     )
 
 
-def test_lightweight_component_sdk(default_fondant_image, load_pipeline):
+def test_lightweight_component_sdk(
+    tmp_path_factory,
+    default_fondant_image,
+    load_pipeline,
+):
     dataset, load_script, caplog_records = load_pipeline
 
     assert len(dataset._graph.keys()) == 1
@@ -168,7 +172,8 @@ def test_lightweight_component_sdk(default_fondant_image, load_pipeline):
     }
     dataset._validate_dataset_definition()
 
-    DockerCompiler().compile(dataset=dataset)
+    with tmp_path_factory.mktemp("temp") as fn:
+        DockerCompiler().compile(dataset=dataset, working_directory=str(fn))
 
 
 def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
@@ -201,6 +206,7 @@ def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
         DockerCompiler().compile(
             dataset=dataset,
             output_path=output_path,
+            working_directory=str(fn),
         )
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
         operation_spec = OperationSpec.from_json(
@@ -240,6 +246,7 @@ def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
         DockerCompiler().compile(
             dataset=dataset,
             output_path=output_path,
+            working_directory=str(fn),
         )
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
         operation_spec = OperationSpec.from_json(
@@ -280,6 +287,7 @@ def test_consumes_mapping_additional_fields(tmp_path_factory, load_pipeline):
         DockerCompiler().compile(
             dataset=dataset,
             output_path=output_path,
+            working_directory=str(fn),
         )
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
         operation_spec = OperationSpec.from_json(
@@ -322,6 +330,7 @@ def test_produces_mapping_additional_fields(tmp_path_factory, load_pipeline):
         DockerCompiler().compile(
             dataset=dataset,
             output_path=output_path,
+            working_directory=str(fn),
         )
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
         operation_spec = OperationSpec.from_json(

--- a/tests/pipeline/test_lightweight_component.py
+++ b/tests/pipeline/test_lightweight_component.py
@@ -13,7 +13,7 @@ import pytest
 from fondant.component import DaskLoadComponent, PandasTransformComponent
 from fondant.core.component_spec import OperationSpec
 from fondant.core.exceptions import InvalidLightweightComponent
-from fondant.dataset import Dataset, Image, Workspace, lightweight_component
+from fondant.dataset import Dataset, Image, lightweight_component
 from fondant.dataset.compiler import DockerCompiler
 from fondant.testing import DockerComposeConfigs
 
@@ -29,11 +29,6 @@ def default_fondant_image():
 
 @pytest.fixture()
 def load_pipeline(caplog):
-    workspace = Workspace(
-        name="dummy-pipeline",
-        base_path="./data",
-    )
-
     @lightweight_component(
         base_image="python:3.10-slim-buster",
         extra_requires=["pandas", "dask"],
@@ -53,17 +48,17 @@ def load_pipeline(caplog):
 
     load_script = CreateData.image().script
 
-    dataset = Dataset.read(
+    dataset = Dataset.create(
         ref=CreateData,
-        workspace=workspace,
+        dataset_name="dummy-dataset",
     )
 
     caplog_records = caplog.records
-    return workspace, dataset, load_script, caplog_records
+    return dataset, load_script, caplog_records
 
 
 def test_build_python_script(load_pipeline):
-    _, _, load_script, _ = load_pipeline
+    _, load_script, _ = load_pipeline
     assert load_script == textwrap.dedent(
         """\
         from typing import *
@@ -92,7 +87,7 @@ def test_build_python_script(load_pipeline):
 
 
 def test_lightweight_component_sdk(default_fondant_image, load_pipeline):
-    workspace, dataset, load_script, caplog_records = load_pipeline
+    dataset, load_script, caplog_records = load_pipeline
 
     assert len(dataset._graph.keys()) == 1
     operation_spec_dict = dataset._graph["createdata"][
@@ -171,9 +166,9 @@ def test_lightweight_component_sdk(default_fondant_image, load_pipeline):
         },
         "produces": {},
     }
-    dataset._validate_dataset_definition(run_id="dummy-run-id", workspace=workspace)
+    dataset._validate_dataset_definition(run_id="dummy-run-id")
 
-    DockerCompiler().compile(dataset=dataset, workspace=workspace)
+    DockerCompiler().compile(dataset=dataset)
 
 
 def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
@@ -193,7 +188,7 @@ def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
             dataframe["a"] = dataframe["a"].map(lambda x: x + self.n)
             return dataframe
 
-    workspace, dataset, _, _ = load_pipeline
+    dataset, _, _ = load_pipeline
 
     _ = dataset.apply(
         ref=AddN,
@@ -205,7 +200,6 @@ def test_consumes_mapping_all_fields(tmp_path_factory, load_pipeline):
         output_path = str(fn / "kubeflow_pipeline.yml")
         DockerCompiler().compile(
             dataset=dataset,
-            workspace=workspace,
             output_path=output_path,
         )
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
@@ -233,7 +227,7 @@ def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
             dataframe["a"] = dataframe["a"].map(lambda x: x + self.n)
             return dataframe
 
-    workspace, dataset, _, _ = load_pipeline
+    dataset, _, _ = load_pipeline
 
     dataset = dataset.apply(
         ref=AddN,
@@ -245,7 +239,6 @@ def test_consumes_mapping_specific_fields(tmp_path_factory, load_pipeline):
         output_path = str(fn / "kubeflow_pipeline.yml")
         DockerCompiler().compile(
             dataset=dataset,
-            workspace=workspace,
             output_path=output_path,
         )
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
@@ -274,7 +267,7 @@ def test_consumes_mapping_additional_fields(tmp_path_factory, load_pipeline):
             dataframe["a"] = dataframe["x"].map(lambda x: x + self.n)
             return dataframe
 
-    workspace, dataset, _, _ = load_pipeline
+    dataset, _, _ = load_pipeline
 
     dataset = dataset.apply(
         ref=AddN,
@@ -286,7 +279,6 @@ def test_consumes_mapping_additional_fields(tmp_path_factory, load_pipeline):
         output_path = str(fn / "kubeflow_pipeline.yml")
         DockerCompiler().compile(
             dataset=dataset,
-            workspace=workspace,
             output_path=output_path,
         )
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
@@ -316,7 +308,7 @@ def test_produces_mapping_additional_fields(tmp_path_factory, load_pipeline):
             dataframe["c"] = dataframe["x"].map(lambda x: x + self.n)
             return dataframe
 
-    workspace, dataset, _, _ = load_pipeline
+    dataset, _, _ = load_pipeline
 
     dataset = dataset.apply(
         ref=AddN,
@@ -329,7 +321,6 @@ def test_produces_mapping_additional_fields(tmp_path_factory, load_pipeline):
         output_path = str(fn / "kubeflow_pipeline.yml")
         DockerCompiler().compile(
             dataset=dataset,
-            workspace=workspace,
             output_path=output_path,
         )
         pipeline_configs = DockerComposeConfigs.from_spec(output_path)
@@ -340,20 +331,14 @@ def test_produces_mapping_additional_fields(tmp_path_factory, load_pipeline):
 
 
 def test_lightweight_component_missing_decorator():
-    workspace = Workspace(
-        name="dummy-pipeline",
-        base_path="./data",
-    )
-
     class Foo(DaskLoadComponent):
         def load(self) -> str:
             return "bar"
 
     with pytest.raises(InvalidLightweightComponent):
-        Dataset.read(
+        Dataset.create(
             ref=Foo,
             produces={"x": pa.int32(), "y": pa.int32()},
-            workspace=workspace,
         )
 
 
@@ -372,14 +357,8 @@ def test_valid_load_component():
             )
             return dd.from_pandas(df, npartitions=1)
 
-    workspace = Workspace(
-        name="dummy-pipeline",
-        base_path="./data",
-    )
-
-    dataset = Dataset.read(
+    dataset = Dataset.create(
         ref=CreateData,
-        workspace=workspace,
     )
 
     assert len(dataset._graph.keys()) == 1
@@ -462,14 +441,8 @@ def test_lightweight_component_decorator_without_parentheses():
         def load(self) -> dd.DataFrame:
             return None
 
-    workspace = Workspace(
-        name="dummy-pipeline",
-        base_path="./data",
-    )
-
-    dataset = Dataset.read(
+    dataset = Dataset.create(
         ref=CreateData,
-        workspace=workspace,
     )
 
     assert len(dataset._graph.keys()) == 1
@@ -532,7 +505,7 @@ def test_infer_consumes_if_not_defined(load_pipeline):
     Test that the consumes mapping is inferred when not defined in dataset interface.
     All columns of the dataset are consumed.
     """
-    workspace, dataset, _, _ = load_pipeline
+    dataset, _, _ = load_pipeline
 
     @lightweight_component(
         base_image="python:3.10-slim-buster",
@@ -579,7 +552,7 @@ def test_infer_consumes_if_additional_properties_true(load_pipeline):
     Test when additional properties is true (no consumes defined in the lightweight component),
     the consumes is inferred from the dataset interface.
     """
-    workspace, dataset, _, _ = load_pipeline
+    dataset, _, _ = load_pipeline
 
     @lightweight_component(
         base_image="python:3.10-slim-buster",

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -242,7 +242,7 @@ def test_valid_pipeline(
     assert dataset._graph["third_component"]["dependencies"] == ["second_component"]
     assert dataset._graph["fourth_component"]["dependencies"] == ["third_component"]
 
-    dataset._validate_workspace_definition("test_pipeline", workspace)
+    dataset._validate_dataset_definition("test_pipeline", workspace)
 
 
 def test_invalid_pipeline_schema(
@@ -365,7 +365,7 @@ def test_invalid_pipeline_declaration(
     )
 
     with pytest.raises(InvalidWorkspaceDefinition):
-        dataset._validate_workspace_definition("test_pipeline", workspace)
+        dataset._validate_dataset_definition("test_pipeline", workspace)
 
 
 def test_reusable_component_op():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from fondant.cli import (
 )
 from fondant.component import DaskLoadComponent
 from fondant.component.executor import Executor, ExecutorFactory
+from fondant.core.manifest import Manifest
 from fondant.core.schema import CloudCredentialsMount
 from fondant.dataset import Dataset, Workspace
 from fondant.dataset.runner import DockerRunner
@@ -68,7 +69,8 @@ def test_basic_invocation(command):
     assert process.returncode == 0
 
 
-TEST_DATASET = Dataset(name="test_dataset", run_id="run-id-1")
+TEST_MANIFEST = Manifest.create(dataset_name="test_dataset", run_id="test_run_id")
+TEST_DATASET = Dataset(manifest=TEST_MANIFEST)
 TEST_WORKSPACE = Workspace("test_workspace", base_path="/dummy/path")
 
 
@@ -339,13 +341,13 @@ def test_local_run_cloud_credentials(mock_docker_installation):
                 credentials=None,
                 extra_volumes=[],
                 build_arg=[],
-                workspace=TEST_WORKSPACE,
+                working_directory="dummy-dir",
             )
             run_local(args)
 
             mock_compiler.assert_called_once_with(
                 TEST_DATASET,
-                workspace=TEST_WORKSPACE,
+                working_directory="dummy-dir",
                 output_path=".fondant/compose.yaml",
                 extra_volumes=[],
                 build_args=[],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ from fondant.component import DaskLoadComponent
 from fondant.component.executor import Executor, ExecutorFactory
 from fondant.core.manifest import Manifest
 from fondant.core.schema import CloudCredentialsMount
-from fondant.dataset import Dataset, Workspace
+from fondant.dataset import Dataset
 from fondant.dataset.runner import DockerRunner
 
 commands = [
@@ -71,7 +71,6 @@ def test_basic_invocation(command):
 
 TEST_MANIFEST = Manifest.create(dataset_name="test_dataset", run_id="test_run_id")
 TEST_DATASET = Dataset(manifest=TEST_MANIFEST)
-TEST_WORKSPACE = Workspace("test_workspace", base_path="/dummy/path")
 
 
 @pytest.mark.parametrize(
@@ -145,8 +144,6 @@ def test_pipeline_from_module(module_str):
     [
         # module does not contain a pipeline instance
         "examples.example_modules.component",
-        # module contains many pipeline instances
-        "examples.example_modules.invalid_double_workspace",
         # Factory expects an argument
         "examples.example_modules.dataset:create_pipeline_with_args",
         # Factory does not expect an argument


### PR DESCRIPTION
Implements the new workflow including initialising datasets from manifest. 

- removes workspace again, using working_directory argument now to enable something like `fondant run ... --working_directory gs://...`
- removes base_path from the manifest and changes the field location to absolute paths
- changes the executor to generate absolute field locations
- add `Dataset.read()` for initialising dataset from manifest path
- adjust compiler code


Try to create sketch out the flow and changes. Still have to fix the test cases and test the changes end to end for all runners. 

![image](https://github.com/ml6team/fondant/assets/15777729/8c330daf-2076-493c-aea2-b7d3f85884b8)
