### PR TITLE
Edit prep release pipeline - refresh aws token

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -59,6 +59,13 @@ jobs:
       - name: Build components
         run: ./scripts/build_components.sh -t $GITHUB_REF_NAME
 
+      # In case the build runs longer as 1h we need to refresh the token
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build data explorer
         run: ./scripts/build_explorer.sh -t $GITHUB_REF_NAME
 


### PR DESCRIPTION
Currently our release pipeline is failing. If all build steps take to long, the AWS token get invalid (valid for 1h). 
Added an additional authentication step to refresh the AWS token.