### PR TITLE
Fixing cicd

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11.8']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11.8']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11.8']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11.8']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,10 @@ jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
-dask = { version = ">= 2024.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
+dask = [
+    { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"], python = "<3.11" },
+    { version = ">= 2024.4.1", extras = ["dataframe", "distributed", "diagnostics"], python = ">=3.11" },
+    ]
 docker = ">= 6.1.3"
 
 # dask-cuda is not yet compatible with Python >3.11.8,
@@ -76,7 +79,7 @@ kfp = ["kfp"]
 vertex = ["kfp", "google-cloud-aiplatform"]
 sagemaker = ["sagemaker", "boto3"]
 
-all = ["dask-cuda", "s3fs", "adlfs", "gcsfs", "kfp", "google-cloud-aiplatform",
+all = ["s3fs", "adlfs", "gcsfs", "kfp", "google-cloud-aiplatform",
     "sagemaker", "boto3"]
 
 [tool.poetry.group.test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
-dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
+dask = { version = ">= 2023.4.1, <2024.3.0", extras = ["dataframe", "distributed", "diagnostics"]}
 docker = ">= 6.1.3"
 
 dask-cuda = { version = ">=23.4.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
-dask = { version = ">= 2023.4.1, != 2024.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
+dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
 docker = ">= 6.1.3"
 
 dask-cuda = { version = ">=23.4.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">= 3.9, <3.11.9"
+python = ">= 3.9, <3.12"
 
 fsspec = ">= 2023.4.0"
 importlib-resources = { version = ">= 1.3", python = "<3.9" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
-dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
+dask = { version = ">= 2023.4.1, != 2024.4.0", extras = ["dataframe", "distributed", "diagnostics"]}
 docker = ">= 6.1.3"
 
 dask-cuda = { version = ">=23.4.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
-dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
+dask = { version = ">= 2024.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
 docker = ">= 6.1.3"
 
 dask-cuda = { version = ">=23.4.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,15 +49,10 @@ jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
-dask = [
-    { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"], python = "<3.11" },
-    { version = ">= 2024.4.1", extras = ["dataframe", "distributed", "diagnostics"], python = ">=3.11" },
-    ]
+dask = { version = ">= 2023.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
 docker = ">= 6.1.3"
 
-# dask-cuda is not yet compatible with Python >3.11.8,
-# since we need to update to a newer dask version
-dask-cuda = { version = ">=23.4.1", optional = true, python = ">=3.9,<3.11" }
+dask-cuda = { version = ">=23.4.1", optional = true }
 
 gcsfs = { version = ">= 2023.10.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }
@@ -79,7 +74,7 @@ kfp = ["kfp"]
 vertex = ["kfp", "google-cloud-aiplatform"]
 sagemaker = ["sagemaker", "boto3"]
 
-all = ["s3fs", "adlfs", "gcsfs", "kfp", "google-cloud-aiplatform",
+all = ["dask-cuda", "s3fs", "adlfs", "gcsfs", "kfp", "google-cloud-aiplatform",
     "sagemaker", "boto3"]
 
 [tool.poetry.group.test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ pyyaml = ">= 5.3.1"
 dask = { version = ">= 2024.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
 docker = ">= 6.1.3"
 
-dask-cuda = { version = ">=23.4.1", optional = true }
+# dask-cuda is not yet compatible with Python >3.11.8,
+# since we need to update to a newer dask version
+dask-cuda = { version = ">=23.4.1", optional = true, python = ">=3.9,<3.11" }
 
 gcsfs = { version = ">= 2023.10.0", optional = true }
 s3fs = { version = ">= 2023.4.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ jsonschema = ">= 4.18"
 pyarrow = ">= 11.0.0"
 pyyaml = ">= 5.3.1"
 
-dask = { version = ">= 2023.4.1, != 2024.4.0", extras = ["dataframe", "distributed", "diagnostics"]}
+dask = { version = ">= 2023.4.1, != 2024.4.1", extras = ["dataframe", "distributed", "diagnostics"]}
 docker = ">= 6.1.3"
 
 dask-cuda = { version = ">=23.4.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">= 3.9, <3.12"
+python = ">= 3.9, <3.11.9"
 
 fsspec = ">= 2023.4.0"
 importlib-resources = { version = ">= 1.3", python = "<3.9" }


### PR DESCRIPTION
dask <= 2024.4.0 is incompatible with python 3.11.9. Github updated there runners and our cicd pipelines were failing. 
A fix was released as part of dask 2024.4.1, however we can not use this version since there are dependency conflicts with dask-cuda.

<s>Limited our python version to <3.11.9</s>

**Update 16/04/24:** 
We encountered `TypeError "<" not supported between instance of 'int' and 'str'`. This is related to sorting operation part of `dask-expr`. dask-expr is part of `dask>=2024.3.0`. Dask supports a specific configuration to disable the computation graph optimizations and the usage of dask-expr. However, limit the dask version to `dask<2024.3.0` would avoid further issues since we have tested these version before.  