### PR TITLE
Mount absolute path of working dir to local runner

### DIFF
--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -105,6 +105,12 @@ class DaskDataLoader(DataIO):
 
         for field_name in self.operation_spec.consumes_from_dataset:
             location = self.manifest.get_field_location(field_name)
+
+            if "://" not in location:
+                # If the location is a local path, we need to remove the root path since we only
+                # mount the working dir to the container
+                location = "/" + "/".join(location.split("/")[-4:])
+
             field_mapping[location].append(field_name)
 
         for location, fields in field_mapping.items():

--- a/src/fondant/component/data_io.py
+++ b/src/fondant/component/data_io.py
@@ -105,12 +105,6 @@ class DaskDataLoader(DataIO):
 
         for field_name in self.operation_spec.consumes_from_dataset:
             location = self.manifest.get_field_location(field_name)
-
-            if "://" not in location:
-                # If the location is a local path, we need to remove the root path since we only
-                # mount the working dir to the container
-                location = "/" + "/".join(location.split("/")[-4:])
-
             field_mapping[location].append(field_name)
 
         for location, fields in field_mapping.items():

--- a/src/fondant/dataset/compiler.py
+++ b/src/fondant/dataset/compiler.py
@@ -180,10 +180,10 @@ class DockerCompiler(Compiler):
         volume = DockerVolume(
             type="bind",
             source=str(p_base_path),
-            target=f"/{p_base_path.stem}",
+            target=str(p_base_path),
         )
-        path = f"/{p_base_path.stem}"
-        return path, volume
+
+        return str(p_base_path), volume
 
     def _generate_spec(
         self,
@@ -246,7 +246,7 @@ class DockerCompiler(Compiler):
             command.extend(
                 [
                     "--working_directory",
-                    working_directory,
+                    path,
                 ],
             )
 

--- a/tests/pipeline/test_compiler.py
+++ b/tests/pipeline/test_compiler.py
@@ -213,7 +213,6 @@ def test_docker_local_path(setup_pipeline, tmp_path_factory):
     with tmp_path_factory.mktemp("temp") as fn:
         # this is the directory mounted in the container
         _, _, dataset, cache_dict = setup_pipeline
-        work_dir_stem = f"/{fn.stem}"
         working_directory = str(fn)
         compiler = DockerCompiler()
         output_path = str(fn / "docker-compose.yml")
@@ -234,14 +233,14 @@ def test_docker_local_path(setup_pipeline, tmp_path_factory):
             assert component_configs.volumes == [
                 {
                     "source": str(fn),
-                    "target": work_dir_stem,
+                    "target": str(fn),
                     "type": "bind",
                 },
             ]
             cleaned_pipeline_name = dataset.name.replace("_", "")
             # check if commands are patched to use the working dir
             expected_output_manifest_path = (
-                f"{work_dir_stem}/{cleaned_pipeline_name}/{expected_run_id}"
+                f"{str(fn)}/{cleaned_pipeline_name}/{expected_run_id}"
                 f"/{component_name}/manifest.json"
             )
 


### PR DESCRIPTION
As part of the new interface and manifest changes this bug appeared. We are not able to run the new fondant version in jupyter notebooks cause the working directory isn't resolved correctly. 

Mounting the complete path instead of the stem solves the issue.