### PR TITLE
Set session duration to 5h in prep release pipeline

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -49,6 +49,7 @@ jobs:
           role-to-assume: arn:aws:iam::904708148714:role/fondant-github-actions
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{env.AWS_REGION}}
+          role-duration-seconds: 18000
 
       - name: Login to Amazon ECR Public
         id: login-ecr-public


### PR DESCRIPTION
Our AWS auth GitHub action has role-duration-seconds limit set to 3600 by default. We have to increase this limit as well next to the role configuration itself.