### PR TITLE
Bugfix:  Fondant base image build

### DIFF
--- a/scripts/build_base_image.sh
+++ b/scripts/build_base_image.sh
@@ -17,20 +17,20 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 esac; shift; done
 
 # Supported Python versions
-python_versions=("3.9" "3.10" "3.11")
+python_versions=("3.9" "3.10" "3.11.8")
 
 for tag in "${tags[@]}"; do
   for python_version in "${python_versions[@]}"; do
     BASENAME=fondant
     IMAGE_TAG=${tag}-py${python_version}
     full_image_names=()
-
     # create repo if not exists
     aws ecr-public describe-repositories --region us-east-1 --repository-names ${BASENAME} || aws ecr-public create-repository --region us-east-1 --repository-name ${BASENAME}
     full_image_names+=("public.ecr.aws/fndnt/${BASENAME}:${IMAGE_TAG}")
     full_image_names+=("fndnt/${BASENAME}:${IMAGE_TAG}")
 
     # Add argument for each tag
+    args=()
     for image_name in "${full_image_names[@]}" ; do
       args+=(-t "$image_name")
     done


### PR DESCRIPTION
In `0.12.0` the lightweight component that uses a default image are not working. 

- During the build of base images the image tag list wasn't initialised correctly within the loop. This means we have overwritten the previous build images. Every base image now contains python version `10.11.9`
- We have limited dask to`<2024.3.0`, but only dask `>=2024.4.1` is compatible with python `>=10.11.9`. Limit python version of the base image build.